### PR TITLE
feat: more window configs: `icon` (winit/gtk-rs) and `fullscreen` (gtk-rs only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,19 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.2"
+image = "0.23"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "0.11", features = ["v2_8"] }
 gio = "0.9"
 gtk = "0.9"
 gdk = "0.13"
+gdk-pixbuf = "0.9"
 glib = "0.10"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = "0.2"
 winit = "0.24"
-image = "0.23.13"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 cc = "1"
@@ -43,5 +44,3 @@ cocoa = "0.24"
 core-graphics = "0.22"
 objc = "0.2"
 winit = "0.24"
-image = "0.23.13"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ glib = "0.10"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = "0.2"
 winit = "0.24"
+image = "0.23.13"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 cc = "1"
@@ -42,4 +43,5 @@ cocoa = "0.24"
 core-graphics = "0.22"
 objc = "0.2"
 winit = "0.24"
+image = "0.23.13"
 

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -74,7 +74,7 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
             _ => {}
         }
         if let Some(icon) = attributes.icon {
-            window.set_window_icon(Some(load_icon(icon)));
+            window.set_window_icon(Some(load_icon(icon)?));
         }
 
         Ok(WinitWindow(window))
@@ -156,16 +156,11 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
         });
     }
 }
-fn load_icon(icon: Icon) -> WinitIcon {
-    let image = match icon {
-        Icon::File(path) => image::open(path)
-            .expect("Failed to load icon path")
-            .into_rgba8(),
-        Icon::Raw(bytes) => image::load_from_memory(&bytes)
-            .expect("Failed to load icon from memory")
-            .into_rgba8(),
-    };
+
+fn load_icon(icon: Icon) -> crate::Result<WinitIcon> {
+    let image = image::load_from_memory(&icon.0)?.into_rgba8();
     let (width, height) = image.dimensions();
     let rgba = image.into_raw();
-    WinitIcon::from_rgba(rgba, width, height).expect("Failed to open icon")
+    let icon = WinitIcon::from_rgba(rgba, width, height)?;
+    Ok(icon)
 }

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -7,11 +7,12 @@ use winit::{
     dpi::LogicalPosition,
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::{Window, WindowAttributes, WindowBuilder},
+    window::{Icon, Window, WindowAttributes, WindowBuilder},
 };
 
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{Arc, Mutex},
 };
 
@@ -73,6 +74,11 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
             (Some(x), Some(y)) => window.set_outer_position(LogicalPosition::new(x, y)),
             _ => {}
         }
+        match attributes.icon {
+            Some(icon) => window.set_window_icon(Some(load_icon(icon.as_path()))),
+            _ => {}
+        }
+
         Ok(WinitWindow(window))
     }
 
@@ -151,4 +157,16 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
             }
         });
     }
+}
+
+fn load_icon(path: &Path) -> Icon {
+    let (icon_rgba, icon_width, icon_height) = {
+        let image = image::open(path)
+            .expect("Failed to open icon path")
+            .into_rgba8();
+        let (width, height) = image.dimensions();
+        let rgba = image.into_raw();
+        (rgba, width, height)
+    };
+    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
 }

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -1,13 +1,13 @@
 use crate::{
-    AppWindowAttributes, ApplicationDispatcher, ApplicationExt, Callback, Message, Result, WebView,
-    WebViewAttributes, WebViewBuilder, WindowExt,
+    AppWindowAttributes, ApplicationDispatcher, ApplicationExt, Callback, Icon, Message, Result,
+    WebView, WebViewAttributes, WebViewBuilder, WindowExt,
 };
 pub use winit::window::WindowId;
 use winit::{
     dpi::LogicalPosition,
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::{Icon, Window, WindowAttributes, WindowBuilder},
+    window::{Icon as WinitIcon, Window, WindowAttributes, WindowBuilder},
 };
 
 use std::{
@@ -74,9 +74,13 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
             (Some(x), Some(y)) => window.set_outer_position(LogicalPosition::new(x, y)),
             _ => {}
         }
-        match attributes.icon {
-            Some(icon) => window.set_window_icon(Some(load_icon(icon.as_path()))),
-            _ => {}
+        if let Some(icon) = attributes.icon {
+            match icon {
+                Icon::File(pathbuf) => {
+                    window.set_window_icon(Some(load_icon_from_path(pathbuf.as_path())));
+                }
+                Icon::Raw(bytes) => {}
+            }
         }
 
         Ok(WinitWindow(window))
@@ -158,8 +162,7 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
         });
     }
 }
-
-fn load_icon(path: &Path) -> Icon {
+fn load_icon_from_path(path: &Path) -> WinitIcon {
     let (icon_rgba, icon_width, icon_height) = {
         let image = image::open(path)
             .expect("Failed to open icon path")
@@ -168,5 +171,5 @@ fn load_icon(path: &Path) -> Icon {
         let rgba = image.into_raw();
         (rgba, width, height)
     };
-    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+    WinitIcon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
 }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -126,6 +126,7 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
         if let Some(icon) = attributes.icon {
             let image = image::load_from_memory(&icon.0)?.into_rgba8();
             let (width, height) = image.dimensions();
+            let row_stride = image.sample_layout().height_stride;
             let pixbuf = gdk_pixbuf::Pixbuf::from_mut_slice(
                 image.into_raw(),
                 gdk_pixbuf::Colorspace::Rgb,
@@ -133,7 +134,7 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
                 8,
                 width as i32,
                 height as i32,
-                1,
+                row_stride as i32,
             );
             window.set_icon(Some(&pixbuf));
         }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -125,7 +125,10 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
             window.fullscreen();
         }
         if let Some(icon) = attributes.icon {
-            let _ = window.set_icon_from_file(icon.as_path());
+            match icon {
+                Icon::File(path) => window.set_icon_from_file(path.as_path()),
+                Icon::Raw(bytes) => {}
+            }
         }
 
         Ok(GtkWindow(window))

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AppWindowAttributes, ApplicationDispatcher, ApplicationExt, Callback, Icon, Message, Result,
-    WebView, WebViewAttributes, WebViewBuilder, WindowExt,
+    AppWindowAttributes, ApplicationDispatcher, ApplicationExt, Callback, Message, Result, WebView,
+    WebViewAttributes, WebViewBuilder, WindowExt,
 };
 
 use std::{
@@ -124,12 +124,18 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
             window.fullscreen();
         }
         if let Some(icon) = attributes.icon {
-            match icon {
-                Icon::File(path) => {
-                    let _ = window.set_icon_from_file(path.as_path());
-                }
-                Icon::Raw(bytes) => {}
-            }
+            let image = image::load_from_memory(&icon.0)?.into_rgba8();
+            let (width, height) = image.dimensions();
+            let pixbuf = gdk_pixbuf::Pixbuf::from_mut_slice(
+                image.into_raw(),
+                gdk_pixbuf::Colorspace::Rgb,
+                true,
+                8,
+                width as i32,
+                height as i32,
+                1,
+            );
+            window.set_icon(Some(&pixbuf));
         }
 
         Ok(GtkWindow(window))

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -1,11 +1,10 @@
 use crate::{
-    AppWindowAttributes, ApplicationDispatcher, ApplicationExt, Callback, Message, Result, WebView,
-    WebViewAttributes, WebViewBuilder, WindowExt,
+    AppWindowAttributes, ApplicationDispatcher, ApplicationExt, Callback, Icon, Message, Result,
+    WebView, WebViewAttributes, WebViewBuilder, WindowExt,
 };
 
 use std::{
     collections::HashMap,
-    path::Path,
     sync::{
         mpsc::{channel, Receiver, Sender},
         Arc, Mutex,
@@ -126,7 +125,9 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
         }
         if let Some(icon) = attributes.icon {
             match icon {
-                Icon::File(path) => window.set_icon_from_file(path.as_path()),
+                Icon::File(path) => {
+                    let _ = window.set_icon_from_file(path.as_path());
+                }
                 Icon::Raw(bytes) => {}
             }
         }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -120,6 +120,9 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
         window.set_visible(attributes.visible);
         window.set_decorated(attributes.decorations);
         window.set_keep_above(attributes.always_on_top);
+        if attributes.fullscreen {
+            window.fullscreen();
+        }
 
         Ok(GtkWindow(window))
     }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -5,6 +5,7 @@ use crate::{
 
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{
         mpsc::{channel, Receiver, Sender},
         Arc, Mutex,
@@ -122,6 +123,9 @@ impl<T> ApplicationExt<'_, T> for Application<T> {
         window.set_keep_above(attributes.always_on_top);
         if attributes.fullscreen {
             window.fullscreen();
+        }
+        if let Some(icon) = attributes.icon {
+            let _ = window.set_icon_from_file(icon.as_path());
         }
 
         Ok(GtkWindow(window))

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -120,7 +120,7 @@ pub struct AppWindowAttributes {
     /// The default is false.
     pub fullscreen: bool,
 
-    /// The PathBuf to the window icon.
+    /// The window icon.
     ///
     /// The default is None,
     pub icon: Option<Icon>,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -29,6 +29,12 @@ pub struct Callback {
     pub function: Box<dyn FnMut(&Dispatcher, i32, Vec<String>) -> i32 + Send>,
 }
 
+#[derive(Debug, Clone)]
+pub enum Icon {
+    File(PathBuf),
+    Raw(Vec<u8>),
+}
+
 // TODO complete fields on WindowAttribute
 /// Attributes to use when creating a window.
 #[derive(Debug, Clone)]
@@ -117,7 +123,7 @@ pub struct AppWindowAttributes {
     /// The PathBuf to the window icon.
     ///
     /// The default is None,
-    pub icon: Option<PathBuf>,
+    pub icon: Option<Icon>,
 }
 
 impl Default for AppWindowAttributes {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 mod general;
 
-use std::path::PathBuf;
+use std::{fs::read, path::Path};
 
 #[cfg(not(target_os = "linux"))]
 pub use general::*;
@@ -30,9 +30,16 @@ pub struct Callback {
 }
 
 #[derive(Debug, Clone)]
-pub enum Icon {
-    File(PathBuf),
-    Raw(Vec<u8>),
+pub struct Icon(pub(crate) Vec<u8>);
+
+impl Icon {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Ok(Self(read(path)?))
+    }
+
+    pub fn from_bytes<B: Into<Vec<u8>>>(bytes: B) -> Result<Self> {
+        Ok(Self(bytes.into()))
+    }
 }
 
 // TODO complete fields on WindowAttribute

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(not(target_os = "linux"))]
 mod general;
+
+use std::path::PathBuf;
+
 #[cfg(not(target_os = "linux"))]
 pub use general::*;
 #[cfg(target_os = "linux")]
@@ -110,6 +113,11 @@ pub struct AppWindowAttributes {
     ///
     /// The default is false.
     pub fullscreen: bool,
+
+    /// The PathBuf to the window icon.
+    ///
+    /// The default is None,
+    pub icon: Option<PathBuf>,
 }
 
 impl Default for AppWindowAttributes {
@@ -132,6 +140,7 @@ impl Default for AppWindowAttributes {
             x: None,
             y: None,
             fullscreen: false,
+            icon: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,10 @@ pub enum Error {
     #[cfg(target_os = "windows")]
     #[error("Windows error: {0:?}")]
     WinrtError(windows::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("image error: {0}")]
+    Image(#[from] image::ImageError),
 }
 
 #[cfg(target_os = "windows")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ mod webview;
 
 pub use application::{
     AppDispatcher, AppWindowAttributes, Application, ApplicationDispatcher, ApplicationExt,
-    Callback, Message, WebViewAttributes, Window, WindowExt, WindowId,
+    Callback, Icon, Message, WebViewAttributes, Window, WindowExt, WindowId,
 };
 pub use webview::{Dispatcher, WebView, WebViewBuilder};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,8 @@ pub use application::{
     Callback, Icon, Message, WebViewAttributes, Window, WindowExt, WindowId,
 };
 pub use webview::{Dispatcher, WebView, WebViewBuilder};
+
+#[cfg(not(target_os = "linux"))]
 use winit::window::BadIcon;
 
 use std::sync::mpsc::SendError;
@@ -117,6 +119,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("image error: {0}")]
     Image(#[from] image::ImageError),
+    #[cfg(not(target_os = "linux"))]
     #[error("Icon error: {0}")]
     Icon(#[from] BadIcon),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub use application::{
     Callback, Icon, Message, WebViewAttributes, Window, WindowExt, WindowId,
 };
 pub use webview::{Dispatcher, WebView, WebViewBuilder};
+use winit::window::BadIcon;
 
 use std::sync::mpsc::SendError;
 
@@ -116,6 +117,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("image error: {0}")]
     Image(#[from] image::ImageError),
+    #[error("Icon error: {0}")]
+    Icon(#[from] BadIcon),
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
`load_icon` function is taken directly from winit's window icon [example](https://github.com/rust-windowing/winit/blob/master/examples/window_icon.rs) it uses [image](https://github.com/image-rs/image) to convert the image to `rgba Vec` so I added it as a dependency.