### PR TITLE
Use IIFE for injected javascript.

### DIFF
--- a/src/webview.rs
+++ b/src/webview.rs
@@ -93,7 +93,8 @@ impl WebViewBuilder {
         F: FnMut(&Dispatcher, i32, Vec<Value>) -> Result<()> + Send + 'static,
     {
         let js = format!(
-            r#"var name = {:?};
+            r#"(function() {{
+                var name = {:?};
                 var RPC = window._rpc = (window._rpc || {{nextSeq: 1}});
                 window[name] = function() {{
                 var seq = RPC.nextSeq++;
@@ -110,6 +111,7 @@ impl WebViewBuilder {
                 }}));
                 return promise;
                 }}
+            }})()
             "#,
             name
         );


### PR DESCRIPTION
Otherwise the global `name` variable is overriden by the last assigned callback and all function invocations target the last defined callback.

This fixes a bug whereby using multiple callbacks when calling `add_window` like this:

```rust
app.add_window(attrs, Some(vec![ipc, log_error, log_info, log_warn]))?;
```

Without this fix all javascript function invocations call the `Callback` named `log_warn` (the last one defined); after applying this fix each `Callback` should be invoked as expected.