### PR TITLE
fix: update format of path passed to custom protocol resolver

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -126,13 +126,7 @@ impl WV for InnerWebView {
                 .unwrap()
                 .register_uri_scheme_as_secure(&name);
             context.register_uri_scheme(&name.clone(), move |request| {
-                let file_path = request
-                    .get_uri()
-                    .unwrap()
-                    .as_str()
-                    .replace(format!("{}://", name).as_str(), "")
-                    // Somehow other assets get index.html in their path
-                    .replace("index.html/", "");
+                let file_path = request.get_uri().unwrap().as_str();
                 let mime = mime_guess::from_path(&file_path)
                     .first()
                     .unwrap()

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -126,7 +126,8 @@ impl WV for InnerWebView {
                 .unwrap()
                 .register_uri_scheme_as_secure(&name);
             context.register_uri_scheme(&name.clone(), move |request| {
-                let file_path = request.get_uri().unwrap().as_str();
+                let uri = request.get_uri().unwrap();
+                let file_path = uri.as_str();
                 let mime = mime_guess::from_path(&file_path)
                     .first()
                     .unwrap()

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -108,8 +108,11 @@ impl WV for InnerWebView {
                     )?;
                     w.add_web_resource_requested(move |_, args| {
                         let uri = args.get_request().unwrap().get_uri().unwrap();
-                        // Remove leading custom protocol indicator
-                        let path = &uri[(23 + name.len())..];
+                        // Undo the protocol workaround when giving path to resolver
+                        let path = &uri.replace(
+                            format!("file://custom-protocol-{}", name),
+                            format!("{}://", name)
+                        );
                         match function(path) {
                             Ok(content) => {
                                 let stream = webview2::Stream::from_bytes(&content);

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -110,8 +110,8 @@ impl WV for InnerWebView {
                         let uri = args.get_request().unwrap().get_uri().unwrap();
                         // Undo the protocol workaround when giving path to resolver
                         let path = &uri.replace(
-                            format!("file://custom-protocol-{}", name),
-                            format!("{}://", name)
+                            &format!("file://custom-protocol-{}", name),
+                            &format!("{}://", name)
                         );
                         match function(path) {
                             Ok(content) => {


### PR DESCRIPTION
now it is consistent cross-platform