### PR TITLE
Rpc api cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,46 @@ cargo run --example multiwindow
 
 For more information, please read the documentation below.
 
+## Rust <-> Javascript
+
+Communication between the host Rust code and webview Javascript is done via [JSON-RPC][].
+
+Embedding code should call `set_handler()` on the application to register an incoming request handler and reply with responses that are passed back to Javascript. On the Javascript side the client is exposed via `window.rpc` with two public methods
+
+1. The `call()` function accepts a method name and parameters and expects a reply.
+2. The `notify()` function accepts a method name and parameters but does not expect a reply.
+
+Both methods return promises but `notify()` resolves immediately.
+
+For example in Rust:
+
+```rust
+use wry::{Application, Result, RpcResponse};
+
+fn main() -> Result<()> {
+    let mut app = Application::new()?;
+    app.set_handler(Box::new(|proxy, mut req| {
+      // Handle the request of type `RpcRequest` and reply with `RpcResponse`
+      // Use the `WindowProxy` to modify the window, eg: `set_fullscreen` etc.
+      None
+    });
+    app.add_window(Default::default())?;
+    app.run();
+    Ok(())
+}
+```
+
+Then in Javascript use `call()` to call a remote method and get a response:
+
+```javascript
+async function callRemoteMethod() {
+  let result = await window.rpc.call('remoteMethod', param1, param2);
+  // Do something with the result
+}
+```
+
+See the `rpc` example for more details.
+
 ## [Documentation](https://docs.rs/wry)
 
 ## Platform-specific notes
@@ -84,3 +124,5 @@ WebView2 provided by Microsoft Edge Chromium is used. So wry supports Windows 7,
 
 ## License
 Apache-2.0/MIT
+
+[JSON-RPC]: https://www.jsonrpc.org

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -38,11 +38,7 @@ async function getAsyncRpcResult() {
     };
 
     // NOTE: must be set before calling add_window().
-<<<<<<< HEAD
-    app.set_rpc_handler(Box::new(|proxy, mut req| {
-=======
     app.set_handler(Box::new(|proxy, mut req| {
->>>>>>> rpc-cleanup
         let mut response = None;
         if &req.method == "fullscreen" {
             if let Some(params) = req.params.take() {

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -38,7 +38,11 @@ async function getAsyncRpcResult() {
     };
 
     // NOTE: must be set before calling add_window().
+<<<<<<< HEAD
     app.set_rpc_handler(Box::new(|proxy, mut req| {
+=======
+    app.set_handler(Box::new(|proxy, mut req| {
+>>>>>>> rpc-cleanup
         let mut response = None;
         if &req.method == "fullscreen" {
             if let Some(params) = req.params.take() {

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -1,6 +1,6 @@
 use crate::{
     application::{App, AppProxy, InnerWebViewAttributes, InnerWindowAttributes},
-    ApplicationProxy, Attributes, Callback, CustomProtocol, Error, Icon, Message, Result, WebView,
+    ApplicationProxy, Attributes, CustomProtocol, Error, Icon, Message, Result, WebView,
     WebViewBuilder, WindowMessage, WindowProxy, RpcHandler,
 };
 #[cfg(target_os = "macos")]
@@ -48,13 +48,11 @@ impl AppProxy for InnerApplicationProxy {
     fn add_window(
         &self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<WindowId> {
         let (sender, receiver) = channel();
         self.send_message(Message::NewWindow(
             attributes,
-            callbacks,
             sender,
             custom_protocol,
         ))?;
@@ -108,6 +106,12 @@ pub struct InnerApplication {
     pub(crate) rpc_handler: Option<Arc<RpcHandler>>,
 }
 
+impl InnerApplication {
+    pub fn is_empty(&self) -> bool {
+        self.webviews.is_empty()
+    }
+}
+
 impl App for InnerApplication {
     type Id = WindowId;
     type Proxy = InnerApplicationProxy;
@@ -126,7 +130,6 @@ impl App for InnerApplication {
     fn create_webview(
         &mut self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<Self::Id> {
         let (window_attrs, webview_attrs) = attributes.split();
@@ -135,7 +138,6 @@ impl App for InnerApplication {
             &self.application_proxy(),
             window,
             webview_attrs,
-            callbacks,
             custom_protocol,
             self.rpc_handler.clone(),
         )?;
@@ -175,7 +177,7 @@ impl App for InnerApplication {
                     _ => {}
                 },
                 Event::UserEvent(message) => match message {
-                    Message::NewWindow(attributes, callbacks, sender, custom_protocol) => {
+                    Message::NewWindow(attributes, sender, custom_protocol) => {
                         let (window_attrs, webview_attrs) = attributes.split();
                         let window = _create_window(&event_loop, window_attrs).unwrap();
                         sender.send(window.id()).unwrap();
@@ -183,7 +185,6 @@ impl App for InnerApplication {
                             &dispatcher,
                             window,
                             webview_attrs,
-                            callbacks,
                             custom_protocol,
                             rpc_handler.clone(),
                         )
@@ -347,7 +348,6 @@ fn _create_webview(
     dispatcher: &InnerApplicationProxy,
     window: Window,
     attributes: InnerWebViewAttributes,
-    callbacks: Option<Vec<Callback>>,
     custom_protocol: Option<CustomProtocol>,
     rpc_handler: Option<Arc<RpcHandler>>,
 ) -> Result<WebView> {
@@ -359,23 +359,7 @@ fn _create_webview(
     for js in attributes.initialization_scripts {
         webview = webview.initialize_script(&js);
     }
-    if let Some(cbs) = callbacks {
-        for Callback { name, mut function } in cbs {
-            let dispatcher = dispatcher.clone();
-            webview = webview.add_callback(&name, move |_, seq, req| {
-                function(
-                    WindowProxy::new(
-                        ApplicationProxy {
-                            inner: dispatcher.clone(),
-                        },
-                        window_id,
-                    ),
-                    seq,
-                    req,
-                )
-            });
-        }
-    }
+
     if let Some(protocol) = custom_protocol {
         webview = webview.register_protocol(protocol.name, protocol.handler)
     }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -1,6 +1,6 @@
 use crate::{
     application::{App, AppProxy, InnerWebViewAttributes, InnerWindowAttributes, WindowProxy},
-    ApplicationProxy, Attributes, Callback, CustomProtocol, Error, Icon, Message, Result, WebView,
+    ApplicationProxy, Attributes, CustomProtocol, Error, Icon, Message, Result, WebView,
     WebViewBuilder, WindowMessage, RpcHandler,
 };
 
@@ -8,7 +8,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     rc::Rc,
-    sync::{Arc, Mutex, mpsc::{channel, Receiver, Sender}},
+    sync::{Arc, mpsc::{channel, Receiver, Sender}},
 };
 
 use cairo::Operator;
@@ -45,13 +45,11 @@ impl AppProxy for InnerApplicationProxy {
     fn add_window(
         &self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<WindowId> {
         let (sender, receiver): (Sender<WindowId>, Receiver<WindowId>) = channel();
         self.send_message(Message::NewWindow(
             attributes,
-            callbacks,
             sender,
             custom_protocol,
         ))?;
@@ -65,6 +63,12 @@ pub struct InnerApplication {
     event_loop_proxy: EventLoopProxy,
     event_loop_proxy_rx: Receiver<Message>,
     pub(crate) rpc_handler: Option<Arc<RpcHandler>>,
+}
+
+impl InnerApplication {
+    pub fn is_empty(&self) -> bool {
+        self.webviews.is_empty()
+    }
 }
 
 impl App for InnerApplication {
@@ -90,7 +94,6 @@ impl App for InnerApplication {
     fn create_webview(
         &mut self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<Self::Id> {
         let (window_attrs, webview_attrs) = attributes.split();
@@ -100,7 +103,6 @@ impl App for InnerApplication {
             &self.application_proxy(),
             window,
             webview_attrs,
-            callbacks,
             custom_protocol,
             self.rpc_handler.clone(),
         )?;
@@ -148,7 +150,7 @@ impl App for InnerApplication {
 
             while let Ok(message) = self.event_loop_proxy_rx.try_recv() {
                 match message {
-                    Message::NewWindow(attributes, callbacks, sender, custom_protocol) => {
+                    Message::NewWindow(attributes, sender, custom_protocol) => {
                         let (window_attrs, webview_attrs) = attributes.split();
                         let window = _create_window(&self.app, window_attrs).unwrap();
                         sender.send(window.get_id()).unwrap();
@@ -156,7 +158,6 @@ impl App for InnerApplication {
                             &proxy,
                             window,
                             webview_attrs,
-                            callbacks,
                             custom_protocol,
                             self.rpc_handler.clone(),
                         )
@@ -392,7 +393,6 @@ fn _create_webview(
     proxy: &InnerApplicationProxy,
     window: ApplicationWindow,
     attributes: InnerWebViewAttributes,
-    callbacks: Option<Vec<Callback>>,
     custom_protocol: Option<CustomProtocol>,
     rpc_handler: Option<Arc<RpcHandler>>,
 ) -> Result<WebView> {
@@ -405,23 +405,7 @@ fn _create_webview(
     for js in attributes.initialization_scripts {
         webview = webview.initialize_script(&js);
     }
-    if let Some(cbs) = callbacks {
-        for Callback { name, mut function } in cbs {
-            let proxy = proxy.clone();
-            webview = webview.add_callback(&name, move |_, seq, req| {
-                function(
-                    WindowProxy::new(
-                        ApplicationProxy {
-                            inner: proxy.clone(),
-                        },
-                        window_id,
-                    ),
-                    seq,
-                    req,
-                )
-            });
-        }
-    }
+
     webview = match attributes.url {
         Some(url) => webview.load_url(&url)?,
         None => webview,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,11 @@ pub mod platform;
 pub mod webview;
 
 pub use application::{
-    Application, ApplicationProxy, Attributes, Callback, CustomProtocol, Icon, Message, WindowId,
+    Application, ApplicationProxy, Attributes, CustomProtocol, Icon, Message, WindowId,
     WindowMessage, WindowProxy, RpcRequest, RpcResponse,
 };
 pub use serde_json::Value;
-pub(crate) use webview::{Dispatcher, WebView, WebViewBuilder, RpcHandler};
+pub(crate) use webview::{WebView, WebViewBuilder, RpcHandler};
 
 #[cfg(not(target_os = "linux"))]
 use winit::window::BadIcon;
@@ -114,6 +114,8 @@ pub enum Error {
     GlibBoolError(#[from] glib::BoolError),
     #[error("Failed to initialize the script")]
     InitScriptError,
+    #[error("Bad RPC request: {0} ((1))")]
+    RpcScriptError(String, String),
     #[error(transparent)]
     NulError(#[from] std::ffi::NulError),
     #[cfg(not(target_os = "linux"))]
@@ -125,6 +127,8 @@ pub enum Error {
     SenderError(#[from] SendError<String>),
     #[error("Failed to send the message")]
     MessageSender,
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
     #[error(transparent)]
     UrlError(#[from] ParseError),
     #[error("IO error: {0}")]

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,17 +1,15 @@
-use crate::platform::{CALLBACKS, RPC};
-use crate::application::{WindowProxy, FuncCall, RpcRequest, RpcResponse, RPC_CALLBACK_NAME};
+use crate::application::WindowProxy;
 use crate::mimetype::MimeType;
 use crate::webview::WV;
-use crate::{Dispatcher, Error, Result, RpcHandler};
+use crate::{Error, Result, RpcHandler};
 
 use std::rc::Rc;
 use std::sync::Arc;
 
-use serde_json::Value;
 use gdk::RGBA;
 use gio::Cancellable;
 use glib::{Bytes, FileError};
-use gtk::{ApplicationWindow as Window, ApplicationWindowExt, ContainerExt, WidgetExt};
+use gtk::{ApplicationWindow as Window, /* ApplicationWindowExt, */ ContainerExt, WidgetExt};
 use url::Url;
 use webkit2gtk::{
     SecurityManagerExt, SettingsExt, URISchemeRequestExt, UserContentInjectedFrames,
@@ -47,97 +45,19 @@ impl WV for InnerWebView {
         // Message handler
         let wv = Rc::clone(&webview);
         manager.register_script_message_handler("external");
-        let window_id = window.get_id() as i64;
         manager.connect_script_message_received(move |_m, msg| {
-            if let Some(js) = msg.get_value() {
-                if let Some(context) = msg.get_global_context() {
-                    if let Some(js) = js.to_string(&context) {
-                        match serde_json::from_str::<FuncCall>(&js) {
-                            Ok(mut ev) => {
-                                // Use `isize` to conform with existing `Callback` API but should 
-                                // really be a `u64`. Note that RPC spec allows for non-numbers 
-                                // in the `id` field!
-                                let id: i32 = if let Some(value) = ev.payload.id.clone().take() {
-                                    if let Value::Number(num) = value {
-                                        if num.is_i64() { num.as_i64().unwrap() as i32 } else { 0 }
-                                    } else { 0 }
-                                } else { 0 };
-
-                                let use_rpc = rpc_handler.is_some() && &ev.callback == RPC_CALLBACK_NAME;
-
-                                // Send to an RPC handler
-                                if use_rpc {
-                                    let (proxy, rpc_handler) = rpc_handler.as_ref().unwrap();
-                                    let mut response = rpc_handler(proxy, ev.payload);
-                                    if let Some(mut response) = response.take() {
-                                        if let Some(id) = response.id {
-                                            let js = if let Some(error) = response.error.take() {
-                                                match serde_json::to_string(&error) {
-                                                    Ok(retval) => {
-                                                        format!("window.external.rpc._error({}, {})",
-                                                            id.to_string(), retval)
-                                                    }
-                                                    Err(_) => {
-                                                        format!("window.external.rpc._error({}, null)",
-                                                            id.to_string())
-                                                    }
-                                                }
-                                            } else if let Some(result) = response.result.take() {
-                                                match serde_json::to_string(&result) {
-                                                    Ok(retval) => {
-                                                        format!("window.external.rpc._result({}, {})",
-                                                            id.to_string(), retval)
-                                                    }
-                                                    Err(_) => {
-                                                        format!("window.external.rpc._result({}, null)",
-                                                            id.to_string())
-                                                    }
-                                                }
-                                            } else {
-                                                // No error or result, assume a positive response
-                                                // with empty result (ACK)
-                                                format!("window.external.rpc._result({}, null)",
-                                                    id.to_string())
-                                            };
-
-                                            let cancellable: Option<&Cancellable> = None;
-                                            wv.run_javascript(&js, cancellable, |_| ());
-                                        }
-                                    }
-                                // Normal callback mechanism
-                                } else {
-                                    let mut hashmap = CALLBACKS.lock().unwrap();
-                                    let (f, d) = hashmap.get_mut(&(window_id, ev.callback)).unwrap();
-                                    // TODO: update `Callback` to take a `Value`?
-                                    let raw_params = if let Some(val) = ev.payload.params.take() {
-                                        val
-                                    } else { Value::Null };
-                                    let params = if let Value::Array(arr) = raw_params {
-                                        arr 
-                                    } else { vec![raw_params] };
-
-                                    let status = f(d, id, params);
-                                    let js = match status {
-                                        Ok(()) => {
-                                            format!(
-                                                r#"window._rpc[{}].resolve("RPC call success"); window._rpc[{}] = undefined"#,
-                                                id, id
-                                            )
-                                        }
-                                        Err(e) => {
-                                            format!(
-                                                r#"window._rpc[{}].reject("RPC call fail with error {}"); window._rpc[{}] = undefined"#,
-                                                id, e, id
-                                            )
-                                        }
-                                    };
-
+            if let (Some(js), Some(context)) = (msg.get_value(), msg.get_global_context()) {
+                if let Some(js) = js.to_string(&context) {
+                    if let Some((proxy, rpc_handler)) = rpc_handler.as_ref() {
+                        match super::rpc_proxy(js, proxy, rpc_handler) {
+                            Ok(result) => {
+                                if let Some(ref script) = result {
                                     let cancellable: Option<&Cancellable> = None;
-                                    wv.run_javascript(&js, cancellable, |_| ());
+                                    wv.run_javascript(script, cancellable, |_| ());
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Bad Javascript function call: {} ({})", e, &js);
+                                eprintln!("{}", e);
                             }
                         }
                     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,8 +1,7 @@
 use crate::mimetype::MimeType;
-use crate::platform::{CALLBACKS, RPC};
 use crate::application::WindowProxy;
 use crate::webview::WV;
-use crate::{Result, Dispatcher, RpcHandler};
+use crate::{Result, RpcHandler};
 
 use std::{
     sync::Arc,
@@ -52,33 +51,30 @@ impl WV for InnerWebView {
         extern "C" fn did_receive(this: &Object, _: Sel, _: id, msg: id) {
             // Safety: objc runtime calls are unsafe
             unsafe {
-                let window_id = *this.get_ivar("_window_id");
+                //let window_id = *this.get_ivar("_window_id");
                 let body: id = msg_send![msg, body];
                 let utf8: *const c_char = msg_send![body, UTF8String];
-                let s = CStr::from_ptr(utf8).to_str().expect("Invalid UTF8 string");
-                let v: RPC = serde_json::from_str(&s).unwrap();
-                let mut hashmap = CALLBACKS.lock().unwrap();
-                let (f, d) = hashmap.get_mut(&(window_id, v.method)).unwrap();
-                let status = f(d, v.id, v.params);
+                let js = CStr::from_ptr(utf8).to_str().expect("Invalid UTF8 string");
 
-                let js = match status {
-                    Ok(()) => {
-                        format!(
-                            r#"window._rpc[{}].resolve("RPC call success"); window._rpc[{}] = undefined"#,
-                            v.id, v.id
-                        )
+                // FIXME: allow access to rpc_handler here?
+
+                /*
+                if let Some((proxy, rpc_handler)) = rpc_handler.as_ref() {
+                    match super::rpc_proxy(js.to_string(), proxy, rpc_handler) {
+                        Ok(result) => {
+                            if let Some(ref script) = result {
+                                let wv: id = msg_send![msg, webView];
+                                let js = NSString::new(script);
+                                let _: id =
+                                    msg_send![wv, evaluateJavaScript:js completionHandler:null::<*const c_void>()];
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("{}", e);
+                        }
                     }
-                    Err(e) => {
-                        format!(
-                            r#"window._rpc[{}].reject("RPC call fail with error {}"); window._rpc[{}] = undefined"#,
-                            v.id, e, v.id
-                        )
-                    }
-                };
-                let wv: id = msg_send![msg, webView];
-                let js = NSString::new(&js);
-                let _: id =
-                    msg_send![wv, evaluateJavaScript:js completionHandler:null::<*const c_void>()];
+                }
+                */
             }
         }
 

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -1,7 +1,7 @@
 use crate::mimetype::MimeType;
 use crate::application::WindowProxy;
 use crate::webview::WV;
-use crate::{Result, Dispatcher, RpcHandler};
+use crate::{Result, RpcHandler};
 
 use std::{
     sync::Arc,

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -1,7 +1,7 @@
 //! [`WebView`] struct and associated types.
 
-use crate::platform::{InnerWebView, CALLBACKS};
-use crate::application::{WindowProxy, RpcRequest, RpcResponse, RPC_CALLBACK_NAME};
+use crate::platform::{InnerWebView};
+use crate::application::{WindowProxy, RpcRequest, RpcResponse};
 use crate::Result;
 
 use std::sync::{Arc, mpsc::{channel, Receiver, Sender}};
@@ -11,7 +11,6 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use serde_json::Value;
 use url::Url;
 
 #[cfg(target_os = "linux")]
@@ -35,6 +34,7 @@ pub struct WebViewBuilder {
     initialization_scripts: Vec<String>,
     window: Window,
     url: Option<Url>,
+    // TODO: remove this field?
     window_id: i64,
     custom_protocol: Option<(String, Box<dyn Fn(&str) -> Result<Vec<u8>>>)>,
     rpc_handler: Option<(
@@ -100,63 +100,11 @@ impl WebViewBuilder {
         self
     }
 
-    /// Add a callback function to the WebView. The callback takse a dispatcher, a sequence number,
-    /// and a vector of arguments passed from callers as parameters.
-    ///
-    /// It uses RPC to communicate with javascript side and the sequence number is used to record
-    /// how many times has this callback been called. Arguments passed from callers is a vector of
-    /// serde values for you to decide how to handle them. IF you need to evaluate any code on
-    /// javascript side, you can use the dispatcher to send them.
-    pub fn add_callback<F>(mut self, name: &str, f: F) -> Self
-    where
-        F: FnMut(&Dispatcher, i32, Vec<Value>) -> Result<()> + Send + 'static,
-    {
-
-        let js = format!(
-            r#"
-            (function() {{
-                var name = {:?};
-                var RPC = window._rpc = (window._rpc || {{nextSeq: 1}});
-                window[name] = function() {{
-                var seq = RPC.nextSeq++;
-                var promise = new Promise(function(resolve, reject) {{
-                    RPC[seq] = {{
-                    resolve: resolve,
-                    reject: reject,
-                    }};
-                }});
-                window.external.invoke(JSON.stringify({{
-                    callback: {:?},
-                    payload: {{
-                        jsonrpc: '2.0',
-                        id: seq,
-                        method: name,
-                        params: Array.prototype.slice.call(arguments),
-                    }}
-                }}));
-                return promise;
-                }}
-            }})()
-            "#,
-            name,
-            name,
-        );
-        self.initialization_scripts.push(js);
-
-        let window_id = self.window_id;
-        CALLBACKS.lock().unwrap().insert(
-            (window_id, name.to_string()),
-            (Box::new(f), Dispatcher(self.tx.clone())),
-        );
-        self
-    }
-
     /// Set the RPC handler.
     pub(crate) fn set_rpc_handler(mut self, proxy: WindowProxy, handler: Arc<RpcHandler>) -> Self {
         let js =
             r#"
             function Rpc() {
-                this._callback = '__rpc__';
                 this._promises = {};
 
                 // Private internal function called on error
@@ -175,16 +123,20 @@ impl WebViewBuilder {
                     }
                 }
 
+                // Private internal function called on failure to remove any promise
+                this._clean = (id) => {
+                    delete this._promises[id];
+                }
+
                 // Call remote method and expect a reply from the handler
                 this.call = function(method) {
                     const id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
                     const params = Array.prototype.slice.call(arguments, 1);
                     const payload = {jsonrpc: "2.0", id, method, params};
-                    const msg = {callback: this._callback, payload};
                     const promise = new Promise((resolve, reject) => {
                         this._promises[id] = {resolve, reject};
                     });
-                    window.external.invoke(JSON.stringify(msg));
+                    window.external.invoke(JSON.stringify(payload));
                     return promise;
                 }
 
@@ -192,8 +144,7 @@ impl WebViewBuilder {
                 this.notify = function(method) {
                     const params = Array.prototype.slice.call(arguments, 1);
                     const payload = {jsonrpc: "2.0", method, params};
-                    const msg = {callback: this._callback, payload};
-                    window.external.invoke(JSON.stringify(msg));
+                    window.external.invoke(JSON.stringify(payload));
                     return Promise.resolve();
                 }
             }


### PR DESCRIPTION
This removes the obsolete callback API completely along with several other improvements and bug fixes.

Outstanding tasks to be done after this is merged:

1) Use `&'static` reference so `RpcHandler` can be exposed to the MacOS platform code
2) Add a `set_callbacks` function to alias Javascript functions to RPC method names (mimics the callback API)