### PR TITLE
Implement draft RPC API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ url = "2.2"
 image = "0.23"
 infer = "0.3"
 
-[dev-dependencies]
-urlencoding = "1"
-
 [target.'cfg(target_os = "linux")'.dependencies]
 cairo-rs = "0.9"
 webkit2gtk = { version = "0.11", features = ["v2_8"] }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,46 @@ cargo run --example multiwindow
 
 For more information, please read the documentation below.
 
+## Rust <-> Javascript
+
+Communication between the host Rust code and webview Javascript is done via [JSON-RPC][].
+
+Embedding code should call `set_handler()` on the application to register an incoming request handler and reply with responses that are passed back to Javascript. On the Javascript side the client is exposed via `window.rpc` with two public methods
+
+1. The `call()` function accepts a method name and parameters and expects a reply.
+2. The `notify()` function accepts a method name and parameters but does not expect a reply.
+
+Both methods return promises but `notify()` resolves immediately.
+
+For example in Rust:
+
+```rust
+use wry::{Application, Result, RpcResponse};
+
+fn main() -> Result<()> {
+    let mut app = Application::new()?;
+    app.set_handler(Box::new(|proxy, mut req| {
+      // Handle the request of type `RpcRequest` and reply with `RpcResponse`
+      // Use the `WindowProxy` to modify the window, eg: `set_fullscreen` etc.
+      None
+    });
+    app.add_window(Default::default())?;
+    app.run();
+    Ok(())
+}
+```
+
+Then in Javascript use `call()` to call a remote method and get a response:
+
+```javascript
+async function callRemoteMethod() {
+  let result = await window.rpc.call('remoteMethod', param1, param2);
+  // Do something with the result
+}
+```
+
+See the `rpc` example for more details.
+
 ## [Documentation](https://docs.rs/wry)
 
 ## Platform-specific notes
@@ -84,3 +124,5 @@ WebView2 provided by Microsoft Edge Chromium is used. So wry supports Windows 7,
 
 ## License
 Apache-2.0/MIT
+
+[JSON-RPC]: https://www.jsonrpc.org

--- a/README.md
+++ b/README.md
@@ -50,26 +50,40 @@ For more information, please read the documentation below.
 
 Communication between the host Rust code and webview Javascript is done via [JSON-RPC][].
 
-Embedding code should call `set_handler()` on the application to register an incoming request handler and reply with responses that are passed back to Javascript. On the Javascript side the client is exposed via `window.rpc` with two public methods
+Embedding code should pass an `RpcHandler` to `add_window_with_configs()` to register an incoming request handler and reply with responses that are passed back to Javascript. On the Javascript side the client is exposed via `window.rpc` with two public methods
 
 1. The `call()` function accepts a method name and parameters and expects a reply.
 2. The `notify()` function accepts a method name and parameters but does not expect a reply.
 
-Both methods return promises but `notify()` resolves immediately.
+Both functions return promises but `notify()` resolves immediately.
 
 For example in Rust:
 
 ```rust
-use wry::{Application, Result, RpcResponse};
+use wry::{Application, Result, WindowProxy, RpcRequest, RpcResponse};
 
 fn main() -> Result<()> {
     let mut app = Application::new()?;
-    app.set_handler(Box::new(|proxy, mut req| {
-      // Handle the request of type `RpcRequest` and reply with `RpcResponse`
+    let handler = Box::new(|proxy: &WindowProxy, mut req: RpcRequest| {
+      // Handle the request of type `RpcRequest` and reply with `Option<RpcResponse>`, 
+      // use the `req.method` field to determine which action to take.
+      // 
+      // If the handler returns a `RpcResponse` it is immediately evaluated 
+      // in the calling webview.
+      // 
       // Use the `WindowProxy` to modify the window, eg: `set_fullscreen` etc.
+      // 
+      // If the request is a notification (no `id` field) then the handler 
+      // can just return `None`.
+      // 
+      // If an `id` field is present and the handler wants to execute asynchronous 
+      // code it can return `None` but then *must* later evaluate either 
+      // `RpcResponse::into_result_script()` or `RpcResponse::into_error_script()` 
+      // in the webview to ensure the promise is resolved or rejected and removed 
+      // from the cache.
       None
     });
-    app.add_window(Default::default())?;
+    app.add_window_with_configs(Default::default(), Some(handler), None)?;
     app.run();
     Ok(())
 }
@@ -81,6 +95,14 @@ Then in Javascript use `call()` to call a remote method and get a response:
 async function callRemoteMethod() {
   let result = await window.rpc.call('remoteMethod', param1, param2);
   // Do something with the result
+}
+```
+
+If Javascript code wants to use a callback style it is easy to alias a function to a method call:
+
+```javascript
+function someRemoteMethod() {
+  return window.rpc.call(arguments.callee.name, Array.prototype.slice(arguments, 0));
 }
 ```
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,63 +1,73 @@
 use wry::Result;
-use wry::{Application, Attributes, Callback};
+use wry::{Application, Attributes, WindowProxy, RpcRequest};
+use serde_json::Value;
 
 fn main() -> Result<()> {
     let mut app = Application::new()?;
 
+    let html = r#"
+<script>    
+async function openWindow() {
+    await window.rpc.notify("openWindow", "https://i.imgur.com/x6tXcr9.gif");
+}
+</script>
+<p>Multiwindow example</p>
+<button onclick="openWindow();">Launch window</button>        
+"#;
+
     let attributes = Attributes {
-        url: Some("https://tauri.studio".to_string()),
+        url: Some(format!("data:text/html,{}", urlencoding::encode(html))),
         // Initialization scripts can be used to define javascript functions and variables.
         initialization_scripts: vec![
-            String::from("breads = NaN"),
-            String::from("menacing = 'ゴ'"),
+            /* Custom initialization scripts go here */
         ],
         ..Default::default()
     };
-    // Callback defines a rust function to be called on javascript side later. Below is a function
-    // which will print the list of parameters after 8th calls.
-    let callback = Callback {
-        name: "world".to_owned(),
-        function: Box::new(|proxy, sequence, requests| {
-            // Proxy is like a window handle for you to send message events to the corresponding webview
-            // window. You can use it to adjust window and evaluate javascript code like below.
-            // This is useful when you want to perform any action in javascript.
-            proxy.evaluate_script("console.log(menacing);")?;
-            // Sequence is a number counting how many times this function being called.
-            if sequence < 8 {
-                println!("{} seconds has passed.", sequence);
-            } else {
-                // Requests is a vector of parameters passed from the caller.
-                println!("{:?}", requests);
-            }
-            Ok(())
-        }),
-    };
 
-    let window1 = app.add_window_with_configs(attributes, Some(vec![callback]), None)?;
     let app_proxy = app.application_proxy();
+    let (window_tx, window_rx) = std::sync::mpsc::channel::<String>();
+
+    let handler = Box::new(move |_proxy: &WindowProxy, req: RpcRequest| {
+        if &req.method == "openWindow" {
+            if let Some(params) = req.params {
+                if let Value::Array(mut arr) = params {
+                    let mut param = if arr.get(0).is_none() {
+                        None
+                    } else {
+                        Some(arr.swap_remove(0))
+                    };
+
+                    if let Some(param) = param.take() {
+                        if let Value::String(url) = param {
+                            let _ = window_tx.send(url);
+                        }
+                    }
+                }
+            }
+        }
+        None 
+    });
+
+    let _ = app.add_window_with_configs(attributes, Some(handler), None)?;
 
     std::thread::spawn(move || {
-        for _ in 0..7 {
-            std::thread::sleep(std::time::Duration::from_secs(1));
-            window1.evaluate_script("world()".to_string()).unwrap();
-        }
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        while let Ok(url) = window_rx.recv() {
+            let new_window = app_proxy
+                .add_window_with_configs(
+                    Attributes {
+                        width: 426.,
+                        height: 197.,
+                        title: "RODA RORA DA".into(),
+                        url: Some(url),
+                        ..Default::default()
+                    },
+                    None,
+                    None,
+                )
+                .unwrap();
+            println!("ID of new window: {:?}", new_window.id());
 
-        window1.set_title("WRYYYYYYYYYYYYYYYYYYYYY").unwrap();
-        let window2 = app_proxy
-            .add_window_with_configs(
-                Attributes {
-                    width: 426.,
-                    height: 197.,
-                    title: "RODA RORA DA".into(),
-                    url: Some("https://i.imgur.com/x6tXcr9.gif".to_string()),
-                    ..Default::default()
-                },
-                None,
-                None,
-            )
-            .unwrap();
-        println!("ID of second window: {:?}", window2.id());
+        }
     });
 
     app.run();

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -16,7 +16,7 @@ async function openWindow() {
 "#;
 
     let attributes = Attributes {
-        url: Some(format!("data:text/html,{}", urlencoding::encode(html))),
+        url: Some(format!("data:text/html,{}", html)),
         // Initialization scripts can be used to define javascript functions and variables.
         initialization_scripts: vec![
             /* Custom initialization scripts go here */

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -37,7 +37,6 @@ async function getAsyncRpcResult() {
         ..Default::default()
     };
 
-    // NOTE: must be set before calling add_window().
     let handler = Box::new(|proxy: &WindowProxy, mut req: RpcRequest| {
         let mut response = None;
         if &req.method == "fullscreen" {

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -31,9 +31,8 @@ async function getAsyncRpcResult() {
 <div id="rpc-result"></div>
 "#;
 
-    let markup = urlencoding::encode(html);
     let attributes = Attributes {
-        url: Some(format!("data:text/html,{}", markup)),
+        url: Some(format!("data:text/html,{}", html)),
         ..Default::default()
     };
 

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -1,5 +1,5 @@
 use wry::Result;
-use wry::{Application, Attributes, RpcResponse};
+use wry::{Application, Attributes, RpcResponse, RpcRequest, WindowProxy};
 use serde::{Serialize, Deserialize};
 use serde_json::Value;
 
@@ -38,7 +38,7 @@ async function getAsyncRpcResult() {
     };
 
     // NOTE: must be set before calling add_window().
-    app.set_handler(Box::new(|proxy, mut req| {
+    let handler = Box::new(|proxy: &WindowProxy, mut req: RpcRequest| {
         let mut response = None;
         if &req.method == "fullscreen" {
             if let Some(params) = req.params.take() {
@@ -69,9 +69,9 @@ async function getAsyncRpcResult() {
         }
 
         response
-    }));
+    });
 
-    app.add_window(attributes)?;
+    app.add_window_with_configs(attributes, Some(handler), None)?;
 
     app.run();
     Ok(())

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -38,7 +38,7 @@ async function getAsyncRpcResult() {
     };
 
     // NOTE: must be set before calling add_window().
-    app.set_rpc_handler(Box::new(|proxy, mut req| {
+    app.set_handler(Box::new(|proxy, mut req| {
         let mut response = None;
         if &req.method == "fullscreen" {
             if let Some(params) = req.params.take() {

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -1,6 +1,6 @@
 use crate::{
     application::{App, AppProxy, InnerWebViewAttributes, InnerWindowAttributes},
-    ApplicationProxy, Attributes, Callback, CustomProtocol, Error, Icon, Message, Result, WebView,
+    ApplicationProxy, Attributes, CustomProtocol, Error, Icon, Message, Result, WebView,
     WebViewBuilder, WindowMessage, WindowProxy, RpcHandler,
 };
 #[cfg(target_os = "macos")]
@@ -48,13 +48,11 @@ impl AppProxy for InnerApplicationProxy {
     fn add_window(
         &self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<WindowId> {
         let (sender, receiver) = channel();
         self.send_message(Message::NewWindow(
             attributes,
-            callbacks,
             sender,
             custom_protocol,
         ))?;
@@ -108,6 +106,12 @@ pub struct InnerApplication {
     pub(crate) rpc_handler: Option<Arc<RpcHandler>>,
 }
 
+impl InnerApplication {
+    pub fn is_empty(&self) -> bool {
+        self.webviews.is_empty()
+    }
+}
+
 impl App for InnerApplication {
     type Id = WindowId;
     type Proxy = InnerApplicationProxy;
@@ -126,7 +130,6 @@ impl App for InnerApplication {
     fn create_webview(
         &mut self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<Self::Id> {
         let (window_attrs, webview_attrs) = attributes.split();
@@ -135,7 +138,6 @@ impl App for InnerApplication {
             &self.application_proxy(),
             window,
             webview_attrs,
-            callbacks,
             custom_protocol,
             self.rpc_handler.clone(),
         )?;
@@ -175,7 +177,7 @@ impl App for InnerApplication {
                     _ => {}
                 },
                 Event::UserEvent(message) => match message {
-                    Message::NewWindow(attributes, callbacks, sender, custom_protocol) => {
+                    Message::NewWindow(attributes, sender, custom_protocol) => {
                         let (window_attrs, webview_attrs) = attributes.split();
                         let window = _create_window(&event_loop, window_attrs).unwrap();
                         sender.send(window.id()).unwrap();
@@ -183,7 +185,6 @@ impl App for InnerApplication {
                             &dispatcher,
                             window,
                             webview_attrs,
-                            callbacks,
                             custom_protocol,
                             rpc_handler.clone(),
                         )
@@ -347,7 +348,6 @@ fn _create_webview(
     dispatcher: &InnerApplicationProxy,
     window: Window,
     attributes: InnerWebViewAttributes,
-    callbacks: Option<Vec<Callback>>,
     custom_protocol: Option<CustomProtocol>,
     rpc_handler: Option<Arc<RpcHandler>>,
 ) -> Result<WebView> {
@@ -359,23 +359,7 @@ fn _create_webview(
     for js in attributes.initialization_scripts {
         webview = webview.initialize_script(&js);
     }
-    if let Some(cbs) = callbacks {
-        for Callback { name, mut function } in cbs {
-            let dispatcher = dispatcher.clone();
-            webview = webview.add_callback(&name, move |_, seq, req| {
-                function(
-                    WindowProxy::new(
-                        ApplicationProxy {
-                            inner: dispatcher.clone(),
-                        },
-                        window_id,
-                    ),
-                    seq,
-                    req,
-                )
-            });
-        }
-    }
+
     if let Some(protocol) = custom_protocol {
         webview = webview.register_protocol(protocol.name, protocol.handler)
     }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -1,6 +1,6 @@
 use crate::{
     application::{App, AppProxy, InnerWebViewAttributes, InnerWindowAttributes, WindowProxy},
-    ApplicationProxy, Attributes, Callback, CustomProtocol, Error, Icon, Message, Result, WebView,
+    ApplicationProxy, Attributes, CustomProtocol, Error, Icon, Message, Result, WebView,
     WebViewBuilder, WindowMessage, RpcHandler,
 };
 
@@ -8,7 +8,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     rc::Rc,
-    sync::{Arc, Mutex, mpsc::{channel, Receiver, Sender}},
+    sync::{Arc, mpsc::{channel, Receiver, Sender}},
 };
 
 use cairo::Operator;
@@ -45,13 +45,11 @@ impl AppProxy for InnerApplicationProxy {
     fn add_window(
         &self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<WindowId> {
         let (sender, receiver): (Sender<WindowId>, Receiver<WindowId>) = channel();
         self.send_message(Message::NewWindow(
             attributes,
-            callbacks,
             sender,
             custom_protocol,
         ))?;
@@ -65,6 +63,12 @@ pub struct InnerApplication {
     event_loop_proxy: EventLoopProxy,
     event_loop_proxy_rx: Receiver<Message>,
     pub(crate) rpc_handler: Option<Arc<RpcHandler>>,
+}
+
+impl InnerApplication {
+    pub fn is_empty(&self) -> bool {
+        self.webviews.is_empty()
+    }
 }
 
 impl App for InnerApplication {
@@ -90,7 +94,6 @@ impl App for InnerApplication {
     fn create_webview(
         &mut self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<Self::Id> {
         let (window_attrs, webview_attrs) = attributes.split();
@@ -100,7 +103,6 @@ impl App for InnerApplication {
             &self.application_proxy(),
             window,
             webview_attrs,
-            callbacks,
             custom_protocol,
             self.rpc_handler.clone(),
         )?;
@@ -148,7 +150,7 @@ impl App for InnerApplication {
 
             while let Ok(message) = self.event_loop_proxy_rx.try_recv() {
                 match message {
-                    Message::NewWindow(attributes, callbacks, sender, custom_protocol) => {
+                    Message::NewWindow(attributes, sender, custom_protocol) => {
                         let (window_attrs, webview_attrs) = attributes.split();
                         let window = _create_window(&self.app, window_attrs).unwrap();
                         sender.send(window.get_id()).unwrap();
@@ -156,7 +158,6 @@ impl App for InnerApplication {
                             &proxy,
                             window,
                             webview_attrs,
-                            callbacks,
                             custom_protocol,
                             self.rpc_handler.clone(),
                         )
@@ -392,7 +393,6 @@ fn _create_webview(
     proxy: &InnerApplicationProxy,
     window: ApplicationWindow,
     attributes: InnerWebViewAttributes,
-    callbacks: Option<Vec<Callback>>,
     custom_protocol: Option<CustomProtocol>,
     rpc_handler: Option<Arc<RpcHandler>>,
 ) -> Result<WebView> {
@@ -405,23 +405,7 @@ fn _create_webview(
     for js in attributes.initialization_scripts {
         webview = webview.initialize_script(&js);
     }
-    if let Some(cbs) = callbacks {
-        for Callback { name, mut function } in cbs {
-            let proxy = proxy.clone();
-            webview = webview.add_callback(&name, move |_, seq, req| {
-                function(
-                    WindowProxy::new(
-                        ApplicationProxy {
-                            inner: proxy.clone(),
-                        },
-                        window_id,
-                    ),
-                    seq,
-                    req,
-                )
-            });
-        }
-    }
+
     webview = match attributes.url {
         Some(url) => webview.load_url(&url)?,
         None => webview,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 #[cfg(not(target_os = "linux"))]
 mod general;
@@ -19,6 +19,7 @@ use std::{fs::read, path::Path, sync::mpsc::Sender};
 
 use serde_json::Value;
 
+/*
 /// Defines a Rust callback function which can be called on Javascript side.
 pub struct Callback {
     /// Name of the callback function.
@@ -44,6 +45,7 @@ impl std::fmt::Debug for Callback {
             .finish()
     }
 }
+*/
 
 pub struct CustomProtocol {
     pub name: String,
@@ -298,7 +300,6 @@ pub enum Message {
     Window(WindowId, WindowMessage),
     NewWindow(
         Attributes,
-        Option<Vec<Callback>>,
         Sender<WindowId>,
         Option<CustomProtocol>,
     ),
@@ -321,7 +322,7 @@ impl ApplicationProxy {
     }
     /// Adds another WebView window to the application. Returns its [`WindowProxy`] after created.
     pub fn add_window(&self, attributes: Attributes) -> Result<WindowProxy> {
-        let id = self.inner.add_window(attributes, None, None)?;
+        let id = self.inner.add_window(attributes, None)?;
         Ok(WindowProxy::new(self.clone(), id))
     }
 
@@ -329,12 +330,11 @@ impl ApplicationProxy {
     pub fn add_window_with_configs(
         &self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<WindowProxy> {
         let id = self
             .inner
-            .add_window(attributes, callbacks, custom_protocol)?;
+            .add_window(attributes, custom_protocol)?;
         Ok(WindowProxy::new(self.clone(), id))
     }
 }
@@ -344,7 +344,6 @@ trait AppProxy {
     fn add_window(
         &self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
         //rpc_handler: Option<RpcHandler>,
     ) -> Result<WindowId>;
@@ -540,7 +539,7 @@ impl Application {
     ///
     /// To create a default window, you could just pass `.add_window(Default::default(), None)`.
     pub fn add_window(&mut self, attributes: Attributes) -> Result<WindowProxy> {
-        let id = self.inner.create_webview(attributes, None, None)?;
+        let id = self.inner.create_webview(attributes, None)?;
         Ok(self.window_proxy(id))
     }
 
@@ -557,12 +556,11 @@ impl Application {
     pub fn add_window_with_configs(
         &mut self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
     ) -> Result<WindowProxy> {
         let id = self
             .inner
-            .create_webview(attributes, callbacks, custom_protocol)?;
+            .create_webview(attributes, custom_protocol)?;
         Ok(self.window_proxy(id))
     }
 
@@ -579,10 +577,11 @@ impl Application {
         WindowProxy::new(self.application_proxy(), window_id)
     }
 
-    /// Set an RPC message handler.
-    pub fn set_rpc_handler(&mut self, handler: RpcHandler) {
-        // TODO: detect if webviews already exist and panic
-        // TODO: because this should be set before callling add_window().
+    /// Set a handler to receive messages from the webview.
+    pub fn set_handler(&mut self, handler: RpcHandler) {
+        if !self.inner.is_empty() {
+            panic!("Webview handler must be set before adding windows (add_window() etc.)")
+        }
 
         self.inner.rpc_handler = Some(Arc::new(handler));
     }
@@ -604,7 +603,6 @@ trait App: Sized {
     fn create_webview(
         &mut self,
         attributes: Attributes,
-        callbacks: Option<Vec<Callback>>,
         custom_protocol: Option<CustomProtocol>,
         //rpc_handler: Option<RpcHandler>,
     ) -> Result<Self::Id>;
@@ -614,21 +612,7 @@ trait App: Sized {
     fn run(self);
 }
 
-pub(crate) const RPC_CALLBACK_NAME: &str = "__rpc__";
 const RPC_VERSION: &str = "2.0";
-
-/// Function call from Javascript.
-///
-/// If the callback name matches the name for an RPC handler
-/// the payload should be passed to the handler transparently.
-///
-/// Otherwise attempt to find a `Callback` with the same name
-/// and pass it the payload `params`.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FuncCall {
-    pub(crate) callback: String,
-    pub(crate) payload: RpcRequest,
-}
 
 /// RPC request message.
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -17,34 +17,6 @@ use std::{fs::read, path::Path, sync::mpsc::Sender};
 
 use serde_json::Value;
 
-/*
-/// Defines a Rust callback function which can be called on Javascript side.
-pub struct Callback {
-    /// Name of the callback function.
-    pub name: String,
-    /// The function itself takes three parameters and return a number as return value.
-    ///
-    /// [`WindowProxy`] can let you adjust the corresponding WebView window.
-    ///
-    /// The second parameter `i32` is a sequence number to count how many times this function has
-    /// been called.
-    ///
-    /// The last vector is the actual list of arguments passed from the caller.
-    ///
-    /// The return value of the function is a number. Return `0` indicates the call is successful,
-    /// and return others if not.
-    pub function: Box<dyn FnMut(WindowProxy, i32, Vec<Value>) -> Result<()> + Send>,
-}
-
-impl std::fmt::Debug for Callback {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Callback")
-            .field("name", &self.name)
-            .finish()
-    }
-}
-*/
-
 pub struct CustomProtocol {
     pub name: String,
     pub handler: Box<dyn Fn(&str) -> Result<Vec<u8>> + Send>,
@@ -293,7 +265,6 @@ pub enum WindowMessage {
 }
 
 /// Describes a general message.
-//#[derive(Debug)]
 pub enum Message {
     Window(WindowId, WindowMessage),
     NewWindow(

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -614,4 +614,18 @@ impl RpcResponse {
             result: None
         } 
     }
+
+    /// Get a script that resolves the promise with a result.
+    pub fn into_result_script(id: Value, result: Value) -> Result<String> {
+        let retval = serde_json::to_string(&result)?;
+        Ok(format!("window.external.rpc._result({}, {})",
+            id.to_string(), retval))
+    }
+
+    /// Get a script that rejects the promise with an error.
+    pub fn into_error_script(id: Value, result: Value) -> Result<String> {
+        let retval = serde_json::to_string(&result)?;
+        Ok(format!("window.external.rpc._error({}, {})",
+            id.to_string(), retval))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,11 @@ pub mod platform;
 pub mod webview;
 
 pub use application::{
-    Application, ApplicationProxy, Attributes, Callback, CustomProtocol, Icon, Message, WindowId,
+    Application, ApplicationProxy, Attributes, CustomProtocol, Icon, Message, WindowId,
     WindowMessage, WindowProxy, RpcRequest, RpcResponse,
 };
 pub use serde_json::Value;
-pub(crate) use webview::{Dispatcher, WebView, WebViewBuilder, RpcHandler};
+pub(crate) use webview::{WebView, WebViewBuilder, RpcHandler};
 
 #[cfg(not(target_os = "linux"))]
 use winit::window::BadIcon;
@@ -114,6 +114,8 @@ pub enum Error {
     GlibBoolError(#[from] glib::BoolError),
     #[error("Failed to initialize the script")]
     InitScriptError,
+    #[error("Bad RPC request: {0} ((1))")]
+    RpcScriptError(String, String),
     #[error(transparent)]
     NulError(#[from] std::ffi::NulError),
     #[cfg(not(target_os = "linux"))]
@@ -125,6 +127,8 @@ pub enum Error {
     SenderError(#[from] SendError<String>),
     #[error("Failed to send the message")]
     MessageSender,
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
     #[error(transparent)]
     UrlError(#[from] ParseError),
     #[error("IO error: {0}")]

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use gdk::RGBA;
 use gio::Cancellable;
 use glib::{Bytes, FileError};
-use gtk::{ApplicationWindow as Window, /* ApplicationWindowExt, */ ContainerExt, WidgetExt};
+use gtk::{ApplicationWindow as Window, ContainerExt, WidgetExt};
 use url::Url;
 use webkit2gtk::{
     SecurityManagerExt, SettingsExt, URISchemeRequestExt, UserContentInjectedFrames,

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,17 +1,15 @@
-use crate::platform::{CALLBACKS, RPC};
-use crate::application::{WindowProxy, FuncCall, RpcRequest, RpcResponse, RPC_CALLBACK_NAME};
+use crate::application::WindowProxy;
 use crate::mimetype::MimeType;
 use crate::webview::WV;
-use crate::{Dispatcher, Error, Result, RpcHandler};
+use crate::{Error, Result, RpcHandler};
 
 use std::rc::Rc;
 use std::sync::Arc;
 
-use serde_json::Value;
 use gdk::RGBA;
 use gio::Cancellable;
 use glib::{Bytes, FileError};
-use gtk::{ApplicationWindow as Window, ApplicationWindowExt, ContainerExt, WidgetExt};
+use gtk::{ApplicationWindow as Window, /* ApplicationWindowExt, */ ContainerExt, WidgetExt};
 use url::Url;
 use webkit2gtk::{
     SecurityManagerExt, SettingsExt, URISchemeRequestExt, UserContentInjectedFrames,
@@ -47,97 +45,19 @@ impl WV for InnerWebView {
         // Message handler
         let wv = Rc::clone(&webview);
         manager.register_script_message_handler("external");
-        let window_id = window.get_id() as i64;
         manager.connect_script_message_received(move |_m, msg| {
-            if let Some(js) = msg.get_value() {
-                if let Some(context) = msg.get_global_context() {
-                    if let Some(js) = js.to_string(&context) {
-                        match serde_json::from_str::<FuncCall>(&js) {
-                            Ok(mut ev) => {
-                                // Use `isize` to conform with existing `Callback` API but should 
-                                // really be a `u64`. Note that RPC spec allows for non-numbers 
-                                // in the `id` field!
-                                let id: i32 = if let Some(value) = ev.payload.id.clone().take() {
-                                    if let Value::Number(num) = value {
-                                        if num.is_i64() { num.as_i64().unwrap() as i32 } else { 0 }
-                                    } else { 0 }
-                                } else { 0 };
-
-                                let use_rpc = rpc_handler.is_some() && &ev.callback == RPC_CALLBACK_NAME;
-
-                                // Send to an RPC handler
-                                if use_rpc {
-                                    let (proxy, rpc_handler) = rpc_handler.as_ref().unwrap();
-                                    let mut response = rpc_handler(proxy, ev.payload);
-                                    if let Some(mut response) = response.take() {
-                                        if let Some(id) = response.id {
-                                            let js = if let Some(error) = response.error.take() {
-                                                match serde_json::to_string(&error) {
-                                                    Ok(retval) => {
-                                                        format!("window.external.rpc._error({}, {})",
-                                                            id.to_string(), retval)
-                                                    }
-                                                    Err(_) => {
-                                                        format!("window.external.rpc._error({}, null)",
-                                                            id.to_string())
-                                                    }
-                                                }
-                                            } else if let Some(result) = response.result.take() {
-                                                match serde_json::to_string(&result) {
-                                                    Ok(retval) => {
-                                                        format!("window.external.rpc._result({}, {})",
-                                                            id.to_string(), retval)
-                                                    }
-                                                    Err(_) => {
-                                                        format!("window.external.rpc._result({}, null)",
-                                                            id.to_string())
-                                                    }
-                                                }
-                                            } else {
-                                                // No error or result, assume a positive response
-                                                // with empty result (ACK)
-                                                format!("window.external.rpc._result({}, null)",
-                                                    id.to_string())
-                                            };
-
-                                            let cancellable: Option<&Cancellable> = None;
-                                            wv.run_javascript(&js, cancellable, |_| ());
-                                        }
-                                    }
-                                // Normal callback mechanism
-                                } else {
-                                    let mut hashmap = CALLBACKS.lock().unwrap();
-                                    let (f, d) = hashmap.get_mut(&(window_id, ev.callback)).unwrap();
-                                    // TODO: update `Callback` to take a `Value`?
-                                    let raw_params = if let Some(val) = ev.payload.params.take() {
-                                        val
-                                    } else { Value::Null };
-                                    let params = if let Value::Array(arr) = raw_params {
-                                        arr 
-                                    } else { vec![raw_params] };
-
-                                    let status = f(d, id, params);
-                                    let js = match status {
-                                        Ok(()) => {
-                                            format!(
-                                                r#"window._rpc[{}].resolve("RPC call success"); window._rpc[{}] = undefined"#,
-                                                id, id
-                                            )
-                                        }
-                                        Err(e) => {
-                                            format!(
-                                                r#"window._rpc[{}].reject("RPC call fail with error {}"); window._rpc[{}] = undefined"#,
-                                                id, e, id
-                                            )
-                                        }
-                                    };
-
+            if let (Some(js), Some(context)) = (msg.get_value(), msg.get_global_context()) {
+                if let Some(js) = js.to_string(&context) {
+                    if let Some((proxy, rpc_handler)) = rpc_handler.as_ref() {
+                        match super::rpc_proxy(js, proxy, rpc_handler) {
+                            Ok(result) => {
+                                if let Some(ref script) = result {
                                     let cancellable: Option<&Cancellable> = None;
-                                    wv.run_javascript(&js, cancellable, |_| ());
+                                    wv.run_javascript(script, cancellable, |_| ());
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Bad Javascript function call: {} ({})", e, &js);
+                                eprintln!("{}", e);
                             }
                         }
                     }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -4,7 +4,6 @@ use crate::webview::WV;
 use crate::{Error, Result, RpcHandler};
 
 use std::rc::Rc;
-use std::sync::Arc;
 
 use gdk::RGBA;
 use gio::Cancellable;
@@ -32,7 +31,7 @@ impl WV for InnerWebView {
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
             WindowProxy,
-            Arc<RpcHandler>,
+            RpcHandler,
         )>,
     ) -> Result<Self> {
         // Webview widget

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,7 +4,6 @@ use crate::webview::WV;
 use crate::{Result, RpcHandler};
 
 use std::{
-    sync::Arc,
     collections::hash_map::DefaultHasher,
     ffi::{c_void, CStr},
     hash::{Hash, Hasher},
@@ -40,7 +39,7 @@ impl WV for InnerWebView {
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
             WindowProxy,
-            Arc<RpcHandler>,
+            RpcHandler,
         )>,
     ) -> Result<Self> {
         let mut hasher = DefaultHasher::new();

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,8 +1,7 @@
 use crate::mimetype::MimeType;
-use crate::platform::{CALLBACKS, RPC};
 use crate::application::WindowProxy;
 use crate::webview::WV;
-use crate::{Result, Dispatcher, RpcHandler};
+use crate::{Result, RpcHandler};
 
 use std::{
     sync::Arc,
@@ -52,33 +51,30 @@ impl WV for InnerWebView {
         extern "C" fn did_receive(this: &Object, _: Sel, _: id, msg: id) {
             // Safety: objc runtime calls are unsafe
             unsafe {
-                let window_id = *this.get_ivar("_window_id");
+                //let window_id = *this.get_ivar("_window_id");
                 let body: id = msg_send![msg, body];
                 let utf8: *const c_char = msg_send![body, UTF8String];
-                let s = CStr::from_ptr(utf8).to_str().expect("Invalid UTF8 string");
-                let v: RPC = serde_json::from_str(&s).unwrap();
-                let mut hashmap = CALLBACKS.lock().unwrap();
-                let (f, d) = hashmap.get_mut(&(window_id, v.method)).unwrap();
-                let status = f(d, v.id, v.params);
+                let js = CStr::from_ptr(utf8).to_str().expect("Invalid UTF8 string");
 
-                let js = match status {
-                    Ok(()) => {
-                        format!(
-                            r#"window._rpc[{}].resolve("RPC call success"); window._rpc[{}] = undefined"#,
-                            v.id, v.id
-                        )
+                // FIXME: allow access to rpc_handler here?
+
+                /*
+                if let Some((proxy, rpc_handler)) = rpc_handler.as_ref() {
+                    match super::rpc_proxy(js.to_string(), proxy, rpc_handler) {
+                        Ok(result) => {
+                            if let Some(ref script) = result {
+                                let wv: id = msg_send![msg, webView];
+                                let js = NSString::new(script);
+                                let _: id =
+                                    msg_send![wv, evaluateJavaScript:js completionHandler:null::<*const c_void>()];
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("{}", e);
+                        }
                     }
-                    Err(e) => {
-                        format!(
-                            r#"window._rpc[{}].reject("RPC call fail with error {}"); window._rpc[{}] = undefined"#,
-                            v.id, e, v.id
-                        )
-                    }
-                };
-                let wv: id = msg_send![msg, webView];
-                let js = NSString::new(&js);
-                let _: id =
-                    msg_send![wv, evaluateJavaScript:js completionHandler:null::<*const c_void>()];
+                }
+                */
             }
         }
 

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -1,8 +1,7 @@
 use crate::mimetype::MimeType;
-use crate::platform::{CALLBACKS, RPC};
 use crate::application::WindowProxy;
 use crate::webview::WV;
-use crate::{Result, Dispatcher, RpcHandler};
+use crate::{Result, RpcHandler};
 
 use std::{
     sync::Arc,
@@ -79,28 +78,19 @@ impl WV for InnerWebView {
 
                 // Message handler
                 w.add_web_message_received(move |webview, args| {
-                    let s = args.try_get_web_message_as_string()?;
-                    let v: RPC = serde_json::from_str(&s).unwrap();
-                    let mut hashmap = CALLBACKS.lock().unwrap();
-                    let (f, d) = hashmap.get_mut(&(window_id, v.method)).unwrap();
-                    let status = f(d, v.id, v.params);
-
-                    let js = match status {
-                        Ok(()) => {
-                            format!(
-                                r#"window._rpc[{}].resolve("RPC call success"); window._rpc[{}] = undefined"#,
-                                v.id, v.id
-                            )
+                    let js = args.try_get_web_message_as_string()?;
+                    if let Some((proxy, rpc_handler)) = rpc_handler.as_ref() {
+                        match super::rpc_proxy(js, proxy, rpc_handler) {
+                            Ok(result) => {
+                                if let Some(ref script) = result {
+                                    webview.execute_script(script, |_| (Ok(())))?;
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("{}", e);
+                            }
                         }
-                        Err(e) => {
-                            format!(
-                                r#"window._rpc[{}].reject("RPC call fail with error {}"); window._rpc[{}] = undefined"#,
-                                v.id, e, v.id
-                            )
-                        }
-                    };
-
-                    webview.execute_script(&js, |_| (Ok(())))?;
+                    }
                     Ok(())
                 })?;
 

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -4,7 +4,6 @@ use crate::webview::WV;
 use crate::{Result, RpcHandler};
 
 use std::{
-    sync::Arc,
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     os::raw::c_void,
@@ -34,7 +33,7 @@ impl WV for InnerWebView {
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
             WindowProxy,
-            Arc<RpcHandler>,
+            RpcHandler,
         )>,
     ) -> Result<Self> {
         let controller: Rc<OnceCell<Controller>> = Rc::new(OnceCell::new());

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -1,7 +1,7 @@
 //! [`WebView`] struct and associated types.
 
-use crate::platform::{InnerWebView, CALLBACKS};
-use crate::application::{WindowProxy, RpcRequest, RpcResponse, RPC_CALLBACK_NAME};
+use crate::platform::{InnerWebView};
+use crate::application::{WindowProxy, RpcRequest, RpcResponse};
 use crate::Result;
 
 use std::sync::{Arc, mpsc::{channel, Receiver, Sender}};
@@ -11,7 +11,6 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use serde_json::Value;
 use url::Url;
 
 #[cfg(target_os = "linux")]
@@ -35,6 +34,7 @@ pub struct WebViewBuilder {
     initialization_scripts: Vec<String>,
     window: Window,
     url: Option<Url>,
+    // TODO: remove this field?
     window_id: i64,
     custom_protocol: Option<(String, Box<dyn Fn(&str) -> Result<Vec<u8>>>)>,
     rpc_handler: Option<(
@@ -100,63 +100,11 @@ impl WebViewBuilder {
         self
     }
 
-    /// Add a callback function to the WebView. The callback takse a dispatcher, a sequence number,
-    /// and a vector of arguments passed from callers as parameters.
-    ///
-    /// It uses RPC to communicate with javascript side and the sequence number is used to record
-    /// how many times has this callback been called. Arguments passed from callers is a vector of
-    /// serde values for you to decide how to handle them. IF you need to evaluate any code on
-    /// javascript side, you can use the dispatcher to send them.
-    pub fn add_callback<F>(mut self, name: &str, f: F) -> Self
-    where
-        F: FnMut(&Dispatcher, i32, Vec<Value>) -> Result<()> + Send + 'static,
-    {
-
-        let js = format!(
-            r#"
-            (function() {{
-                var name = {:?};
-                var RPC = window._rpc = (window._rpc || {{nextSeq: 1}});
-                window[name] = function() {{
-                var seq = RPC.nextSeq++;
-                var promise = new Promise(function(resolve, reject) {{
-                    RPC[seq] = {{
-                    resolve: resolve,
-                    reject: reject,
-                    }};
-                }});
-                window.external.invoke(JSON.stringify({{
-                    callback: {:?},
-                    payload: {{
-                        jsonrpc: '2.0',
-                        id: seq,
-                        method: name,
-                        params: Array.prototype.slice.call(arguments),
-                    }}
-                }}));
-                return promise;
-                }}
-            }})()
-            "#,
-            name,
-            name,
-        );
-        self.initialization_scripts.push(js);
-
-        let window_id = self.window_id;
-        CALLBACKS.lock().unwrap().insert(
-            (window_id, name.to_string()),
-            (Box::new(f), Dispatcher(self.tx.clone())),
-        );
-        self
-    }
-
     /// Set the RPC handler.
     pub(crate) fn set_rpc_handler(mut self, proxy: WindowProxy, handler: Arc<RpcHandler>) -> Self {
         let js =
             r#"
             function Rpc() {
-                this._callback = '__rpc__';
                 this._promises = {};
 
                 // Private internal function called on error
@@ -175,16 +123,20 @@ impl WebViewBuilder {
                     }
                 }
 
+                // Private internal function called on failure to remove any promise
+                this._clean = (id) => {
+                    delete this._promises[id];
+                }
+
                 // Call remote method and expect a reply from the handler
                 this.call = function(method) {
                     const id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
                     const params = Array.prototype.slice.call(arguments, 1);
                     const payload = {jsonrpc: "2.0", id, method, params};
-                    const msg = {callback: this._callback, payload};
                     const promise = new Promise((resolve, reject) => {
                         this._promises[id] = {resolve, reject};
                     });
-                    window.external.invoke(JSON.stringify(msg));
+                    window.external.invoke(JSON.stringify(payload));
                     return promise;
                 }
 
@@ -192,8 +144,7 @@ impl WebViewBuilder {
                 this.notify = function(method) {
                     const params = Array.prototype.slice.call(arguments, 1);
                     const payload = {jsonrpc: "2.0", method, params};
-                    const msg = {callback: this._callback, payload};
-                    window.external.invoke(JSON.stringify(msg));
+                    window.external.invoke(JSON.stringify(payload));
                     return Promise.resolve();
                 }
             }

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -20,7 +20,7 @@ use winit::platform::windows::WindowExtWindows;
 #[cfg(not(target_os = "linux"))]
 use winit::window::Window;
 
-pub type RpcHandler = Box<dyn Fn(&WindowProxy, RpcRequest) -> Option<RpcResponse> + Send + Sync>;
+pub type RpcHandler = Box<dyn Fn(&WindowProxy, RpcRequest) -> Option<RpcResponse> + Send>;
 
 /// Builder type of [`WebView`].
 ///

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -14,7 +14,7 @@ use std::{
 use url::Url;
 
 #[cfg(target_os = "linux")]
-use gtk::{ApplicationWindow as Window, ApplicationWindowExt};
+use gtk::{ApplicationWindow as Window};
 #[cfg(target_os = "windows")]
 use winit::platform::windows::WindowExtWindows;
 #[cfg(not(target_os = "linux"))]
@@ -34,8 +34,6 @@ pub struct WebViewBuilder {
     initialization_scripts: Vec<String>,
     window: Window,
     url: Option<Url>,
-    // TODO: remove this field?
-    window_id: i64,
     custom_protocol: Option<(String, Box<dyn Fn(&str) -> Result<Vec<u8>>>)>,
     rpc_handler: Option<(
         WindowProxy,
@@ -47,14 +45,6 @@ impl WebViewBuilder {
     /// Create [`WebViewBuilder`] from provided [`Window`].
     pub fn new(window: Window) -> Result<Self> {
         let (tx, rx) = channel();
-        #[cfg(not(target_os = "linux"))]
-        let window_id = {
-            let mut hasher = DefaultHasher::new();
-            window.id().hash(&mut hasher);
-            hasher.finish() as i64
-        };
-        #[cfg(target_os = "linux")]
-        let window_id = window.get_id() as i64;
 
         Ok(Self {
             tx,
@@ -63,7 +53,6 @@ impl WebViewBuilder {
             window,
             url: None,
             transparent: false,
-            window_id,
             custom_protocol: None,
             rpc_handler: None,
         })

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -112,11 +112,6 @@ impl WebViewBuilder {
                     }
                 }
 
-                // Private internal function called on failure to remove any promise
-                this._clean = (id) => {
-                    delete this._promises[id];
-                }
-
                 // Call remote method and expect a reply from the handler
                 this.call = function(method) {
                     const id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -4,7 +4,7 @@ use crate::platform::{InnerWebView};
 use crate::application::{WindowProxy, RpcRequest, RpcResponse};
 use crate::Result;
 
-use std::sync::{Arc, mpsc::{channel, Receiver, Sender}};
+use std::sync::{mpsc::{channel, Receiver, Sender}};
 #[cfg(not(target_os = "linux"))]
 use std::{
     collections::hash_map::DefaultHasher,
@@ -39,7 +39,7 @@ pub struct WebViewBuilder {
     custom_protocol: Option<(String, Box<dyn Fn(&str) -> Result<Vec<u8>>>)>,
     rpc_handler: Option<(
         WindowProxy,
-        Arc<RpcHandler>,
+        RpcHandler,
     )>,
 }
 
@@ -101,7 +101,7 @@ impl WebViewBuilder {
     }
 
     /// Set the RPC handler.
-    pub(crate) fn set_rpc_handler(mut self, proxy: WindowProxy, handler: Arc<RpcHandler>) -> Self {
+    pub(crate) fn set_rpc_handler(mut self, proxy: WindowProxy, handler: RpcHandler) -> Self {
         let js =
             r#"
             function Rpc() {
@@ -282,7 +282,7 @@ pub(crate) trait WV: Sized {
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
             WindowProxy,
-            Arc<RpcHandler>,
+            RpcHandler,
         )>,
     ) -> Result<Self>;
 


### PR DESCRIPTION
Remove old Callback mechanism.

* Remove obsolete Callback API
* Remove FuncCall and RPC
* Update README
* Rename set_rpc_handler() to set_handler()
* Use shared rpc_proxy() function for platform consistency
* Improve handling of promise cleanup
* Update README with RPC API info.
* Panic if webview handler is set after window creation.
* Improve rpc_proxy() logic, try to ensure any corresponding promise is always removed.
* Remove FuncCall wrapper.