### PR TITLE
File drop handlers

### DIFF
--- a/examples/dragndrop.rs
+++ b/examples/dragndrop.rs
@@ -1,0 +1,30 @@
+use wry::{Application, Attributes, Result, FileDropHandler};
+
+// Apps can have a global file drop handler, and invidiual windows can have their own, too.
+
+fn main() -> Result<()> {
+    let mut app = Application::new()?;
+    
+    app.set_file_drop_handler(FileDropHandler::new(|status| {
+        println!("Any window: {:?}", status);
+    }));
+
+    app.add_window(Attributes {
+        url: Some("about:blank".to_string()),
+        file_drop_handler: Some(FileDropHandler::new(|status| {
+            println!("Window 1: {:?}", status);
+        })),
+        ..Default::default()
+    })?;
+    
+    app.add_window(Attributes {
+        url: Some("about:blank".to_string()),
+        file_drop_handler: Some(FileDropHandler::new(|status| {
+            println!("Window 2: {:?}", status);
+        })),
+        ..Default::default()
+    })?;
+
+    app.run();
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub mod webview;
 
 pub use application::{
     Application, ApplicationProxy, Attributes, Callback, CustomProtocol, Icon, Message, WindowId,
-    WindowMessage, WindowProxy, RpcRequest, RpcResponse,
+    WindowMessage, WindowProxy, RpcRequest, RpcResponse, FileDropStatus, FileDropHandler
 };
 pub use serde_json::Value;
 pub(crate) use webview::{Dispatcher, WebView, WebViewBuilder, RpcHandler};


### PR DESCRIPTION
# Progress

- [X] Windows support
- [ ] Linux support
- [ ] macOS support
- [ ] `FileDropStatus::Hovered`, `FileDropStatus::Cancelled` (depends on [Webview2 1.0.790-prerelease](https://docs.microsoft.com/en-us/microsoft-edge/webview2/releasenotes#10790-prerelease))

# [Example](https://github.com/WilliamVenner/wry/blob/feat/file_drop_handlers/examples/dragndrop.rs)

```rust
use wry::{Application, Attributes, Result, FileDropHandler};

// Apps can have a global file drop handler, and invidiual windows can have their own, too.

fn main() -> Result<()> {
    let mut app = Application::new()?;
    
    app.set_file_drop_handler(FileDropHandler::new(|status| {
        println!("Any window: {:?}", status);
    }));

    app.add_window(Attributes {
        url: Some("about:blank".to_string()),
        file_drop_handler: Some(FileDropHandler::new(|status| {
            println!("Window 1: {:?}", status);
        })),
        ..Default::default()
    })?;
    
    app.add_window(Attributes {
        url: Some("about:blank".to_string()),
        file_drop_handler: Some(FileDropHandler::new(|status| {
            println!("Window 2: {:?}", status);
        })),
        ..Default::default()
    })?;

    app.run();
    Ok(())
}
```