### PR TITLE
Use Rc for WindowProxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ For example in Rust:
 
 ```rust
 use wry::{Application, Result, WindowProxy, RpcRequest, RpcResponse};
+use std::rc::Rc;
 
 fn main() -> Result<()> {
     let mut app = Application::new()?;
-    let handler = Box::new(|proxy: &WindowProxy, mut req: RpcRequest| {
+    let handler = Box::new(|proxy: Rc<WindowProxy>, mut req: RpcRequest| {
       // Handle the request of type `RpcRequest` and reply with `Option<RpcResponse>`, 
       // use the `req.method` field to determine which action to take.
       // 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,5 +1,6 @@
 use wry::Result;
 use wry::{Application, Attributes, WindowProxy, RpcRequest};
+use std::rc::Rc;
 use serde_json::Value;
 
 fn main() -> Result<()> {
@@ -27,7 +28,7 @@ async function openWindow() {
     let app_proxy = app.application_proxy();
     let (window_tx, window_rx) = std::sync::mpsc::channel::<String>();
 
-    let handler = Box::new(move |_proxy: &WindowProxy, req: RpcRequest| {
+    let handler = Box::new(move |_proxy: Rc<WindowProxy>, req: RpcRequest| {
         if &req.method == "openWindow" {
             if let Some(params) = req.params {
                 if let Value::Array(mut arr) = params {

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -1,5 +1,6 @@
 use wry::Result;
 use wry::{Application, Attributes, RpcResponse, RpcRequest, WindowProxy};
+use std::rc::Rc;
 use serde::{Serialize, Deserialize};
 use serde_json::Value;
 
@@ -36,7 +37,7 @@ async function getAsyncRpcResult() {
         ..Default::default()
     };
 
-    let handler = Box::new(|proxy: &WindowProxy, mut req: RpcRequest| {
+    let handler = Box::new(|proxy: Rc<WindowProxy>, mut req: RpcRequest| {
         let mut response = None;
         if &req.method == "fullscreen" {
             if let Some(params) = req.params.take() {

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -13,7 +13,7 @@ use winit::{
     window::{Fullscreen, Icon as WinitIcon, Window, WindowAttributes, WindowBuilder},
 };
 
-use std::{collections::HashMap, sync::mpsc::channel};
+use std::{rc::Rc, collections::HashMap, sync::mpsc::channel};
 
 #[cfg(target_os = "windows")]
 use {
@@ -365,7 +365,7 @@ fn _create_webview(
             },
             rpc_win_id,
         );
-        webview = webview.set_rpc_handler(rpc_proxy, rpc_handler);
+        webview = webview.set_rpc_handler(Rc::new(rpc_proxy), rpc_handler);
     }
 
     webview = match attributes.url {

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -416,7 +416,7 @@ fn _create_webview(
             },
             rpc_win_id,
         );
-        webview = webview.set_rpc_handler(rpc_proxy, rpc_handler);
+        webview = webview.set_rpc_handler(Rc::new(rpc_proxy), rpc_handler);
     }
 
     let webview = webview.build()?;

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -30,7 +30,7 @@ impl WV for InnerWebView {
         transparent: bool,
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
-            WindowProxy,
+            Rc<WindowProxy>,
             RpcHandler,
         )>,
     ) -> Result<Self> {
@@ -47,7 +47,7 @@ impl WV for InnerWebView {
         manager.connect_script_message_received(move |_m, msg| {
             if let (Some(js), Some(context)) = (msg.get_value(), msg.get_global_context()) {
                 if let Some(js) = js.to_string(&context) {
-                    if let Some((proxy, rpc_handler)) = rpc_handler.as_ref() {
+                    if let Some((proxy, rpc_handler)) = rpc_handler.as_ref().map(|(p, r)| (Rc::clone(p), r)) {
                         match super::rpc_proxy(js, proxy, rpc_handler) {
                             Ok(result) => {
                                 if let Some(ref script) = result {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,6 +4,7 @@ use crate::webview::WV;
 use crate::{Result, RpcHandler};
 
 use std::{
+    rc::Rc,
     collections::hash_map::DefaultHasher,
     ffi::{c_void, CStr},
     hash::{Hash, Hasher},
@@ -38,7 +39,7 @@ impl WV for InnerWebView {
         transparent: bool,
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
-            WindowProxy,
+            Rc<WindowProxy>,
             RpcHandler,
         )>,
     ) -> Result<Self> {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -20,12 +20,13 @@ pub use gtk::*;
 #[cfg(not(target_os = "linux"))]
 pub use winit::*;
 
+use std::rc::Rc;
 use serde_json::Value;
 
 use crate::{Error, Result, RpcHandler, application::{WindowProxy, RpcRequest, RpcResponse}};
 
 // Helper so all platforms handle RPC messages consistently.
-pub(crate) fn rpc_proxy(js: String, proxy: &WindowProxy, handler: &RpcHandler) -> Result<Option<String>> {
+pub(crate) fn rpc_proxy(js: String, proxy: Rc<WindowProxy>, handler: &RpcHandler) -> Result<Option<String>> {
     let req = serde_json::from_str::<RpcRequest>(&js).map_err(|e| {
         Error::RpcScriptError(e.to_string(), js)
     })?;

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -32,7 +32,7 @@ impl WV for InnerWebView {
         transparent: bool,
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
-            WindowProxy,
+            Rc<WindowProxy>,
             RpcHandler,
         )>,
     ) -> Result<Self> {

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -3,6 +3,7 @@
 use crate::platform::{InnerWebView};
 use crate::application::{WindowProxy, RpcRequest, RpcResponse};
 use crate::Result;
+use std::rc::Rc;
 
 use std::sync::{mpsc::{channel, Receiver, Sender}};
 #[cfg(not(target_os = "linux"))]
@@ -20,7 +21,7 @@ use winit::platform::windows::WindowExtWindows;
 #[cfg(not(target_os = "linux"))]
 use winit::window::Window;
 
-pub type RpcHandler = Box<dyn Fn(&WindowProxy, RpcRequest) -> Option<RpcResponse> + Send>;
+pub type RpcHandler = Box<dyn Fn(Rc<WindowProxy>, RpcRequest) -> Option<RpcResponse> + Send>;
 
 /// Builder type of [`WebView`].
 ///
@@ -36,7 +37,7 @@ pub struct WebViewBuilder {
     url: Option<Url>,
     custom_protocol: Option<(String, Box<dyn Fn(&str) -> Result<Vec<u8>>>)>,
     rpc_handler: Option<(
-        WindowProxy,
+        Rc<WindowProxy>,
         RpcHandler,
     )>,
 }
@@ -90,7 +91,7 @@ impl WebViewBuilder {
     }
 
     /// Set the RPC handler.
-    pub(crate) fn set_rpc_handler(mut self, proxy: WindowProxy, handler: RpcHandler) -> Self {
+    pub(crate) fn set_rpc_handler(mut self, proxy: Rc<WindowProxy>, handler: RpcHandler) -> Self {
         let js =
             r#"
             function Rpc() {
@@ -265,7 +266,7 @@ pub(crate) trait WV: Sized {
         transparent: bool,
         custom_protocol: Option<(String, F)>,
         rpc_handler: Option<(
-            WindowProxy,
+            Rc<WindowProxy>,
             RpcHandler,
         )>,
     ) -> Result<Self>;


### PR DESCRIPTION
Hi @wusyong,

I made a mistake passing `WindowProxy` by reference, could we pass an `Rc` instead so it is easy for calling code to pass off to services.

Hope you haven't started on the platform work so we can get this in. Thanks :+1: 