### PR TITLE
Fix rpc Javascript scope bug.

### DIFF
--- a/src/webview.rs
+++ b/src/webview.rs
@@ -85,6 +85,7 @@ impl WebViewBuilder {
     pub fn set_rpc_handler(mut self, handler: RpcHandler) -> Self {
         let js = r#"
             function Rpc() {
+                const self = this;
                 this._promises = {};
 
                 // Private internal function called on error
@@ -109,7 +110,7 @@ impl WebViewBuilder {
                     const params = Array.prototype.slice.call(arguments, 1);
                     const payload = {jsonrpc: "2.0", id, method, params};
                     const promise = new Promise((resolve, reject) => {
-                        this._promises[id] = {resolve, reject};
+                        self._promises[id] = {resolve, reject};
                     });
                     window.external.invoke(JSON.stringify(payload));
                     return promise;


### PR DESCRIPTION
Fix for a scope bug with the injected RPC code.

Suprised this didn't manifest earlier but after a colleague reported a bug on macOS I started debugging the RPC communication and came across this issue:

```
undefined:28:39: CONSOLE ERROR Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'this._promises[id] = {resolve, reject}')
```

Both `call` and `notify` must be `function` (not `() => {}`) so they can access `arguments` but because they are they don't benefit from inheriting the `this` scope so we fix this using the `const self`.