### PR TITLE
Expose RpcRequest and RpcResponse as public.

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -18,8 +18,6 @@ use crate::Result;
 
 use std::sync::mpsc::Sender;
 
-use serde_json::Value;
-
 /// Describes a message for a WebView window.
 #[derive(Debug)]
 pub enum WindowMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ pub use application::{
     WindowMessage, WindowProxy, WindowRpcHandler,
 };
 pub use serde_json::Value;
-pub(crate) use webview::{RpcHandler, RpcRequest, RpcResponse, WebView, WebViewBuilder};
+pub(crate) use webview::{RpcHandler, WebView, WebViewBuilder};
+pub use webview::{RpcRequest, RpcResponse};
 
 #[cfg(not(target_os = "linux"))]
 use winit::window::BadIcon;


### PR DESCRIPTION
Required for handlers to transform requests and responses into internal types used to service method calls.

Fixes examples too.