### PR TITLE
fix: exit winit's event loop in `WindowMessage::Close` if necessary

### DIFF
--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -202,6 +202,9 @@ impl App for InnerApplication {
                                 WindowMessage::Hide => window.set_visible(false),
                                 WindowMessage::Close => {
                                     windows.remove(&id);
+                                    if windows.is_empty() {
+                                        *control_flow = ControlFlow::Exit;
+                                    }
                                 }
                                 WindowMessage::SetDecorations(decorations) => {
                                     window.set_decorations(decorations)


### PR DESCRIPTION
currently, closing the last window programmatically doesn't exit winit's event_loop.