### PR TITLE
Fix visibility on webview2 when window was invisible previously

### DIFF
--- a/.changes/visible.md
+++ b/.changes/visible.md
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+Fix visibility on webview2 when window was invisible previously and then shown.
+

--- a/src/webview/win/mod.rs
+++ b/src/webview/win/mod.rs
@@ -180,6 +180,7 @@ impl WV for InnerWebView {
           }
         }
 
+        controller.put_is_visible(true);
         let _ = controller_clone.set(controller);
 
         if let Some(file_drop_handler) = file_drop_handler {


### PR DESCRIPTION
We set webview2 to be always visible for simplicity. This is more of a workaround. Microsoft is also working to fix it:
https://github.com/MicrosoftEdge/WebView2Feedback/issues/1077

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
