### PR TITLE
fix: spawn async event loop on gtk to prevent delayed messages (fix #132)

### DIFF
--- a/.changes/delayed_processing.md
+++ b/.changes/delayed_processing.md
@@ -1,0 +1,5 @@
+---
+'wry': patch
+---
+
+Fix messages to the webview from the backend being delayed on Linux/GTK when the user is not actively engaged with the UI.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ glib = "0.10"
 gtk = "0.9"
 gdk = "0.13"
 gdk-pixbuf = "0.9"
+async-channel = "1.6"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 webview2 = "0.1.0-beta.1"


### PR DESCRIPTION
Resolves #132 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This change spawns an async event loop on GTK's main thread to process incoming messages from the backend instead of using the same loop that calls `gtk::main_iteration()`. This allows messages to be processed quickly even when the user isn't interacting with the app because messages won't be impeded while waiting for `gtk::main_iteration()` to complete.