### PR TITLE
Load html

### DIFF
--- a/src/application/attributes.rs
+++ b/src/application/attributes.rs
@@ -203,6 +203,12 @@ pub struct Attributes {
   ///
   /// The default is `None`.
   pub user_data_path: Option<PathBuf>,
+
+  /// A HTML String can be rendered with the webview window.
+  /// Use either this or load from a URL.
+  ///
+  /// The default is `None`.
+  pub html: Option<String>,
 }
 
 impl Attributes {
@@ -233,6 +239,7 @@ impl Attributes {
         url: self.url,
         initialization_scripts: self.initialization_scripts,
         user_data_path: self.user_data_path,
+        html: self.html,
       },
     )
   }
@@ -263,6 +270,7 @@ impl Default for Attributes {
       url: None,
       initialization_scripts: vec![],
       user_data_path: None,
+      html: None,
     }
   }
 }
@@ -293,4 +301,5 @@ pub(crate) struct InnerWebViewAttributes {
   pub url: Option<String>,
   pub initialization_scripts: Vec<String>,
   pub user_data_path: Option<PathBuf>,
+  pub html: Option<String>,
 }

--- a/src/application/general.rs
+++ b/src/application/general.rs
@@ -468,6 +468,11 @@ fn _create_webview(
     None => webview,
   };
 
+  webview = match attributes.html {
+    Some(html) => webview.load_html(html)?,
+    None => webview,
+  };
+
   let webview = webview.build()?;
   Ok(webview)
 }

--- a/src/application/gtkrs.rs
+++ b/src/application/gtkrs.rs
@@ -468,6 +468,11 @@ fn _create_webview(
     None => webview,
   };
 
+  webview = match attributes.html {
+    Some(html) => webview.load_html(html)?,
+    None => webview,
+  };
+
   for protocol in custom_protocols {
     webview = webview.register_protocol(protocol.name, protocol.handler);
   }

--- a/src/webview/linux/mod.rs
+++ b/src/webview/linux/mod.rs
@@ -36,6 +36,7 @@ impl InnerWebView {
     rpc_handler: Option<RpcHandler>,
     file_drop_handler: Option<FileDropHandler>,
     _user_data_path: Option<PathBuf>,
+    html: Option<String>
   ) -> Result<Self> {
     // Webview widget
     let manager = UserContentManager::new();
@@ -152,6 +153,10 @@ impl InnerWebView {
     // Navigation
     if let Some(url) = url {
       w.webview.load_uri(url.as_str());
+    }
+
+    if let Some(html) = html {
+      w.webview.load_html(html.as_str(), None);
     }
 
     Ok(w)

--- a/src/webview/linux/mod.rs
+++ b/src/webview/linux/mod.rs
@@ -36,7 +36,7 @@ impl InnerWebView {
     rpc_handler: Option<RpcHandler>,
     file_drop_handler: Option<FileDropHandler>,
     _user_data_path: Option<PathBuf>,
-    html: Option<String>
+    html: Option<String>,
   ) -> Result<Self> {
     // Webview widget
     let manager = UserContentManager::new();

--- a/src/webview/macos/mod.rs
+++ b/src/webview/macos/mod.rs
@@ -47,6 +47,7 @@ impl InnerWebView {
     rpc_handler: Option<RpcHandler>,
     file_drop_handler: Option<FileDropHandler>,
     _user_data_path: Option<PathBuf>,
+    html: Option<String>,
   ) -> Result<Self> {
     // Function for rpc handler
     extern "C" fn did_receive(this: &Object, _: Sel, _: id, msg: id) {
@@ -255,6 +256,10 @@ impl InnerWebView {
         } else {
           w.navigate(url.as_str());
         }
+      }
+
+      if let Some(html) = html {
+        w.navigate_to_string(html.as_str());
       }
 
       let view = window.ns_view() as id;

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -117,7 +117,7 @@ pub struct WebViewBuilder {
   rpc_handler: Option<RpcHandler>,
   file_drop_handler: Option<FileDropHandler>,
   user_data_path: Option<PathBuf>,
-  html: Option<String>
+  html: Option<String>,
 }
 
 impl WebViewBuilder {
@@ -256,7 +256,7 @@ impl WebViewBuilder {
   pub fn load_html(mut self, html: String) -> Result<Self> {
     self.html = Some(html);
     Ok(self)
-  } 
+  }
 
   /// Consume the builder and create the [`WebView`].
   pub fn build(self) -> Result<WebView> {

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -117,6 +117,7 @@ pub struct WebViewBuilder {
   rpc_handler: Option<RpcHandler>,
   file_drop_handler: Option<FileDropHandler>,
   user_data_path: Option<PathBuf>,
+  html: Option<String>
 }
 
 impl WebViewBuilder {
@@ -142,6 +143,7 @@ impl WebViewBuilder {
       rpc_handler: None,
       file_drop_handler: None,
       user_data_path: None,
+      html: None,
     })
   }
 
@@ -250,6 +252,12 @@ impl WebViewBuilder {
     Ok(self)
   }
 
+  /// Load a HTML String without any sanity checks.
+  pub fn load_html(mut self, html: String) -> Result<Self> {
+    self.html = Some(html);
+    Ok(self)
+  } 
+
   /// Consume the builder and create the [`WebView`].
   pub fn build(self) -> Result<WebView> {
     let webview = InnerWebView::new(
@@ -261,6 +269,7 @@ impl WebViewBuilder {
       self.rpc_handler,
       self.file_drop_handler,
       self.user_data_path,
+      self.html,
     )?;
     Ok(WebView {
       window: self.window,
@@ -305,6 +314,7 @@ impl WebView {
       None,
       transparent,
       picky_vec,
+      None,
       None,
       None,
       None,

--- a/src/webview/win32/mod.rs
+++ b/src/webview/win32/mod.rs
@@ -37,6 +37,7 @@ impl InnerWebView {
     rpc_handler: Option<RpcHandler>,
     file_drop_handler: Option<FileDropHandler>,
     user_data_path: Option<PathBuf>,
+    html: Option<String>,
   ) -> Result<Self> {
     let hwnd = window.hwnd() as HWND;
 
@@ -177,6 +178,10 @@ impl InnerWebView {
             }
             w.navigate(&url_string)?;
           }
+        }
+
+        if let Some(html) = html {
+          w.navigate_to_string(html.as_str())?;
         }
 
         controller.put_is_visible(true)?;

--- a/src/webview/winrt/mod.rs
+++ b/src/webview/winrt/mod.rs
@@ -57,6 +57,7 @@ impl InnerWebView {
     rpc_handler: Option<RpcHandler>,
     file_drop_handler: Option<FileDropHandler>,
     user_data_path: Option<PathBuf>,
+    html: Option<String>,
   ) -> Result<Self> {
     let hwnd = HWND(window.hwnd() as _);
 
@@ -210,6 +211,10 @@ impl InnerWebView {
         }
         w.Navigate(url_string.as_str())?;
       }
+    }
+
+    if let Some(html) = html {
+      w.navigate_to_string(html.as_str())?;
     }
 
     controller.SetIsVisible(true)?;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

For standalone self-contained apps, that use html for the GUI it might be desirable to integrate the HTML into the binary. 

This is currently possible like so:
```rust
let window = app.add_window(Attributes{
        title: String::from("Hello Self-Contained"),
        url: Some(["data:text/html,", include_str!("../dist/index.html")].join("")),
        ..Default::default()
})?;
```

However there are multiple problems with this approach, the main one beeing, that URLs can only be of a [certain length](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers) and therefore this does not work for big files. Also the URL is checked, which is taking some time for larger strings.

This PR introduces an option to pass a `html` string like so:
```rust
let window = app.add_window(Attributes{
        title: String::from("Hello Self-Contained"),
        html: Some(include_str!("../dist/index.html").to_string()),
        ..Default::default()
})?;
```

**Other information:**

- The main open point is how this should behave, if `html` and `url` are set. Currently `html` would overwrite the `url` option. Specifying both just does not make sense to me.
- Maybe there should also be a `load_html(html: &str)` function somewhere, I am just not familiar enough with the API, so a hint, as to where this should be added would be appreciated

Apart from that I think it would be better to use a `&str` to remove the overhead, but I did not manage to use that in an `Option<>`.

I implemented this for myself first, but decided it might be worth to open a PR, to discuss this and maybe get some feedback.