### PR TITLE
bug(macOS): Runtime panic when no file_drop_handler

### DIFF
--- a/.changes/macos-filedrop.md
+++ b/.changes/macos-filedrop.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Fix runtime panic on macOS, when no file handler are defined.

--- a/src/webview/macos/mod.rs
+++ b/src/webview/macos/mod.rs
@@ -199,9 +199,12 @@ impl InnerWebView {
       }
 
       // File drop handling
-      if let Some(file_drop_handler) = file_drop_handler {
-        set_file_drop_handler(webview, file_drop_handler)
-      };
+      match file_drop_handler {
+        // if we have a file_drop_handler defined, use the defined handler
+        Some(file_drop_handler) => set_file_drop_handler(webview, file_drop_handler),
+        // prevent panic by using a blank handler
+        None => set_file_drop_handler(webview, Box::new(|_event| false)),
+      }
 
       let w = Self {
         webview: Id::from_ptr(webview),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).


**Other information:**

Fix #176 