### PR TITLE
fix(custom-protocol): Make sure custom protocol on Windows is over HTTPS

### DIFF
--- a/.changes/windows-ssl-custom-protocol.md
+++ b/.changes/windows-ssl-custom-protocol.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Make sure custom protocol on Windows is over HTTPS.

--- a/src/webview/win32/mod.rs
+++ b/src/webview/win32/mod.rs
@@ -117,7 +117,7 @@ impl InnerWebView {
           // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
           custom_protocol_names.insert(name.clone());
           w.add_web_resource_requested_filter(
-            &format!("http://custom-protocol-{}*", name),
+            &format!("https://custom-protocol-{}*", name),
             webview2::WebResourceContext::All,
           )?;
           let env_clone = env_.clone();
@@ -125,7 +125,7 @@ impl InnerWebView {
             let uri = args.get_request()?.get_uri()?;
             // Undo the protocol workaround when giving path to resolver
             let path = &uri.replace(
-              &format!("http://custom-protocol-{}", name),
+              &format!("https://custom-protocol-{}", name),
               &format!("{}://", name),
             );
 
@@ -175,7 +175,7 @@ impl InnerWebView {
               // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
               url_string = url.as_str().replace(
                 &format!("{}://", name),
-                &format!("http://custom-protocol-{}", name),
+                &format!("https://custom-protocol-{}", name),
               )
             }
             w.navigate(&url_string)?;

--- a/src/webview/winrt/mod.rs
+++ b/src/webview/winrt/mod.rs
@@ -141,7 +141,7 @@ impl InnerWebView {
       // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
       custom_protocol_names.insert(name.clone());
       w.AddWebResourceRequestedFilter(
-        format!("http://custom-protocol-{}*", name).as_str(),
+        format!("https://custom-protocol-{}*", name).as_str(),
         webview2::CoreWebView2WebResourceContext::All,
       )?;
       let env_ = env.clone();
@@ -154,7 +154,7 @@ impl InnerWebView {
           if let Ok(uri) = String::from_utf16(args.Request()?.Uri()?.as_wide()) {
             // Undo the protocol workaround when giving path to resolver
             let path = uri.replace(
-              &format!("http://custom-protocol-{}", name),
+              &format!("https://custom-protocol-{}", name),
               &format!("{}://", name),
             );
 
@@ -208,7 +208,7 @@ impl InnerWebView {
           // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
           url_string = url.as_str().replace(
             &format!("{}://", name),
-            &format!("http://custom-protocol-{}", name),
+            &format!("https://custom-protocol-{}", name),
           )
         }
         w.Navigate(url_string.as_str())?;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

**Other information:**
I thought we’ll get an SSL error but after my tests, I figured out we should use HTTPS instead of HTTP.

![Screen Shot 2021-04-20 at 3 31 36 PM](https://user-images.githubusercontent.com/22237916/115453500-b7ecc280-a1ed-11eb-8265-253e4fd35a3e.png)

