### PR TITLE
feat: allow resizing of borderless gtk windows

### DIFF
--- a/src/application/window.rs
+++ b/src/application/window.rs
@@ -422,6 +422,8 @@ impl Window {
           if let Some(gdk_window) = window.get_window() {
             let (cx, cy) = event.get_root();
             let result = hit_test(&gdk_window, cx, cy);
+
+            // this check is necessary, otherwise the window won't recieve the click properly when resize isn't needed
             if result != WindowEdge::__Unknown(8) {
               window.begin_resize_drag(result, 1, cx as i32, cy as i32, event.get_time());
             }

--- a/src/application/window.rs
+++ b/src/application/window.rs
@@ -784,6 +784,7 @@ pub(crate) fn hit_test(window: &gdk::Window, cx: f64, cy: f64) -> WindowEdge {
     _ => WindowEdge::__Unknown(8),
   };
 
+  // FIXME: calling `window.begin_resize_drag` seems to revert the cursor back to normal style
   window.set_cursor(Some(&Cursor::new_for_display(
     &display,
     match edge {

--- a/src/webview/linux/mod.rs
+++ b/src/webview/linux/mod.rs
@@ -74,6 +74,8 @@ impl InnerWebView {
         let (cx, cy) = event.get_root();
         if let Some(window) = webview.get_parent_window() {
           let result = crate::application::window::hit_test(&window, cx, cy);
+
+          // this check is necessary, otherwise the webview won't recieve the click properly when resize isn't needed
           if result != WindowEdge::__Unknown(8) {
             window.begin_resize_drag(result, 1, cx as i32, cy as i32, event.get_time());
           }

--- a/src/webview/linux/mod.rs
+++ b/src/webview/linux/mod.rs
@@ -73,12 +73,7 @@ impl InnerWebView {
       if event.get_button() == 1 {
         let (cx, cy) = event.get_root();
         if let Some(window) = webview.get_parent_window() {
-          let (left, top) = window.get_position();
-          let (w, h) = (window.get_width(), window.get_height());
-          let (right, bottom) = (left + w, top + h);
-
-          let result =
-            crate::application::window::hit_test(left, top, right, bottom, cx as i32, cy as i32);
+          let result = crate::application::window::hit_test(&window, cx, cy);
           if result != WindowEdge::__Unknown(8) {
             window.begin_resize_drag(result, 1, cx as i32, cy as i32, event.get_time());
           }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

it works fine excepts two things:
1. when the left mouse button is pressed, we call `begin_resize_drag` but that seems to stop the `notify-motion` signal from firing and the cursor style reverts back to normal. it could be that something wrong on my system (using a custom DE setup), so someone test and confirm please.


2. <s>when the webview is attached, the mouse click isn't passed through to the window widget, so the resize won't work. A possible solution is to detect the click on the webview dom and use the rpc handler to call `begin_resize_drag`.</s>. Fixed by attaching `button_press` event on the webview widget.