### PR TITLE
refactor: code style in window getters

### DIFF
--- a/src/application/window.rs
+++ b/src/application/window.rs
@@ -499,7 +499,6 @@ impl Window {
 
     window.connect_window_state_event(move |_window, event| {
       let state = event.get_new_window_state();
-      println!("{:?}", state.contains(WindowState::MAXIMIZED));
       max_clone.store(state.contains(WindowState::MAXIMIZED), Ordering::Release);
 
       Inhibit(false)
@@ -536,7 +535,7 @@ impl Window {
   }
 
   pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-    let (x, y) = (&self.position.0, &self.position.1);
+    let (x, y) = &*self.position;
     Ok(PhysicalPosition::new(
       x.load(Ordering::Acquire),
       y.load(Ordering::Acquire),
@@ -544,7 +543,7 @@ impl Window {
   }
 
   pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-    let (x, y) = (&self.position.0, &self.position.1);
+    let (x, y) = &*self.position;
     Ok(PhysicalPosition::new(
       x.load(Ordering::Acquire),
       y.load(Ordering::Acquire),
@@ -566,7 +565,7 @@ impl Window {
   }
 
   pub fn inner_size(&self) -> PhysicalSize<u32> {
-    let (width, height) = (&self.size.0, &self.size.1);
+    let (width, height) = &*self.size;
 
     PhysicalSize::new(
       width.load(Ordering::Acquire) as u32,
@@ -586,7 +585,7 @@ impl Window {
   }
 
   pub fn outer_size(&self) -> PhysicalSize<u32> {
-    let (width, height) = (&self.size.0, &self.size.1);
+    let (width, height) = &*self.size;
 
     PhysicalSize::new(
       width.load(Ordering::Acquire) as u32,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
