### PR TITLE
fix(macOS): Window layers

### DIFF
--- a/.changes/macos-layers.md
+++ b/.changes/macos-layers.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix `macOS` cursors and other minors UI glitch.

--- a/src/webview/macos/mod.rs
+++ b/src/webview/macos/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 use cocoa::{
   appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable},
-  base::id,
+  base::{id, YES},
 };
 use core_graphics::geometry::{CGPoint, CGRect, CGSize};
 use objc::{
@@ -191,9 +191,8 @@ impl InnerWebView {
       }
 
       // Resize
-      let size = window.inner_size().to_logical(window.scale_factor());
-      let rect = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(size.width, size.height));
-      let _: () = msg_send![webview, initWithFrame:rect configuration:config];
+      let zero = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(0., 0.));
+      let _: () = msg_send![webview, initWithFrame:zero configuration:config];
       webview.setAutoresizingMask_(NSViewHeightSizable | NSViewWidthSizable);
 
       // Message handler
@@ -230,6 +229,9 @@ impl InnerWebView {
         // prevent panic by using a blank handler
         None => set_file_drop_handler(webview, window.clone(), Box::new(|_, _| false)),
       };
+
+      // use layer
+      let _: () = msg_send![webview, setWantsLayer: YES];
 
       let w = Self {
         webview: Id::from_ptr(webview),
@@ -289,8 +291,8 @@ impl InnerWebView {
         }
       }
 
-      let view = window.ns_view() as id;
-      view.addSubview_(webview);
+      let ns_windows = window.ns_window() as id;
+      let _: () = msg_send![ns_windows, setContentView: webview];
 
       Ok(w)
     }

--- a/src/webview/macos/mod.rs
+++ b/src/webview/macos/mod.rs
@@ -230,9 +230,6 @@ impl InnerWebView {
         None => set_file_drop_handler(webview, window.clone(), Box::new(|_, _| false)),
       };
 
-      // use layer
-      let _: () = msg_send![webview, setWantsLayer: YES];
-
       let w = Self {
         webview: Id::from_ptr(webview),
         manager,
@@ -290,9 +287,11 @@ impl InnerWebView {
           w.navigate(url.as_str());
         }
       }
-
-      let ns_windows = window.ns_window() as id;
-      let _: () = msg_send![ns_windows, setContentView: webview];
+      // Tell the webview we use layers
+      let _: () = msg_send![webview, setWantsLayer:YES];
+      // Inject the web view into the window as main content
+      let ns_window = window.ns_window() as id;
+      let _: () = msg_send![ns_window, setContentView:webview];
 
       Ok(w)
     }

--- a/src/webview/macos/mod.rs
+++ b/src/webview/macos/mod.rs
@@ -288,10 +288,10 @@ impl InnerWebView {
         }
       }
       // Tell the webview we use layers
-      let _: () = msg_send![webview, setWantsLayer:YES];
+      let _: () = msg_send![webview, setWantsLayer: YES];
       // Inject the web view into the window as main content
       let ns_window = window.ns_window() as id;
-      let _: () = msg_send![ns_window, setContentView:webview];
+      let _: () = msg_send![ns_window, setContentView: webview];
 
       Ok(w)
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

**Other information:**
Fix #175 
Related to #184

Instead of injecting the webview as a subview into the winit created view, we inject the wen view into the window directly.
This removes an unused layer.

Also, the webview is now created with a `CGRect` set to 0 and the macOS layer takes care to auto-resize the webview correctly.

https://user-images.githubusercontent.com/22237916/116466107-18a67b80-a83c-11eb-9cf1-ae4497d78170.mov


 
