### PR TITLE
(additional examples) - set icon, use fixed webview runtime

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,6 @@
 
 Run the `cargo run --example <file_name>` to see how each example works.
 
-- `webview_fixed`: a basic example which sets a temporary environment variable to use the fixed version of the webview runtime.
-- `icon`: a basic example demonstrating how to set an icon for the application.
 - `hello_world`: the basic example to show the types and methods to create an application.
 - `fullscreen`: full screen example demonstrates how to configure the window with attributes.
 - `transparent`: transparent example that also show how to create a valid data URI.
@@ -14,3 +12,5 @@ Run the `cargo run --example <file_name>` to see how each example works.
 - `custom_data_directory`: uses a custom data directory (Windows and Linux only).
 - `custom_protocol`: uses a custom protocol to load files from bytes.
 - `detect_js_ecma`: detects which versions of ECMAScript is supported by the webview.
+- `webview_fixed`: a basic example which sets a temporary environment variable to use the fixed version of the webview runtime.
+- `icon`: a basic example demonstrating how to set an icon for the application.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 Run the `cargo run --example <file_name>` to see how each example works.
 
-- `webview_fixed`: a basic example which set a temporary environment variable to use the fixed version of the webview runtime.
+- `webview_fixed`: a basic example which sets a temporary environment variable to use the fixed version of the webview runtime.
 - `icon`: a basic example demonstrating how to set an icon for the application.
 - `hello_world`: the basic example to show the types and methods to create an application.
 - `fullscreen`: full screen example demonstrates how to configure the window with attributes.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,8 @@
 
 Run the `cargo run --example <file_name>` to see how each example works.
 
+- `webview_fixed`: a basic example which set a temporary environment variable to use the fixed version of the webview runtime.
+- `icon`: a basic example demonstrating how to set an icon for the application.
 - `hello_world`: the basic example to show the types and methods to create an application.
 - `fullscreen`: full screen example demonstrates how to configure the window with attributes.
 - `transparent`: transparent example that also show how to create a valid data URI.

--- a/examples/icon.rs
+++ b/examples/icon.rs
@@ -1,0 +1,44 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+fn main() -> wry::Result<()> {
+    use wry::{
+      application::{
+        event::{Event, StartCause, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::WindowBuilder,
+      },
+      webview::WebViewBuilder,
+    };
+    use ico::*;
+
+    // use a window icon
+    let file = std::fs::File::open("<specify_the_icon_here>").unwrap();
+    let icon_dir = ico::IconDir::read(file).unwrap();
+    let image = icon_dir.entries()[0].decode().unwrap();
+    let rgba = image.rgba_data();
+    let icon = WindowIcon::from_rgba(rgba.to_vec(), 256, 256)?;
+  
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new()
+      .with_title("Hello World")
+      .with_window_icon(Some(icon))
+      .build(&event_loop)?;
+    let _webview = WebViewBuilder::new(window)?
+      .with_url("https://tauri.studio")?
+      .build()?;
+  
+    event_loop.run(move |event, _, control_flow| {
+      *control_flow = ControlFlow::Poll;
+  
+      match event {
+        Event::NewEvents(StartCause::Init) => println!("Wry has started!"),
+        Event::WindowEvent {
+          event: WindowEvent::CloseRequested,
+          ..
+        } => *control_flow = ControlFlow::Exit,
+        _ => (),
+      }
+    });
+  }

--- a/examples/webview_fixed.rs
+++ b/examples/webview_fixed.rs
@@ -1,0 +1,43 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+fn main() -> wry::Result<()> {
+    use wry::{
+      application::{
+        event::{Event, StartCause, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::WindowBuilder,
+      },
+      webview::WebViewBuilder,
+    };
+    use std::env;
+
+    // env::set_var creates a temporary environment variable while to application is opened
+    // set here the path to the unzipped .cab file, which contains the fixed version of the webview runtime
+    env::set_var(
+        "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER",
+        "<path_to_your_webview_director>",
+    );
+  
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new()
+      .with_title("Hello World")
+      .build(&event_loop)?;
+    let _webview = WebViewBuilder::new(window)?
+      .with_url("https://tauri.studio")?
+      .build()?;
+  
+    event_loop.run(move |event, _, control_flow| {
+      *control_flow = ControlFlow::Poll;
+  
+      match event {
+        Event::NewEvents(StartCause::Init) => println!("Wry has started!"),
+        Event::WindowEvent {
+          event: WindowEvent::CloseRequested,
+          ..
+        } => *control_flow = ControlFlow::Exit,
+        _ => (),
+      }
+    });
+  }


### PR DESCRIPTION
I made two little examples, since it took me some time to figure these things out - maybe they´re helpful for others. 

- how to set an icon for a wry application
- how to use the fixed version of the webview runtime, when you can´t install it due to missing admin rights (windows).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
