### PR TITLE
Add `with_web_context` method

### DIFF
--- a/.changes/builder.md
+++ b/.changes/builder.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add `with_web_context` method that can work well with builder pattern.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = [ "gui" ]
 
 [package.metadata.docs.rs]
 features = [ "dox" ]
-rustdoc-args = [ "--cfg", "doc_cfg" ]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
   "x86_64-pc-windows-msvc",

--- a/examples/custom_data_directory.rs
+++ b/examples/custom_data_directory.rs
@@ -32,7 +32,8 @@ fn main() -> wry::Result<()> {
   let _webview = WebViewBuilder::new(window)
     .unwrap()
     .with_url("https://tauri.studio")?
-    .build(&web_context)?;
+    .with_web_context(&web_context)
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -74,7 +74,7 @@ fn main() -> wry::Result<()> {
     })
     // tell the webview to load the custom protocol
     .with_url("wry.dev://")?
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/custom_titlebar.rs
+++ b/examples/custom_titlebar.rs
@@ -119,7 +119,7 @@ fn main() -> wry::Result<()> {
     .with_url(url)?
     .with_initialization_script(script)
     .with_rpc_handler(handler)
-    .build(&Default::default())?;
+    .build()?;
   webviews.insert(webview.window().id(), webview);
 
   event_loop.run(move |event, _, control_flow| {

--- a/examples/detect_js_ecma.rs
+++ b/examples/detect_js_ecma.rs
@@ -128,7 +128,7 @@ fn main() -> wry::Result<()> {
     </html>
     "#,
     )?
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/dragndrop.rs
+++ b/examples/dragndrop.rs
@@ -27,7 +27,7 @@ fn main() -> wry::Result<()> {
       println!("Window 1: {:?}", data);
       false // Returning true will block the OS default behaviour.
     })
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -21,7 +21,7 @@ fn main() -> wry::Result<()> {
   let webview = WebViewBuilder::new(window)
     .unwrap()
     .with_url("https://www.wirple.com/")?
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -18,7 +18,7 @@ fn main() -> wry::Result<()> {
     .build(&event_loop)?;
   let _webview = WebViewBuilder::new(window)?
     .with_url("https://tauri.studio")?
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/html_test.rs
+++ b/examples/html_test.rs
@@ -18,7 +18,7 @@ fn main() -> wry::Result<()> {
     .build(&event_loop)?;
   let _webview = WebViewBuilder::new(window)?
     .with_url("https://html5test.com")?
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/menu_bar.rs
+++ b/examples/menu_bar.rs
@@ -93,7 +93,7 @@ fn main() -> wry::Result<()> {
   // Build the webview
   let webview = WebViewBuilder::new(window)?
     .with_url("https://tauri.studio")?
-    .build(&Default::default())?;
+    .build()?;
   // launch WRY process
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -51,7 +51,8 @@ fn main() -> wry::Result<()> {
             }"#,
     )
     .with_rpc_handler(handler)
-    .build(&web_context)?;
+    .with_web_context(&web_context)
+    .build()?;
   let mut webviews = HashMap::new();
   webviews.insert(id, webview1);
 
@@ -72,7 +73,8 @@ fn main() -> wry::Result<()> {
         .unwrap()
         .with_url(&url)
         .unwrap()
-        .build(&web_context)
+        .with_web_context(&web_context)
+        .build()
         .unwrap();
       webviews.insert(id, webview2);
     } else if trigger && instant.elapsed() >= eight_secs {

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -80,7 +80,7 @@ async function getAsyncRpcResult() {
     .unwrap()
     .with_url(url)?
     .with_rpc_handler(handler)
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -66,7 +66,7 @@ fn main() -> wry::Result<()> {
             .unwrap()
             .with_url("https://tauri.studio")
             .unwrap()
-            .build(&Default::default())
+            .build()
             .unwrap();
           webviews.insert(id, webview);
         }

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -37,7 +37,7 @@ fn main() -> wry::Result<()> {
               </script>
             </html>"#,
     )?
-    .build(&Default::default())?;
+    .build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/validate_webview.rs
+++ b/examples/validate_webview.rs
@@ -26,7 +26,7 @@ fn main() -> wry::Result<()> {
         .build(&event_loop)?;
       let _webview = WebViewBuilder::new(window)?
         .with_url("https://tauri.studio")?
-        .build(&Default::default())?;
+        .build()?;
 
       event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!     .build(&event_loop)?;
 //!   let _webview = WebViewBuilder::new(window)?
 //!     .with_url("https://tauri.studio")?
-//!     .build(&Default::default())?;
+//!     .build()?;
 //!
 //!   event_loop.run(move |event, _, control_flow| {
 //!     *control_flow = ControlFlow::Wait;
@@ -77,7 +77,6 @@
 //! [`with_file_drop_handler`]: crate::webview::WebView::with_file_drop_handler
 //! [`with_custom_protocol`]: crate::webview::WebView::with_custom_protocol
 
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::type_complexity)]

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -193,7 +193,7 @@ impl<'a> WebViewBuilder<'a> {
   pub fn with_url(mut self, url: &str) -> Result<Self> {
     self.webview.url = Some(Url::parse(url)?);
     Ok(self)
-  } 
+  }
 
   /// Set the web context that can share with multiple [`WebView`]s.
   pub fn with_web_context(mut self, web_context: &'a WebContext) -> Self {

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -77,9 +77,6 @@ pub struct WebViewAttributes {
   pub file_drop_handler: Option<Box<dyn Fn(&Window, FileDropEvent) -> bool>>,
   #[cfg(not(feature = "file-drop"))]
   file_drop_handler: Option<Box<dyn Fn(&Window, FileDropEvent) -> bool>>,
-  /// Whether the WebView window should have a custom user data path. This is useful in Windows
-  /// when a bundled application can't have the webview data inside `Program Files`.
-  pub data_directory: Option<PathBuf>,
 }
 
 impl Default for WebViewAttributes {
@@ -92,7 +89,6 @@ impl Default for WebViewAttributes {
       custom_protocols: vec![],
       rpc_handler: None,
       file_drop_handler: None,
-      data_directory: None,
     }
   }
 }
@@ -102,17 +98,23 @@ impl Default for WebViewAttributes {
 /// [`WebViewBuilder`] / [`WebView`] are the basic building blocks to constrcut WebView contents and
 /// scripts for those who prefer to control fine grained window creation and event handling.
 /// [`WebViewBuilder`] privides ability to setup initialization before web engine starts.
-pub struct WebViewBuilder {
+pub struct WebViewBuilder<'a> {
   pub webview: WebViewAttributes,
+  web_context: Option<&'a WebContext>,
   window: Window,
 }
 
-impl WebViewBuilder {
+impl<'a> WebViewBuilder<'a> {
   /// Create [`WebViewBuilder`] from provided [`Window`].
   pub fn new(window: Window) -> Result<Self> {
     let webview = WebViewAttributes::default();
+    let web_context = None;
 
-    Ok(Self { webview, window })
+    Ok(Self {
+      webview,
+      web_context,
+      window,
+    })
   }
 
   /// Sets whether the WebView should be transparent.
@@ -193,6 +195,11 @@ impl WebViewBuilder {
     Ok(self)
   }
 
+  pub fn with_web_context(mut self, web_context: &'a WebContext) -> Self {
+    self.web_context = Some(web_context);
+    self
+  }
+
   /// Consume the builder and create the [`WebView`].
   ///
   /// Platform-specific behavior:
@@ -201,7 +208,7 @@ impl WebViewBuilder {
   /// called in the same thread with the [`EventLoop`] you create.
   ///
   /// [`EventLoop`]: crate::application::event_loop::EventLoop
-  pub fn build(mut self, web_context: &WebContext) -> Result<WebView> {
+  pub fn build(mut self) -> Result<WebView> {
     if self.webview.rpc_handler.is_some() {
       let js = r#"
             (function() {
@@ -256,7 +263,7 @@ impl WebViewBuilder {
       self.webview.initialization_scripts.push(js.to_string());
     }
     let window = Rc::new(self.window);
-    let webview = InnerWebView::new(window.clone(), self.webview, web_context)?;
+    let webview = InnerWebView::new(window.clone(), self.webview, self.web_context)?;
     Ok(WebView { window, webview })
   }
 }
@@ -301,8 +308,8 @@ impl WebView {
   /// called in the same thread with the [`EventLoop`] you create.
   ///
   /// [`EventLoop`]: crate::application::event_loop::EventLoop
-  pub fn new(window: Window, web_context: &WebContext) -> Result<Self> {
-    WebViewBuilder::new(window)?.build(web_context)
+  pub fn new(window: Window) -> Result<Self> {
+    WebViewBuilder::new(window)?.build()
   }
 
   /// Get the [`Window`] associate with the [`WebView`]. This can let you perform window related

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -193,8 +193,9 @@ impl<'a> WebViewBuilder<'a> {
   pub fn with_url(mut self, url: &str) -> Result<Self> {
     self.webview.url = Some(Url::parse(url)?);
     Ok(self)
-  }
+  } 
 
+  /// Set the web context that can share with multiple [`WebView`]s.
   pub fn with_web_context(mut self, web_context: &'a WebContext) -> Self {
     self.web_context = Some(web_context);
     self

--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 /// [`WebView`]: crate::webview::WebView
 pub struct WebContext {
   data: WebContextData,
-  #[allow(dead_code)]
+  #[allow(dead_code)] // It's no need on Windows and macOS.
   os: WebContextImpl,
 }
 

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -37,13 +37,21 @@ impl InnerWebView {
   pub fn new(
     window: Rc<Window>,
     mut attributes: WebViewAttributes,
-    web_context: &WebContext,
+    web_context: Option<&WebContext>,
   ) -> Result<Self> {
     let window_rc = Rc::clone(&window);
     let window = &window.gtk_window();
     // Webview widget
     let manager = UserContentManager::new();
 
+    let default_context;
+    let web_context = match web_context {
+      Some(w) => w,
+      None => {
+        default_context = Default::default();
+        &default_context
+      }
+    };
     let context = web_context.context();
     let mut webview = WebViewBuilder::new();
     webview = webview.web_context(context);

--- a/src/webview/webview2/win32/mod.rs
+++ b/src/webview/webview2/win32/mod.rs
@@ -39,7 +39,7 @@ impl InnerWebView {
   pub fn new(
     window: Rc<Window>,
     mut attributes: WebViewAttributes,
-    web_context: &WebContext,
+    web_context: Option<&WebContext>,
   ) -> Result<Self> {
     let hwnd = window.hwnd() as HWND;
 
@@ -51,8 +51,10 @@ impl InnerWebView {
 
     let mut webview_builder = webview2::EnvironmentBuilder::new();
 
-    if let Some(data_directory) = web_context.data_directory() {
-      webview_builder = webview_builder.with_user_data_folder(&data_directory);
+    if let Some(web_context) = web_context {
+      if let Some(data_directory) = web_context.data_directory() {
+        webview_builder = webview_builder.with_user_data_folder(&data_directory);
+      }
     }
 
     // Webview controller

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -62,7 +62,7 @@ impl InnerWebView {
   pub fn new(
     window: Rc<Window>,
     attributes: WebViewAttributes,
-    _web_context: &WebContext,
+    _web_context: Option<&WebContext>,
   ) -> Result<Self> {
     // Function for rpc handler
     extern "C" fn did_receive(this: &Object, _: Sel, _: id, msg: id) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This method keep the `&WebContext` signature and can work well with the builder pattern.
User don't need to specify default context if they don't need it in this way.