### PR TITLE
move set_allows_automation to WebContext method

### DIFF
--- a/.changes/web-context-set-allows-automation.md
+++ b/.changes/web-context-set-allows-automation.md
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+`WebContext::set_allows_automation` is now available to specify if the context should allow automation (e.g. WebDriver).
+It is only enforced on Linux, but may expand platforms in the future.

--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -34,7 +34,7 @@ impl WebContext {
   /// **Note:** This is currently only enforced on Linux, and has the stipulation that
   /// only 1 context allows automation at a time.
   pub fn set_allows_automation(&mut self, flag: bool) {
-      self.os.set_allows_automation(flag);
+    self.os.set_allows_automation(flag);
   }
 }
 
@@ -141,8 +141,8 @@ pub mod unix {
     }
 
     pub fn set_allows_automation(&mut self, flag: bool) {
-        self.automation = flag;
-        self.context.set_automation_allowed(flag);
+      self.automation = flag;
+      self.context.set_automation_allowed(flag);
     }
   }
 

--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -28,6 +28,14 @@ impl WebContext {
   pub fn data_directory(&self) -> Option<&Path> {
     self.data.data_directory()
   }
+
+  /// Set if this context allows automation.
+  ///
+  /// **Note:** This is currently only enforced on Linux, and has the stipulation that
+  /// only 1 context allows automation at a time.
+  pub fn set_allows_automation(&mut self, flag: bool) {
+      self.os.set_allows_automation(flag);
+  }
 }
 
 impl Default for WebContext {
@@ -59,6 +67,8 @@ impl WebContextImpl {
   fn new(_data: &WebContextData) -> Self {
     Self
   }
+
+  fn set_allows_automation(&mut self, _flag: bool) {}
 }
 
 #[cfg(target_os = "linux")]
@@ -129,6 +139,11 @@ pub mod unix {
         automation,
       }
     }
+
+    pub fn set_allows_automation(&mut self, flag: bool) {
+        self.automation = flag;
+        self.context.set_automation_allowed(flag);
+    }
   }
 
   /// [`WebContext`](super::WebContext) items that only matter on unix.
@@ -143,11 +158,6 @@ pub mod unix {
     ///
     /// **Note:** `libwebkit2gtk` only allows 1 automation context at a time.
     fn allows_automation(&self) -> bool;
-
-    /// Set if this context allows automation.
-    ///
-    /// **Note:** `libwebkit2gtk` only allows 1 automation context at a time.
-    fn set_allows_automation(&mut self, flag: bool);
   }
 
   impl WebContextExt for super::WebContext {
@@ -161,11 +171,6 @@ pub mod unix {
 
     fn allows_automation(&self) -> bool {
       self.os.automation
-    }
-
-    fn set_allows_automation(&mut self, flag: bool) {
-      self.os.automation = flag;
-      self.os.context.set_automation_allowed(flag);
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
 allows tauri-runtime-wry to set the automation mode when dealing with multiple data directories (so multiple WebContext)