### PR TITLE
feat(windows): force refresh on `webview.resize()`

### DIFF
--- a/.changes/webview-resize.md
+++ b/.changes/webview-resize.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Force webview to refresh on `Webview#resize` even if the window size did not change, allowing a fix to https://github.com/tauri-apps/tauri/issues/1911.

--- a/examples/custom_titlebar.rs
+++ b/examples/custom_titlebar.rs
@@ -139,7 +139,7 @@ fn main() -> wry::Result<()> {
             *control_flow = ControlFlow::Exit
           }
         }
-        WindowEvent::Resized(_) => {
+        WindowEvent::Resized(_) | WindowEvent::Moved(_) => {
           let _ = webviews[&window_id].resize();
         }
         _ => (),

--- a/src/webview/webview2/win32/mod.rs
+++ b/src/webview/webview2/win32/mod.rs
@@ -259,7 +259,7 @@ impl InnerWebView {
       if let Some(c) = self.controller.get() {
         rect.left = rect.left + 1;
         c.put_bounds(rect)?;
-         rect.left = rect.left - 1;
+        rect.left = rect.left - 1;
         c.put_bounds(rect)?;
       }
     }

--- a/src/webview/webview2/win32/mod.rs
+++ b/src/webview/webview2/win32/mod.rs
@@ -257,6 +257,9 @@ impl InnerWebView {
       let mut rect = std::mem::zeroed();
       GetClientRect(hwnd, &mut rect);
       if let Some(c) = self.controller.get() {
+        rect.left = rect.left + 1;
+        c.put_bounds(rect)?;
+         rect.left = rect.left - 1;
         c.put_bounds(rect)?;
       }
     }

--- a/src/webview/webview2/winrt/mod.rs
+++ b/src/webview/webview2/winrt/mod.rs
@@ -261,6 +261,12 @@ impl InnerWebView {
         c.SetBounds(Rect {
           X: 0f32,
           Y: 0f32,
+          Width: width + 1 as f32,
+          Height: height as f32,
+        })?;
+        c.SetBounds(Rect {
+          X: 0f32,
+          Y: 0f32,
           Width: width as f32,
           Height: height as f32,
         })?;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

See https://github.com/tauri-apps/tauri/issues/1911#issuecomment-871778931
Thanks to @nicholasdgoodman
