### PR TITLE
chore(linux): call window.destroy()

### DIFF
--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -285,10 +285,10 @@ pub struct WebView {
 impl Drop for WebView {
   fn drop(&mut self) {
     #[cfg(target_os = "linux")]
-    {
+    unsafe {
       use crate::application::platform::unix::WindowExtUnix;
-      use gtk::GtkWindowExt;
-      self.window.gtk_window().close();
+      use gtk::prelude::WidgetExtManual;
+      self.window().gtk_window().destroy();
     }
     #[cfg(target_os = "windows")]
     unsafe {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other, please describe: update to next tao

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is needed because of the fix applied on https://github.com/tauri-apps/tao/pull/114 (the CloseRequested event does not immediately destroys the window anymore, which is the behavior on macOS and Windows, so we need to force destroy on webview drop).