### PR TITLE
fix(macos): Remove keypress handler in the webview for copy/paste/cut

### DIFF
--- a/.changes/webview-paste.md
+++ b/.changes/webview-paste.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+macOS: Remove handler in the webview as it should be handled with the menu.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -267,35 +267,10 @@ impl InnerWebView {
       // Initialize scripts
       w.init(
         r#"window.external = {
-                    invoke: function(s) {
-                        window.webkit.messageHandlers.external.postMessage(s);
-                    },
-                };
-
-                window.addEventListener("keydown", function(e) {
-                    if (e.defaultPrevented) {
-                        return;
-                    }
-
-                   if (e.metaKey) {
-                        switch(e.key) {
-                            case "x":
-                                document.execCommand("cut");
-                                e.preventDefault();
-                                break;
-                            case "c":
-                                document.execCommand("copy");
-                                e.preventDefault();
-                                break;
-                            case "v":
-                                document.execCommand("paste");
-                                e.preventDefault();
-                                break;
-                            default:
-                                return;
-                        }
-                    }
-                }, true);"#,
+              invoke: function(s) {
+                window.webkit.messageHandlers.external.postMessage(s);
+              },
+            };"#,
       );
       for js in attributes.initialization_scripts {
         w.init(&js);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It should be handled by the menu. 
It prevents showing a popup when we do `cmd+v`
