### PR TITLE
Use A fake webview in the automation closure (webkit2gtk)

### DIFF
--- a/.changes/webdriver-auto-closure.md
+++ b/.changes/webdriver-auto-closure.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+(internal) webkit2gtk automation closures now return a fake webview instead of `unimplemented!()`

--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -172,7 +172,13 @@ pub mod unix {
           .expect("invalid wry version patch"),
       );
 
-      context.connect_automation_started(move |_, auto| {
+      context.connect_automation_started(move |ctx, auto| {
+        let webview = {
+          let mut webview = webkit2gtk::WebViewBuilder::new();
+          webview = webview.web_context(ctx);
+          webview = webview.is_controlled_by_automation(true);
+          webview.build()
+        };
         auto.set_application_info(&app_info);
 
         // We do **NOT** support arbitrarily creating new webviews.
@@ -180,7 +186,10 @@ pub mod unix {
         // default WindowBuilder to use to create the window it will use, and
         // possibly "default" webview attributes. Difficulty comes in for controlling
         // the owned Window that would need to be used.
-        auto.connect_create_web_view(None, move |_| unimplemented!());
+        //
+        // NOTE: We use a fake webview just created above to give back, although the testing
+        // suites that call it do not seem to use it.
+        auto.connect_create_web_view(None, move |_| webview.clone());
       });
 
       Self {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Some WebDriver testing frameworks seem to call this without using it. I'm assuming to suss out supported features of the underlying WebDriver server it is communicating with.