### PR TITLE
Fix async multiwindow deadlock

### DIFF
--- a/.changes/async-multiwindow.md
+++ b/.changes/async-multiwindow.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixed a Linux multi-window issue where the internal url loader didn't unlock when flushed while empty

--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -404,6 +404,8 @@ pub mod unix {
           });
 
           webview.load_uri(url.as_str());
+        } else {
+            self.unlock();
         }
       }
     }

--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -405,7 +405,7 @@ pub mod unix {
 
           webview.load_uri(url.as_str());
         } else {
-            self.unlock();
+          self.unlock();
         }
       }
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This is triggered only when the queue is flushed while being empty. Due to how the `mutli_window` example is constructed, the flushing can happen twice before the second webview is queued.