### PR TITLE
Use the first created webview for webkit2gtk automation callbacks

### DIFF
--- a/.changes/webcontext-first-webview.md
+++ b/.changes/webcontext-first-webview.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On Linux, automation callbacks now use the first created webview as the return value

--- a/.changes/webdriver-auto-closure.md
+++ b/.changes/webdriver-auto-closure.md
@@ -1,5 +1,0 @@
----
-"wry": patch
----
-
-(internal) webkit2gtk automation closures now return a fake webview instead of `unimplemented!()`

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -54,14 +54,15 @@ impl InnerWebView {
       }
     };
 
-    let manager = web_context.manager();
     let webview = {
       let mut webview = WebViewBuilder::new();
-      webview = webview.user_content_manager(manager);
+      webview = webview.user_content_manager(web_context.manager());
       webview = webview.web_context(web_context.context());
       webview = webview.is_controlled_by_automation(web_context.allows_automation());
       webview.build()
     };
+
+    web_context.register_automation(webview.clone());
 
     // Message handler
     let webview = Rc::new(webview);
@@ -75,6 +76,8 @@ impl InnerWebView {
       w.id().hash(&mut hasher);
       hasher.finish().to_string()
     };
+
+    let manager = web_context.manager();
 
     // Connect before registering as recommended by the docs
     manager.connect_script_message_received(None, move |_m, msg| {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This is the real fix for #379. A reference to the webview passed in the automation callback is the default webview (called window in WebDriver world) that gets attached when connected to the application from a WebDriver server. With the previous partial fix, you could find the actual window and switch to it, but this fix makes it that the first created webview is the default window that is attached to. This is the same behavior as before the WebContext changes in #359 which allowed multi-window to work with WebDriver.

I checked this with Selenium and WebdriverIO on Linux. Using https://github.com/chippers/hello_tauri. Recreate the steps by building `cargo b --release && cd webdriver && yarn && yarn workspaces run test`. That should build everything then run both the Selenium and WebdriverIO tests against the example application using this `wry` branch.

I also successfully tested single and multi-window WebDriver tests from my mini-scripts available at https://gist.github.com/chippers/db4305dac38e53399ee6775d6380b31a. `main.js` is for testing `detect_js_ecma` and `multi.js` is for `multi_window`. Note that you need to add something like
```rust
// enable automation on TAURI_AUTOMATION=true (set automatically by tauri-driver)
web_context.set_allows_automation(std::env::var("TAURI_AUTOMATION").as_deref() == Ok("true"));
```
to enable the automation on those two examples when testing them.

