### PR TITLE
In custom_titlebar example handle touchstart event to drag titlebar fix: #390

### DIFF
--- a/examples/custom_titlebar.rs
+++ b/examples/custom_titlebar.rs
@@ -56,6 +56,11 @@ fn main() -> wry::Result<()> {
             : window.rpc.notify('drag_window');
         }
       })
+      document.addEventListener('touchstart', (e) => {
+        if (e.target.classList.contains('drag-region')) {
+          window.rpc.notify('drag_window');
+        }
+      })
 
       const style = document.createElement('style');
       style.textContent = `


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X ] Other, please describe: missing functionality in example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes. Issue #___
- [X ] No


**The PR fulfills these requirements:**

- [ X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [NA ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

See issue #390. There is some awkward code duplication (compared to using a single handler), but using a single handler seems clumsier.

(I probably won't be using a custom titlebar for [the DomTerm project](https://domterm.org) because it doesn't handle window resizing or other features of the standard titlebar.  I might try to work with the Gtk.HeaderBar class, which provides more functionality, but that won't happen anytime soon.)
