### PR TITLE
feature: allow FnMut handlers instead of Fn

### DIFF
--- a/src/webview/wkwebview/file_drop.rs
+++ b/src/webview/wkwebview/file_drop.rs
@@ -56,8 +56,8 @@ static OBJC_DRAGGING_UPDATED: Lazy<extern "C" fn(*const Object, Sel, id) -> NSDr
 pub(crate) unsafe fn set_file_drop_handler(
   webview: *mut Object,
   window: Rc<Window>,
-  handler: Box<dyn Fn(&Window, FileDropEvent) -> bool>,
-) -> *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>) {
+  handler: Box<dyn FnMut(&Window, FileDropEvent) -> bool>,
+) -> *mut (Box<dyn FnMut(&Window, FileDropEvent) -> bool>, Rc<Window>) {
   let listener = Box::into_raw(Box::new((handler, window)));
   (*webview).set_ivar("FileDropHandler", listener as *mut _ as *mut c_void);
   listener

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -55,12 +55,12 @@ pub struct InnerWebView {
   // Note that if following functions signatures are changed in the future,
   // all fucntions pointer declarations in objc callbacks below all need to get updated.
   rpc_handler_ptr: *mut (
-    Box<dyn Fn(&Window, RpcRequest) -> Option<RpcResponse>>,
+    Box<dyn FnMut(&Window, RpcRequest) -> Option<RpcResponse>>,
     Rc<Window>,
   ),
   #[cfg(target_os = "macos")]
-  file_drop_ptr: *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>),
-  protocol_ptrs: Vec<*mut Box<dyn Fn(&HttpRequest) -> Result<HttpResponse>>>,
+  file_drop_ptr: *mut (Box<dyn FnMut(&Window, FileDropEvent) -> bool>, Rc<Window>),
+  protocol_ptrs: Vec<*mut Box<dyn FnMut(&HttpRequest) -> Result<HttpResponse>>>,
 }
 
 impl InnerWebView {
@@ -83,7 +83,7 @@ impl InnerWebView {
         let utf8: *const c_char = msg_send![body, UTF8String];
         let js = CStr::from_ptr(utf8).to_str().expect("Invalid UTF8 string");
 
-        match super::rpc_proxy(&function.1, js.to_string(), &function.0) {
+        match super::rpc_proxy(&function.1, js.to_string(), &mut function.0) {
           Ok(result) => {
             let script = result.unwrap_or_default();
             let wv: id = msg_send![msg, webView];


### PR DESCRIPTION
This PR expands the various webview handlers from Fn to FnMut, allowing capture handlers to mutate values internally without needing external synchronization or interior mutability.

These handlers are not Send anyways, so there's no concern about data races or synchronization, so Fn is overly restrictive. FnMut makes more sense if the closures capture something like a channel which needs to be &mut to be polled.

While implementing this, nothing blew up in my face, but I can't make any strong judgements about the safety of this PR since there seems to be some interaction layer not handled directly in Rust code.


---
Edit:

This PR has safety issues, apparently. It is not valid to make rpc_handler FnMut - with the current safety construct of the inner workings on WebView. I did start to receive segfaults, too.

