### PR TITLE
fix: #366: Use a workaround to fix CORS on Linux

### DIFF
--- a/src/webview/web_context.rs
+++ b/src/webview/web_context.rs
@@ -318,7 +318,7 @@ pub mod unix {
     context
       .security_manager()
       .ok_or(Error::MissingManager)?
-      .register_uri_scheme_as_secure(name);
+      .register_uri_scheme_as_local(name);
 
     context.register_uri_scheme(name, move |request| {
       if let Some(uri) = request.uri() {


### PR DESCRIPTION
Use a workaround to fix CORS on Linux (WebKitGtk) when making XHR requests inside a custom URI scheme context.

After some investigations, it seems like WebKitGtk has some trouble filling in the `Origin` header when the custom URI scheme is not registered as a local scheme in the security manager.

Reference (How WebKitGtk itself handles this issue): https://github.com/WebKit/WebKit/blob/9b6eae32a61d94be9963ef60d73a6d378099a97d/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp#L82-L91

Should fix #366. Testing welcome.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] ~~A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).~~

If adding a **new feature**, the PR's description includes:
- [X] ~~A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)~~

**Other information:**
