### PR TITLE
Update webview2-com and windows crates

### DIFF
--- a/.changes/windows-0.25.0.md
+++ b/.changes/windows-0.25.0.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Update the `windows` crate to 0.25.0, which comes with pre-built libraries. WRY and Tao can both reference the same types directly from the `windows` crate instead of sharing bindings in `webview2-com-sys`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.2"
-tao = { git = "https://github.com/tauri-apps/tao", branch = "next", default-features = false, features = [ "serde" ] }
+#tao = { git = "https://github.com/tauri-apps/tao", branch = "next", default-features = false, features = [ "serde" ] }
+tao = { git = "https://github.com/wravery/tao", branch = "update-webview2", default-features = false, features = [ "serde" ] }
 http = "0.2.5"
 
 [dev-dependencies]
@@ -56,8 +57,19 @@ gtk = "0.14"
 gdk = "0.14"
 
 [target."cfg(target_os = \"windows\")".dependencies]
-webview2-com = "0.4.0"
-windows = "0.19.0"
+webview2-com = "0.6.0"
+
+[target."cfg(target_os = \"windows\")".dependencies.windows]
+version = "0.24.0"
+features = [
+  "build",
+  "Win32_Foundation",
+  "Win32_System_Com",
+  "Win32_System_Ole",
+  "Win32_System_SystemServices",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging",
+]
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]
 cocoa = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.2"
-#tao = { git = "https://github.com/tauri-apps/tao", branch = "next", default-features = false, features = [ "serde" ] }
-tao = { git = "https://github.com/wravery/tao", branch = "update-webview2", default-features = false, features = [ "serde" ] }
+tao = { git = "https://github.com/tauri-apps/tao", branch = "next", default-features = false, features = [ "serde" ] }
 http = "0.2.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,10 +57,10 @@ gtk = "0.14"
 gdk = "0.14"
 
 [target."cfg(target_os = \"windows\")".dependencies]
-webview2-com = "0.6.0"
+webview2-com = "0.7.0"
 
 [target."cfg(target_os = \"windows\")".dependencies.windows]
-version = "0.24.0"
+version = "0.25.0"
 features = [
   "build",
   "Win32_Foundation",

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -34,13 +34,9 @@ pub(crate) mod webview2;
 use self::webview2::*;
 use crate::{Error, Result};
 #[cfg(target_os = "windows")]
-use webview2_com::{
-  Microsoft::Web::WebView2::Win32::ICoreWebView2Controller, Windows::Win32::Foundation::HWND,
-};
+use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 #[cfg(target_os = "windows")]
-use windows::{
-  Win32::Foundation::HWND as External_HWND, Win32::UI::WindowsAndMessaging::DestroyWindow,
-};
+use windows::{Win32::Foundation::HWND, Win32::UI::WindowsAndMessaging::DestroyWindow};
 
 use std::{path::PathBuf, rc::Rc};
 
@@ -377,7 +373,7 @@ impl Drop for WebView {
     }
     #[cfg(target_os = "windows")]
     unsafe {
-      DestroyWindow(External_HWND(self.window.hwnd() as _));
+      DestroyWindow(HWND(self.window.hwnd() as _));
     }
   }
 }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -37,6 +37,10 @@ use crate::{Error, Result};
 use webview2_com::{
   Microsoft::Web::WebView2::Win32::ICoreWebView2Controller, Windows::Win32::Foundation::HWND,
 };
+#[cfg(target_os = "windows")]
+use windows::{
+  Win32::Foundation::HWND as External_HWND, Win32::UI::WindowsAndMessaging::DestroyWindow,
+};
 
 use std::{path::PathBuf, rc::Rc};
 
@@ -373,8 +377,7 @@ impl Drop for WebView {
     }
     #[cfg(target_os = "windows")]
     unsafe {
-      use webview2_com::Windows::Win32::UI::WindowsAndMessaging::DestroyWindow;
-      DestroyWindow(HWND(self.window.hwnd() as _));
+      DestroyWindow(External_HWND(self.window.hwnd() as _));
     }
   }
 }
@@ -418,7 +421,9 @@ impl WebView {
   /// provide a way to resize automatically.
   pub fn resize(&self) -> Result<()> {
     #[cfg(target_os = "windows")]
-    self.webview.resize(HWND(self.window.hwnd() as _))?;
+    self
+      .webview
+      .resize(HWND(self.window.hwnd() as _))?;
     Ok(())
   }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -421,9 +421,7 @@ impl WebView {
   /// provide a way to resize automatically.
   pub fn resize(&self) -> Result<()> {
     #[cfg(target_os = "windows")]
-    self
-      .webview
-      .resize(HWND(self.window.hwnd() as _))?;
+    self.webview.resize(HWND(self.window.hwnd() as _))?;
     Ok(())
   }
 

--- a/src/webview/webview2/file_drop.rs
+++ b/src/webview/webview2/file_drop.rs
@@ -184,7 +184,7 @@ impl FileDropHandler {
     data_obj: &Option<IDataObject>,
     paths: &mut Vec<PathBuf>,
   ) -> Option<HDROP> {
-    let mut drop_format = FORMATETC {
+    let drop_format = FORMATETC {
       cfFormat: CF_HDROP.0 as u16,
       ptd: ptr::null_mut(),
       dwAspect: DVASPECT_CONTENT.0 as u32,
@@ -195,7 +195,7 @@ impl FileDropHandler {
     match data_obj
       .as_ref()
       .expect("Received null IDataObject")
-      .GetData(&mut drop_format)
+      .GetData(&drop_format)
     {
       Ok(medium) => {
         let hglobal = medium.Anonymous.hGlobal;

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -72,11 +72,7 @@ impl InnerWebView {
 
     if let Some(file_drop_handler) = file_drop_handler {
       let mut controller = FileDropController::new();
-      controller.listen(
-        External_HWND(hwnd.0),
-        file_drop_window.clone(),
-        file_drop_handler,
-      );
+      controller.listen(External_HWND(hwnd.0), file_drop_window, file_drop_handler);
       let _ = file_drop_controller.set(controller);
     }
 

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -14,19 +14,26 @@ use file_drop::FileDropController;
 use std::{collections::HashSet, rc::Rc, sync::mpsc};
 
 use once_cell::unsync::OnceCell;
-use webview2_com::{
-  Microsoft::Web::WebView2::Win32::*,
-  WebMessageReceivedEventHandler, WindowCloseRequestedEventHandler,
-  Windows::Win32::{
-    Foundation::{BOOL, E_FAIL, E_POINTER, HWND, POINT, PWSTR, RECT},
-    Storage::StructuredStorage::CreateStreamOnHGlobal,
+
+use windows::{
+  runtime::Interface,
+  Win32::{
+    Foundation::{E_FAIL, E_POINTER, HWND as External_HWND, POINT, RECT as External_RECT},
+    System::Com::{IStream as External_IStream, StructuredStorage::CreateStreamOnHGlobal},
     UI::WindowsAndMessaging::{
       self as win32wm, DestroyWindow, GetClientRect, GetCursorPos, WM_NCLBUTTONDOWN,
     },
   },
+};
+
+use webview2_com::{
+  Microsoft::Web::WebView2::Win32::*,
+  Windows::Win32::{
+    Foundation::{BOOL, HWND, PWSTR, RECT},
+    System::WinRT::EventRegistrationToken,
+  },
   *,
 };
-use windows::Interface;
 
 use crate::{
   application::{platform::windows::WindowExtWindows, window::Window},
@@ -59,7 +66,7 @@ impl InnerWebView {
 
     if let Some(file_drop_handler) = attributes.file_drop_handler.take() {
       let mut controller = FileDropController::new();
-      controller.listen(hwnd, window.clone(), file_drop_handler);
+      controller.listen(External_HWND(hwnd.0), window.clone(), file_drop_handler);
       let _ = file_drop_controller.set(controller);
     }
 
@@ -110,7 +117,7 @@ impl InnerWebView {
       }),
       Box::new(move |error_code, environment| {
         error_code?;
-        tx.send(environment.ok_or_else(|| windows::Error::fast_error(E_POINTER)))
+        tx.send(environment.ok_or_else(|| windows::runtime::Error::fast_error(E_POINTER)))
           .expect("send over mpsc channel");
         Ok(())
       }),
@@ -136,7 +143,7 @@ impl InnerWebView {
       }),
       Box::new(move |error_code, controller| {
         error_code?;
-        tx.send(controller.ok_or_else(|| windows::Error::fast_error(E_POINTER)))
+        tx.send(controller.ok_or_else(|| windows::runtime::Error::fast_error(E_POINTER)))
           .expect("send over mpsc channel");
         Ok(())
       }),
@@ -155,7 +162,7 @@ impl InnerWebView {
     controller: &ICoreWebView2Controller,
   ) -> webview2_com::Result<ICoreWebView2> {
     let webview =
-      unsafe { controller.get_CoreWebView2() }.map_err(webview2_com::Error::WindowsError)?;
+      unsafe { controller.CoreWebView2() }.map_err(webview2_com::Error::WindowsError)?;
 
     // Transparent
     if attributes.transparent {
@@ -164,7 +171,7 @@ impl InnerWebView {
         .map_err(webview2_com::Error::WindowsError)?;
       unsafe {
         controller2
-          .put_DefaultBackgroundColor(COREWEBVIEW2_COLOR {
+          .SetDefaultBackgroundColor(COREWEBVIEW2_COLOR {
             R: 0,
             G: 0,
             B: 0,
@@ -178,43 +185,49 @@ impl InnerWebView {
     // taking it in the local variable and then just ignoring it because all of the event handlers
     // are registered for the life of the webview, but if we wanted to be able to remove them later
     // we would hold onto them in self.
-    let mut token = Windows::Win32::System::WinRT::EventRegistrationToken::default();
+    let mut token = EventRegistrationToken::default();
 
     // Safety: System calls are unsafe
     unsafe {
       let handler: ICoreWebView2WindowCloseRequestedEventHandler =
         WindowCloseRequestedEventHandler::create(Box::new(move |_, _| {
-          if DestroyWindow(hwnd).as_bool() {
+          if DestroyWindow(External_HWND(hwnd.0)).as_bool() {
             Ok(())
           } else {
             Err(E_FAIL.into())
           }
         }));
       webview
-        .add_WindowCloseRequested(handler, &mut token)
+        .WindowCloseRequested(handler, &mut token)
         .map_err(webview2_com::Error::WindowsError)?;
 
       let settings = webview
-        .get_Settings()
+        .Settings()
         .map_err(webview2_com::Error::WindowsError)?;
       settings
-        .put_IsStatusBarEnabled(false)
+        .SetIsStatusBarEnabled(false)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
-        .put_AreDefaultContextMenusEnabled(true)
+        .SetAreDefaultContextMenusEnabled(true)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
-        .put_IsZoomControlEnabled(false)
+        .SetIsZoomControlEnabled(false)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
-        .put_AreDevToolsEnabled(false)
+        .SetAreDevToolsEnabled(false)
         .map_err(webview2_com::Error::WindowsError)?;
-      debug_assert_eq!(settings.put_AreDevToolsEnabled(true), Ok(()));
+      debug_assert_eq!(settings.SetAreDevToolsEnabled(true), Ok(()));
 
-      let mut rect = RECT::default();
-      GetClientRect(hwnd, &mut rect);
+      let mut rect = External_RECT::default();
+      GetClientRect(External_HWND(hwnd.0), &mut rect);
+      let rect = RECT {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+      };
       controller
-        .put_Bounds(rect)
+        .SetBounds(rect)
         .map_err(webview2_com::Error::WindowsError)?;
     }
 
@@ -239,7 +252,7 @@ impl InnerWebView {
     // Message handler
     let rpc_handler = attributes.rpc_handler.take();
     unsafe {
-      webview.add_WebMessageReceived(
+      webview.WebMessageReceived(
         WebMessageReceivedEventHandler::create(Box::new(move |webview, args| {
           if let (Some(webview), Some(args)) = (webview, args) {
             let mut js = PWSTR::default();
@@ -251,7 +264,7 @@ impl InnerWebView {
 
                 let mut point = POINT::default();
                 GetCursorPos(&mut point);
-                let result = hit_test(HWND(window.hwnd() as _), point.x, point.y);
+                let result = hit_test(External_HWND(window.hwnd() as _), point.x, point.y);
                 let cursor = match result.0 as u32 {
                   win32wm::HTLEFT => CursorIcon::WResize,
                   win32wm::HTTOP => CursorIcon::NResize,
@@ -320,21 +333,21 @@ impl InnerWebView {
       let env = env.clone();
       unsafe {
         webview
-          .add_WebResourceRequested(
+          .WebResourceRequested(
             WebResourceRequestedEventHandler::create(Box::new(move |_, args| {
               if let Some(args) = args {
-                let webview_request = args.get_Request()?;
+                let webview_request = args.Request()?;
                 let mut request = HttpRequestBuilder::new();
 
                 // request method (GET, POST, PUT etc..)
                 let mut request_method = PWSTR::default();
-                webview_request.get_Method(&mut request_method)?;
+                webview_request.Method(&mut request_method)?;
                 let request_method = take_pwstr(request_method);
 
                 // get all headers from the request
-                let headers = webview_request.get_Headers()?.GetIterator()?;
+                let headers = webview_request.Headers()?.GetIterator()?;
                 let mut has_current = BOOL::default();
-                headers.get_HasCurrentHeader(&mut has_current)?;
+                headers.HasCurrentHeader(&mut has_current)?;
                 if has_current.as_bool() {
                   loop {
                     let mut key = PWSTR::default();
@@ -352,10 +365,11 @@ impl InnerWebView {
 
                 // get the body content if available
                 let mut body_sent = Vec::new();
-                if let Ok(content) = webview_request.get_Content() {
+                if let Ok(content) = webview_request.Content() {
                   let mut buffer: [u8; 1024] = [0; 1024];
                   loop {
                     let mut cb_read = 0;
+                    let content: External_IStream = content.cast()?;
                     content.Read(
                       buffer.as_mut_ptr() as *mut _,
                       buffer.len() as u32,
@@ -372,7 +386,7 @@ impl InnerWebView {
 
                 // uri
                 let mut uri = PWSTR::default();
-                webview_request.get_Uri(&mut uri)?;
+                webview_request.Uri(&mut uri)?;
                 let uri = take_pwstr(uri);
 
                 if let Some(custom_protocol) = custom_protocols
@@ -424,10 +438,11 @@ impl InnerWebView {
 
                       // FIXME: Set http response version
 
+                      let body_sent = body_sent.map(|content| content.cast().unwrap());
                       let response =
                         env.CreateWebResourceResponse(body_sent, status_code, "OK", headers_map)?;
 
-                      args.put_Response(response)?;
+                      args.SetResponse(response)?;
                       Ok(())
                     }
                     Err(_) => Err(E_FAIL.into()),
@@ -447,13 +462,13 @@ impl InnerWebView {
     if attributes.clipboard {
       unsafe {
         webview
-          .add_PermissionRequested(
+          .PermissionRequested(
             PermissionRequestedEventHandler::create(Box::new(|_, args| {
               if let Some(args) = args {
                 let mut kind = COREWEBVIEW2_PERMISSION_KIND_UNKNOWN_PERMISSION;
-                args.get_PermissionKind(&mut kind)?;
+                args.PermissionKind(&mut kind)?;
                 if kind == COREWEBVIEW2_PERMISSION_KIND_CLIPBOARD_READ {
-                  args.put_State(COREWEBVIEW2_PERMISSION_STATE_ALLOW)?;
+                  args.SetState(COREWEBVIEW2_PERMISSION_STATE_ALLOW)?;
                 }
               }
               Ok(())
@@ -502,7 +517,7 @@ impl InnerWebView {
 
     unsafe {
       controller
-        .put_IsVisible(true)
+        .SetIsVisible(true)
         .map_err(webview2_com::Error::WindowsError)?;
       controller
         .MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC)
@@ -527,7 +542,7 @@ impl InnerWebView {
     )
   }
 
-  fn execute_script(webview: &ICoreWebView2, js: String) -> windows::Result<()> {
+  fn execute_script(webview: &ICoreWebView2, js: String) -> windows::runtime::Result<()> {
     unsafe {
       webview.ExecuteScript(
         js,
@@ -549,9 +564,15 @@ impl InnerWebView {
     // Safety: System calls are unsafe
     // XXX: Resizing on Windows is usually sluggish. Many other applications share same behavior.
     unsafe {
-      let mut rect = RECT::default();
-      GetClientRect(hwnd, &mut rect);
-      self.controller.put_Bounds(rect)
+      let mut rect = External_RECT::default();
+      GetClientRect(External_HWND(hwnd.0), &mut rect);
+      let rect = RECT {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+      };
+      self.controller.SetBounds(rect)
     }
     .map_err(|error| Error::WebView2Error(webview2_com::Error::WindowsError(error)))
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is a follow-up to https://github.com/tauri-apps/tao/pull/240.

Once the `windows` crate is able to point the overlapping types (e.g. `HWND`, `BOOL`, `RECT`, etc.) from WebView2 back to the pre-compiled libraries, we should do a cleanup which removes the `External_...` type aliases and the conversions.