### PR TITLE
remove "tray" from default features and allow using "ayatana" instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,12 @@ jobs:
             ${{ matrix.platform }}-stable-cargo-core-
 
       - name: build wry
-        run: cargo build --target ${{ matrix.platform.target }}
+        run: cargo build --features tray --target ${{ matrix.platform.target }}
 
       - name: build tests and examples
         shell: bash
-        run: cargo test --no-run --verbose --target ${{ matrix.platform.target }}
+        run: cargo test --no-run --verbose --features tray --target ${{ matrix.platform.target }}
 
       - name: run tests
         if: (!contains(matrix.platform.target, 'ios'))
-        run: cargo test --verbose --target ${{ matrix.platform.target }}
+        run: cargo test --verbose --features tray --target ${{ matrix.platform.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,15 @@ targets = [
 ]
 
 [features]
-default = [ "file-drop", "protocol", "tray" ]
+default = [ "file-drop", "protocol" ]
 file-drop = [ ]
 protocol = [ ]
 dox = [ "tao/dox" ]
-tray = [ "tao/tray" ]
+tray = [ "tao/tray", "system_tray" ]
+ayatana = [ "tao/ayatana", "system_tray" ]
 transparent = [ ]
 fullscreen = [ ]
+system_tray = [ ]
 
 [dependencies]
 libc = "0.2"
@@ -78,3 +80,11 @@ cocoa = "0.24"
 core-graphics = "0.22"
 objc = "0.2"
 objc_id = "0.1"
+
+[[example]]
+name = "system_tray_no_menu"
+required-features = ["system_tray"]
+
+[[example]]
+name = "system_tray"
+required-features = ["system_tray"]


### PR DESCRIPTION
The "tray" feature enables dependency on libappindicator3.

On Debian 11 (and some other systems), libappindicator3 was
removed and replaced with libayatana-appindicator3:
  https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#noteworthy-obsolete-packages

This new library can be used by enabling the "ayatana" feature.

Depending on the system, only one of those library will usually
be available, and thus, only one of the "tray" and "ayatana"
feature would compile fine.

Having "tray" in default features did prevent building on systems
with no libappindicator3 available.