### PR TITLE
Update webview2-com to 0.11.0

### DIFF
--- a/.changes/webview2-com-0.11.0.md
+++ b/.changes/webview2-com-0.11.0.md
@@ -1,0 +1,7 @@
+---
+"wry": patch
+---
+
+Update the `webview2-com` crate 0.11.0:
+- Fix silent build script errors related to unconfigured nuget in https://github.com/wravery/webview2-rs/pull/4
+- Update the WebView2 SDK (not the runtime, just the API bindings) to the latest 1.0.1072.54 version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ gtk = "0.15"
 gdk = "0.15"
 
 [target."cfg(target_os = \"windows\")".dependencies]
-webview2-com = "0.10.0"
+webview2-com = "0.11.0"
 windows_macros = "0.30.0"
 sys-info = "0.9"
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Update the `webview2-com` crate 0.11.0:
- Fix silent build script errors related to unconfigured nuget in https://github.com/wravery/webview2-rs/pull/4
- Update the WebView2 SDK (not the runtime, just the API bindings) to the latest 1.0.1072.54 version