### PR TITLE
fix: cross compilation from macOS

### DIFF
--- a/.changes/fix-cross-compile-macos.md
+++ b/.changes/fix-cross-compile-macos.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix cross compilation from `macOS`.

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#[cfg(not(target_os = "macos"))]
-fn main() {}
-
-#[cfg(target_os = "macos")]
 fn main() {
-  println!("cargo:rustc-link-lib=framework=WebKit");
+  let is_macos = std::env::var("TARGET")
+    .map(|t| t.ends_with("-darwin"))
+    .unwrap_or_default();
+  if is_macos {
+    println!("cargo:rustc-link-lib=framework=WebKit");
+  }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixes an issue when cross compiling `cargo build --target x86_64-pc-windows-gnu` on macOS systems, since we can't use `#[cfg()]` to link the WebKit framework as that checks the system target instead of the runtime selected one.
