### PR TITLE
Changed NSDragOperation from link to copy

### DIFF
--- a/src/webview/wkwebview/file_drop.rs
+++ b/src/webview/wkwebview/file_drop.rs
@@ -19,7 +19,7 @@ use crate::{application::window::Window, webview::FileDropEvent};
 
 pub(crate) type NSDragOperation = cocoa::foundation::NSUInteger;
 #[allow(non_upper_case_globals)]
-const NSDragOperationLink: NSDragOperation = 2;
+const NSDragOperationCopy: NSDragOperation = 1;
 
 static OBJC_DRAGGING_ENTERED: Lazy<extern "C" fn(*const Object, Sel, id) -> NSDragOperation> =
   Lazy::new(|| unsafe {
@@ -96,8 +96,8 @@ extern "C" fn dragging_updated(this: &mut Object, sel: Sel, drag_info: id) -> NS
   let os_operation = OBJC_DRAGGING_UPDATED(this, sel, drag_info);
   if os_operation == 0 {
     // 0 will be returned for a file drop on any arbitrary location on the webview.
-    // We'll override that with NSDragOperationLink.
-    NSDragOperationLink
+    // We'll override that with NSDragOperationCopy.
+    NSDragOperationCopy
   } else {
     // A different NSDragOperation is returned when a file is hovered over something like
     // a <input type="file">, so we'll make sure to preserve that behaviour.
@@ -113,7 +113,7 @@ extern "C" fn dragging_entered(this: &mut Object, sel: Sel, drag_info: id) -> NS
     // Reject the Wry file drop (invoke the OS default behaviour)
     OBJC_DRAGGING_ENTERED(this, sel, drag_info)
   } else {
-    NSDragOperationLink
+    NSDragOperationCopy
   }
 }
 


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Consistency improvement. 
Currently there is inconsistency between implementations of webview for different platforms. For example in `webview2` the drag handler returns `DROPEFFECT_COPY` while in webkit it was NSDragOperation.link. 
In addition there is another handler in winit/tao which also returns NSDragOperation.copy and currently the cursor in MacOS flickers between two states when dragging onto the application border and the webview itself.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

Since there is no ability to define a custom callback for d&d events, this PR affects only UX

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
