### PR TITLE
fix(macOS): enable tab navigation on all elements, fixes #406

### DIFF
--- a/.changes/fix-tab-focus.md
+++ b/.changes/fix-tab-focus.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Enable tab navigation on macOS.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -261,6 +261,9 @@ impl InnerWebView {
         let _: id = msg_send![_preference, setValue:_yes forKey:dev];
       }
 
+      #[cfg(target_os("macos"))]
+      let _: () = msg_send![_preference, setValue:_yes forKey:NSString::new("tabFocusesLinks")];
+
       #[cfg(feature = "transparent")]
       if attributes.transparent {
         let no: id = msg_send![class!(NSNumber), numberWithBool:0];

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -261,8 +261,8 @@ impl InnerWebView {
         let _: id = msg_send![_preference, setValue:_yes forKey:dev];
       }
 
-      #[cfg(target_os("macos"))]
-      let _: () = msg_send![_preference, setValue:_yes forKey:NSString::new("tabFocusesLinks")];
+      #[cfg(target_os = "macos")]
+      let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("tabFocusesLinks")];
 
       #[cfg(feature = "transparent")]
       if attributes.transparent {


### PR DESCRIPTION
I forgot the changefile as always, but i'll add it once i'm back and if someone can confirm that this actually works (it did work in my mac vm).

Furthermore we might want to solve this differently, like giving the user an option to choose if this should be enabled or not, because apparently the default shortcut for this is command+tab instead of tab :shrug: (i'd prefer to force this behavior for cross-platform consistency)

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary