### PR TITLE
Fix resizing issue custom titlebar example

### DIFF
--- a/examples/custom_titlebar.rs
+++ b/examples/custom_titlebar.rs
@@ -27,8 +27,8 @@ fn main() -> wry::Result<()> {
 
   let url = r#"data:text/html,
         <body>
-          <div class='drag-region titlebar'>
-            <div class="left">Awesome WRY Window</div>
+          <div class='titlebar'>
+            <div class="drag-region left">Awesome WRY Window</div>
             <div class="right">
               <div class="titlebar-button" id="minimize">
                 <img src="https://api.iconify.design/codicon:chrome-minimize.svg" />
@@ -77,12 +77,13 @@ fn main() -> wry::Result<()> {
         }
         .titlebar {
           height: 30px;
+          display: grid;
+          grid-auto-flow: column;
+          grid-template-columns: 1fr max-content max-content max-content;
+          align-items: center;
           background: #1F1F1F;
           color: white;
           user-select: none;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
         }
         .titlebar-button {
           display: inline-flex;


### PR DESCRIPTION
It was impossible to click and resize using the top edge of the window in the custom titlebar example
Instead the window would be dragged.
By moving the `drag-region` to the title element and using `grid` instead of `flex` this is fixed.
Given that people often start working from a certain example I think it could save people quite some debugging time.
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
