### PR TITLE
chore(examples): fix to use `.with_dev_tool()` to enable devtool

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -16,9 +16,12 @@ fn main() -> wry::Result<()> {
   let window = WindowBuilder::new()
     .with_title("Hello World")
     .build(&event_loop)?;
-  let webview = WebViewBuilder::new(window)?
-    .with_url("https://html5test.com")?
-    .build()?;
+  let webview = WebViewBuilder::new(window)?.with_url("https://html5test.com")?;
+
+  #[cfg(debug_assertions)]
+  let webview = webview.with_dev_tool(true);
+
+  let webview = webview.build()?;
 
   #[cfg(debug_assertions)]
   webview.devtool();

--- a/examples/navigation_event.rs
+++ b/examples/navigation_event.rs
@@ -27,8 +27,12 @@ fn main() -> wry::Result<()> {
       let submitted = proxy.send_event(UserEvent::Navigation(uri.clone())).is_ok();
 
       submitted && uri.contains("neverssl")
-    })
-    .build()?;
+    });
+
+  #[cfg(debug_assertions)]
+  let webview = webview.with_dev_tool(true);
+
+  let webview = webview.build()?;
 
   #[cfg(debug_assertions)]
   webview.devtool();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

It seems that devtool is not working in some examples, because `devtool` option was not enabled in `wry::webview::WebViewAttributes`.

I fixed to invoke `. with_dev_tool` method for enabling devtool in webview.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
