### PR TITLE
feat: add function to close the devtool and check if it is opened

### DIFF
--- a/.changes/close-devtool.md
+++ b/.changes/close-devtool.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Added `close_devtool` function to `Webview`.

--- a/.changes/close-devtool.md
+++ b/.changes/close-devtool.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Added `close_devtool` function to `Webview`.
+Added `close_devtools` function to `Webview`.

--- a/.changes/devtool-feature-flag.md
+++ b/.changes/devtool-feature-flag.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Hide the devtool functions behind the `any(debug_assertions, feature = "devtool")` flag.
+Hide the devtool functions behind the `any(debug_assertions, feature = "devtools")` flag.

--- a/.changes/devtool-feature-flag.md
+++ b/.changes/devtool-feature-flag.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Hide the devtool functions behind the `any(debug_assertions, feature = "devtool")` flag.

--- a/.changes/devtool-fn-refactor.md
+++ b/.changes/devtool-fn-refactor.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Renamed the `devtool` function to `open_devtool`.
+**Breaking change:** Renamed the `devtool` function to `open_devtools`.

--- a/.changes/devtool-fn-refactor.md
+++ b/.changes/devtool-fn-refactor.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Renamed the `devtool` function to `open_devtool`.

--- a/.changes/is-devtool-visible.md
+++ b/.changes/is-devtool-visible.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Added `is_devtool_visible` function to `Webview`.
+Added `is_devtools_visible` function to `Webview`.

--- a/.changes/is-devtool-visible.md
+++ b/.changes/is-devtool-visible.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Added `is_devtools_visible` function to `Webview`.
+Added `is_devtools_open` function to `Webview`.

--- a/.changes/is-devtool-visible.md
+++ b/.changes/is-devtool-visible.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Added `is_devtool_visible` function to `Webview`.

--- a/.changes/rename-devtools-feature.md
+++ b/.changes/rename-devtools-feature.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+**Breaking change**: Renamed the `devtool` feature to `devtools`.

--- a/.changes/with-devtool-builder-refactor.md
+++ b/.changes/with-devtool-builder-refactor.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+**Breaking change:** Renamed the `with_dev_tool` function to `with_devtools`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ protocol = [ ]
 dox = [ "tao/dox" ]
 tray = [ "tao/tray" ]
 ayatana = [ "tao/ayatana" ]
-devtool = [ ]
+devtools = [ ]
 transparent = [ ]
 fullscreen = [ ]
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -21,7 +21,7 @@ fn main() -> wry::Result<()> {
     .build()?;
 
   #[cfg(debug_assertions)]
-  webview.devtool();
+  webview.open_devtool();
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -19,12 +19,12 @@ fn main() -> wry::Result<()> {
   let webview = WebViewBuilder::new(window)?.with_url("https://html5test.com")?;
 
   #[cfg(debug_assertions)]
-  let webview = webview.with_dev_tool(true);
+  let webview = webview.with_devtools(true);
 
   let webview = webview.build()?;
 
   #[cfg(debug_assertions)]
-  webview.open_devtool();
+  webview.open_devtools();
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/navigation_event.rs
+++ b/examples/navigation_event.rs
@@ -31,7 +31,7 @@ fn main() -> wry::Result<()> {
     .build()?;
 
   #[cfg(debug_assertions)]
-  webview.devtool();
+  webview.open_devtool();
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/examples/navigation_event.rs
+++ b/examples/navigation_event.rs
@@ -30,12 +30,12 @@ fn main() -> wry::Result<()> {
     });
 
   #[cfg(debug_assertions)]
-  let webview = webview.with_dev_tool(true);
+  let webview = webview.with_devtools(true);
 
   let webview = webview.build()?;
 
   #[cfg(debug_assertions)]
-  webview.open_devtool();
+  webview.open_devtools();
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -43,7 +43,7 @@ impl InnerWebView {
   pub fn close_devtools(&self) {}
 
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtools_visible(&self) -> bool {
+  pub fn is_devtools_open(&self) -> bool {
     false
   }
 

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -36,7 +36,11 @@ impl InnerWebView {
 
   pub fn focus(&self) {}
 
-  pub fn devtool(&self) {}
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn open_devtool(&self) {}
+
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn close_devtool(&self) {}
 
   pub fn run(self, env: JNIEnv, _jclass: JClass, jobject: JObject) -> Result<jobject> {
     let string_class = env.find_class("java/lang/String")?;

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -42,6 +42,11 @@ impl InnerWebView {
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn close_devtool(&self) {}
 
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn is_devtool_visible(&self) -> bool {
+    false
+  }
+
   pub fn run(self, env: JNIEnv, _jclass: JClass, jobject: JObject) -> Result<jobject> {
     let string_class = env.find_class("java/lang/String")?;
     // let client = env.call_method(

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -37,13 +37,13 @@ impl InnerWebView {
   pub fn focus(&self) {}
 
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn open_devtool(&self) {}
+  pub fn open_devtools(&self) {}
 
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn close_devtool(&self) {}
+  pub fn close_devtools(&self) {}
 
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtool_visible(&self) -> bool {
+  pub fn is_devtools_visible(&self) -> bool {
     false
   }
 

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -36,13 +36,13 @@ impl InnerWebView {
 
   pub fn focus(&self) {}
 
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn open_devtools(&self) {}
 
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn close_devtools(&self) {}
 
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn is_devtools_visible(&self) -> bool {
     false
   }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -430,8 +430,21 @@ impl WebView {
   }
 
   /// Open the web inspector which is usually called dev tool.
-  pub fn devtool(&self) {
-    self.webview.devtool();
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn open_devtool(&self) {
+    self.webview.open_devtool();
+  }
+
+  /// Close the web inspector which is usually called dev tool.
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn close_devtool(&self) {
+    self.webview.close_devtool();
+  }
+
+  /// Gets the devtool window's current vibility state.
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn is_devtool_visible(&self) -> bool {
+    self.webview.is_devtool_visible()
   }
 
   pub fn inner_size(&self) -> PhysicalSize<u32> {

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -430,18 +430,30 @@ impl WebView {
   }
 
   /// Open the web inspector which is usually called dev tool.
+  /// 
+  /// ## Platform-specific
+  ///
+  /// - **Android / iOS:** Not implemented.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn open_devtool(&self) {
     self.webview.open_devtool();
   }
 
   /// Close the web inspector which is usually called dev tool.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows / Android / iOS:** Not implemented.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn close_devtool(&self) {
     self.webview.close_devtool();
   }
 
   /// Gets the devtool window's current vibility state.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows / Android / iOS:** Not implemented.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn is_devtool_visible(&self) -> bool {
     self.webview.is_devtool_visible()

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -140,7 +140,7 @@ pub struct WebViewAttributes {
   /// # Warning
   /// This will call private functions on **macOS**. It's still enabled if set in **debug** build on mac,
   /// but requires `devtool` feature flag to actually enable it in **release** build.
-  pub devtool: bool,
+  pub devtools: bool,
 }
 
 impl Default for WebViewAttributes {
@@ -157,7 +157,7 @@ impl Default for WebViewAttributes {
       file_drop_handler: None,
       navigation_handler: None,
       clipboard: false,
-      devtool: false,
+      devtools: false,
     }
   }
 }
@@ -308,8 +308,8 @@ impl<'a> WebViewBuilder<'a> {
   /// # Warning
   /// This will call private functions on **macOS**. It's still enabled if set in **debug** build on mac,
   /// but requires `devtool` feature flag to actually enable it in **release** build.
-  pub fn with_devtools(mut self, devtool: bool) -> Self {
-    self.webview.devtool = devtool;
+  pub fn with_devtools(mut self, devtools: bool) -> Self {
+    self.webview.devtools = devtools;
     self
   }
 
@@ -434,7 +434,7 @@ impl WebView {
   /// ## Platform-specific
   ///
   /// - **Android / iOS:** Not supported.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn open_devtools(&self) {
     self.webview.open_devtools();
   }
@@ -444,7 +444,7 @@ impl WebView {
   /// ## Platform-specific
   ///
   /// - **Windows / Android / iOS:** Not supported.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn close_devtools(&self) {
     self.webview.close_devtools();
   }
@@ -454,7 +454,7 @@ impl WebView {
   /// ## Platform-specific
   ///
   /// - **Windows / Android / iOS:** Not supported.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn is_devtoolss_open(&self) -> bool {
     self.webview.is_devtools_visible()
   }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -308,7 +308,7 @@ impl<'a> WebViewBuilder<'a> {
   /// # Warning
   /// This will call private functions on **macOS**. It's still enabled if set in **debug** build on mac,
   /// but requires `devtool` feature flag to actually enable it in **release** build.
-  pub fn with_dev_tool(mut self, devtool: bool) -> Self {
+  pub fn with_devtools(mut self, devtool: bool) -> Self {
     self.webview.devtool = devtool;
     self
   }
@@ -435,8 +435,8 @@ impl WebView {
   ///
   /// - **Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn open_devtool(&self) {
-    self.webview.open_devtool();
+  pub fn open_devtools(&self) {
+    self.webview.open_devtools();
   }
 
   /// Close the web inspector which is usually called dev tool.
@@ -445,8 +445,8 @@ impl WebView {
   ///
   /// - **Windows / Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn close_devtool(&self) {
-    self.webview.close_devtool();
+  pub fn close_devtools(&self) {
+    self.webview.close_devtools();
   }
 
   /// Gets the devtool window's current vibility state.
@@ -455,8 +455,8 @@ impl WebView {
   ///
   /// - **Windows / Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtools_open(&self) -> bool {
-    self.webview.is_devtool_visible()
+  pub fn is_devtoolss_open(&self) -> bool {
+    self.webview.is_devtools_visible()
   }
 
   pub fn inner_size(&self) -> PhysicalSize<u32> {

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -307,7 +307,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// # Warning
   /// This will call private functions on **macOS**. It's still enabled if set in **debug** build on mac,
-  /// but requires `devtool` feature flag to actually enable it in **release** build.
+  /// but requires `devtools` feature flag to actually enable it in **release** build.
   pub fn with_devtools(mut self, devtool: bool) -> Self {
     self.webview.devtool = devtool;
     self
@@ -456,7 +456,7 @@ impl WebView {
   /// - **Windows / Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn is_devtoolss_open(&self) -> bool {
-    self.webview.is_devtools_visible()
+    self.webview.is_devtools_open()
   }
 
   pub fn inner_size(&self) -> PhysicalSize<u32> {

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -430,7 +430,7 @@ impl WebView {
   }
 
   /// Open the web inspector which is usually called dev tool.
-  /// 
+  ///
   /// ## Platform-specific
   ///
   /// - **Android / iOS:** Not implemented.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -433,7 +433,7 @@ impl WebView {
   ///
   /// ## Platform-specific
   ///
-  /// - **Android / iOS:** Not implemented.
+  /// - **Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn open_devtool(&self) {
     self.webview.open_devtool();
@@ -443,7 +443,7 @@ impl WebView {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows / Android / iOS:** Not implemented.
+  /// - **Windows / Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn close_devtool(&self) {
     self.webview.close_devtool();
@@ -453,9 +453,9 @@ impl WebView {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows / Android / iOS:** Not implemented.
+  /// - **Windows / Android / iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtool_visible(&self) -> bool {
+  pub fn is_devtools_open(&self) -> bool {
     self.webview.is_devtool_visible()
   }
 

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -41,7 +41,7 @@ mod web_context;
 pub struct InnerWebView {
   pub(crate) webview: Rc<WebView>,
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  is_inspector_visible: Arc<AtomicBool>,
+  is_inspector_open: Arc<AtomicBool>,
 }
 
 impl InnerWebView {
@@ -278,26 +278,26 @@ impl InnerWebView {
     }
 
     #[cfg(any(debug_assertions, feature = "devtool"))]
-    let is_inspector_visible = {
-      let is_inspector_visible = Arc::new(AtomicBool::default());
+    let is_inspector_open = {
+      let is_inspector_open = Arc::new(AtomicBool::default());
       if let Some(inspector) = WebViewExt::inspector(&*webview) {
-        let is_inspector_visible_ = is_inspector_visible.clone();
+        let is_inspector_open_ = is_inspector_open.clone();
         inspector.connect_bring_to_front(move |_| {
-          is_inspector_visible_.store(true, Ordering::Relaxed);
+          is_inspector_open_.store(true, Ordering::Relaxed);
           false
         });
-        let is_inspector_visible_ = is_inspector_visible.clone();
+        let is_inspector_open_ = is_inspector_open.clone();
         inspector.connect_closed(move |_| {
-          is_inspector_visible_.store(false, Ordering::Relaxed);
+          is_inspector_open_.store(false, Ordering::Relaxed);
         });
       }
-      is_inspector_visible
+      is_inspector_open
     };
 
     let w = Self {
       webview,
       #[cfg(any(debug_assertions, feature = "devtool"))]
-      is_inspector_visible,
+      is_inspector_open,
     };
 
     // Initialize message handler
@@ -372,7 +372,7 @@ impl InnerWebView {
     if let Some(inspector) = WebViewExt::inspector(&*self.webview) {
       inspector.show();
       // `bring-to-front` is not received in this case
-      self.is_inspector_visible.store(true, Ordering::Relaxed);
+      self.is_inspector_open.store(true, Ordering::Relaxed);
     }
   }
 
@@ -387,7 +387,7 @@ impl InnerWebView {
   /// Gets the devtool window's current vibility state.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn is_devtools_visible(&self) -> bool {
-    self.is_inspector_visible.load(Ordering::Relaxed)
+    self.is_inspector_open.load(Ordering::Relaxed)
   }
 }
 

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#[cfg(any(debug_assertions, feature = "devtool"))]
+#[cfg(any(debug_assertions, feature = "devtools"))]
 use std::sync::{
   atomic::{AtomicBool, Ordering},
   Arc,
@@ -40,7 +40,7 @@ mod web_context;
 
 pub struct InnerWebView {
   pub(crate) webview: Rc<WebView>,
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   is_inspector_visible: Arc<AtomicBool>,
 }
 
@@ -258,7 +258,7 @@ impl InnerWebView {
       // Set user agent
       settings.set_user_agent(attributes.user_agent.as_deref());
 
-      if attributes.devtool {
+      if attributes.devtools {
         settings.set_enable_developer_extras(true);
       }
     }
@@ -277,7 +277,7 @@ impl InnerWebView {
       window.show_all();
     }
 
-    #[cfg(any(debug_assertions, feature = "devtool"))]
+    #[cfg(any(debug_assertions, feature = "devtools"))]
     let is_inspector_visible = {
       let is_inspector_visible = Arc::new(AtomicBool::default());
       if let Some(inspector) = WebViewExt::inspector(&*webview) {
@@ -296,7 +296,7 @@ impl InnerWebView {
 
     let w = Self {
       webview,
-      #[cfg(any(debug_assertions, feature = "devtool"))]
+      #[cfg(any(debug_assertions, feature = "devtools"))]
       is_inspector_visible,
     };
 
@@ -367,7 +367,7 @@ impl InnerWebView {
   }
 
   /// Open the web inspector which is usually called dev tool.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn open_devtools(&self) {
     if let Some(inspector) = WebViewExt::inspector(&*self.webview) {
       inspector.show();
@@ -377,7 +377,7 @@ impl InnerWebView {
   }
 
   /// Close the web inspector which is usually called dev tool.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn close_devtools(&self) {
     if let Some(inspector) = WebViewExt::inspector(&*self.webview) {
       inspector.close();
@@ -385,7 +385,7 @@ impl InnerWebView {
   }
 
   /// Gets the devtool window's current vibility state.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn is_devtools_visible(&self) -> bool {
     self.is_inspector_visible.load(Ordering::Relaxed)
   }

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -368,7 +368,7 @@ impl InnerWebView {
 
   /// Open the web inspector which is usually called dev tool.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn open_devtool(&self) {
+  pub fn open_devtools(&self) {
     if let Some(inspector) = WebViewExt::inspector(&*self.webview) {
       inspector.show();
       // `bring-to-front` is not received in this case
@@ -378,7 +378,7 @@ impl InnerWebView {
 
   /// Close the web inspector which is usually called dev tool.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn close_devtool(&self) {
+  pub fn close_devtools(&self) {
     if let Some(inspector) = WebViewExt::inspector(&*self.webview) {
       inspector.close();
     }
@@ -386,7 +386,7 @@ impl InnerWebView {
 
   /// Gets the devtool window's current vibility state.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtool_visible(&self) -> bool {
+  pub fn is_devtools_visible(&self) -> bool {
     self.is_inspector_visible.load(Ordering::Relaxed)
   }
 }

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -603,9 +603,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
   /// Open the web inspector which is usually called dev tool.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn open_devtool(&self) {
-    let _ = unsafe {
-      self.webview.OpenDevToolsWindow()
-    };
+    let _ = unsafe { self.webview.OpenDevToolsWindow() };
   }
 
   /// Close the web inspector which is usually called dev tool.

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -607,6 +607,16 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
       self.webview.OpenDevToolsWindow();
     };
   }
+
+  /// Close the web inspector which is usually called dev tool.
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn close_devtool(&self) {}
+
+  /// Gets the devtool window's current vibility state.
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn is_devtool_visible(&self) -> bool {
+    false
+  }
 }
 
 pub fn platform_webview_version() -> Result<String> {

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -216,7 +216,7 @@ impl InnerWebView {
       settings
         .SetAreDevToolsEnabled(false)
         .map_err(webview2_com::Error::WindowsError)?;
-      if attributes.devtool {
+      if attributes.devtools {
         let _ = settings.SetAreDevToolsEnabled(true);
       }
 
@@ -601,17 +601,17 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
   }
 
   /// Open the web inspector which is usually called dev tool.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn open_devtools(&self) {
     let _ = unsafe { self.webview.OpenDevToolsWindow() };
   }
 
   /// Close the web inspector which is usually called dev tool.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn close_devtools(&self) {}
 
   /// Gets the devtool window's current vibility state.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn is_devtools_visible(&self) -> bool {
     false
   }

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -217,7 +217,7 @@ impl InnerWebView {
         .SetAreDevToolsEnabled(false)
         .map_err(webview2_com::Error::WindowsError)?;
       if attributes.devtool {
-        settings.SetAreDevToolsEnabled(true);
+        let _ = settings.SetAreDevToolsEnabled(true);
       }
 
       let mut rect = RECT::default();
@@ -604,7 +604,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn open_devtool(&self) {
     let _ = unsafe {
-      self.webview.OpenDevToolsWindow();
+      self.webview.OpenDevToolsWindow()
     };
   }
 

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -602,17 +602,17 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
   /// Open the web inspector which is usually called dev tool.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn open_devtool(&self) {
+  pub fn open_devtools(&self) {
     let _ = unsafe { self.webview.OpenDevToolsWindow() };
   }
 
   /// Close the web inspector which is usually called dev tool.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn close_devtool(&self) {}
+  pub fn close_devtools(&self) {}
 
   /// Gets the devtool window's current vibility state.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtool_visible(&self) -> bool {
+  pub fn is_devtools_visible(&self) -> bool {
     false
   }
 }

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -601,7 +601,8 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
   }
 
   /// Open the web inspector which is usually called dev tool.
-  pub fn devtool(&self) {
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn open_devtool(&self) {
     let _ = unsafe {
       self.webview.OpenDevToolsWindow();
     };

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -612,7 +612,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
   /// Gets the devtool window's current vibility state.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtools_visible(&self) -> bool {
+  pub fn is_devtools_open(&self) -> bool {
     false
   }
 }

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -524,7 +524,8 @@ r#"Object.defineProperty(window, 'ipc', {
   ///
   /// ## Platform-specific
   ///
-  /// - **iOS:** Not implemented.
+  /// - **iOS:** Not supported.
+.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn close_devtool(&self) {
     #[cfg(target_os = "macos")]
@@ -539,7 +540,7 @@ r#"Object.defineProperty(window, 'ipc', {
   ///
   /// ## Platform-specific
   ///
-  /// - **iOS:** Not implemented, always returns false.
+  /// - **iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn is_devtool_visible(&self) -> bool {
     #[cfg(target_os = "macos")]

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -510,7 +510,8 @@ r#"Object.defineProperty(window, 'ipc', {
   /// ## Platform-specific
   ///
   /// - **iOS:** Not implemented.
-  pub fn devtool(&self) {
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn open_devtool(&self) {
     #[cfg(target_os = "macos")]
     #[cfg(any(debug_assertions, feature = "devtool"))]
     unsafe {

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -513,12 +513,44 @@ r#"Object.defineProperty(window, 'ipc', {
   #[cfg(any(debug_assertions, feature = "devtool"))]
   pub fn open_devtool(&self) {
     #[cfg(target_os = "macos")]
-    #[cfg(any(debug_assertions, feature = "devtool"))]
     unsafe {
       // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>
       let tool: id = msg_send![self.webview, _inspector];
       let _: id = msg_send![tool, show];
     }
+  }
+
+  /// Close the web inspector which is usually called dev tool.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS:** Not implemented.
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn close_devtool(&self) {
+    #[cfg(target_os = "macos")]
+    unsafe {
+      // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>
+      let tool: id = msg_send![self.webview, _inspector];
+      let _: id = msg_send![tool, close];
+    }
+  }
+
+  /// Gets the devtool window's current vibility state.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS:** Not implemented, always returns false.
+  #[cfg(any(debug_assertions, feature = "devtool"))]
+  pub fn is_devtool_visible(&self) -> bool {
+    #[cfg(target_os = "macos")]
+    unsafe {
+      // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>
+      let tool: id = msg_send![self.webview, _inspector];
+      let is_visible: objc::runtime::BOOL = msg_send![tool, isVisible];
+      is_visible == objc::runtime::YES
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
   }
 
   #[cfg(target_os = "macos")]

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -254,8 +254,8 @@ impl InnerWebView {
       let _preference: id = msg_send![config, preferences];
       let _yes: id = msg_send![class!(NSNumber), numberWithBool:1];
 
-      #[cfg(any(debug_assertions, feature = "devtool"))]
-      if attributes.devtool {
+      #[cfg(any(debug_assertions, feature = "devtools"))]
+      if attributes.devtools {
         // Equivalent Obj-C:
         // [[config preferences] setValue:@YES forKey:@"developerExtrasEnabled"];
         let dev = NSString::new("developerExtrasEnabled");
@@ -510,7 +510,7 @@ r#"Object.defineProperty(window, 'ipc', {
   /// ## Platform-specific
   ///
   /// - **iOS:** Not implemented.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn open_devtools(&self) {
     #[cfg(target_os = "macos")]
     unsafe {
@@ -525,7 +525,7 @@ r#"Object.defineProperty(window, 'ipc', {
   /// ## Platform-specific
   ///
   /// - **iOS:** Not supported.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn close_devtools(&self) {
     #[cfg(target_os = "macos")]
     unsafe {
@@ -540,7 +540,7 @@ r#"Object.defineProperty(window, 'ipc', {
   /// ## Platform-specific
   ///
   /// - **iOS:** Not supported.
-  #[cfg(any(debug_assertions, feature = "devtool"))]
+  #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn is_devtools_visible(&self) -> bool {
     #[cfg(target_os = "macos")]
     unsafe {

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -541,7 +541,7 @@ r#"Object.defineProperty(window, 'ipc', {
   ///
   /// - **iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtools_visible(&self) -> bool {
+  pub fn is_devtools_open(&self) -> bool {
     #[cfg(target_os = "macos")]
     unsafe {
       // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -511,7 +511,7 @@ r#"Object.defineProperty(window, 'ipc', {
   ///
   /// - **iOS:** Not implemented.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn open_devtool(&self) {
+  pub fn open_devtools(&self) {
     #[cfg(target_os = "macos")]
     unsafe {
       // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>
@@ -525,9 +525,8 @@ r#"Object.defineProperty(window, 'ipc', {
   /// ## Platform-specific
   ///
   /// - **iOS:** Not supported.
-.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn close_devtool(&self) {
+  pub fn close_devtools(&self) {
     #[cfg(target_os = "macos")]
     unsafe {
       // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>
@@ -542,7 +541,7 @@ r#"Object.defineProperty(window, 'ipc', {
   ///
   /// - **iOS:** Not supported.
   #[cfg(any(debug_assertions, feature = "devtool"))]
-  pub fn is_devtool_visible(&self) -> bool {
+  pub fn is_devtools_visible(&self) -> bool {
     #[cfg(target_os = "macos")]
     unsafe {
       // taken from <https://github.com/WebKit/WebKit/blob/784f93cb80a386c29186c510bba910b67ce3adc1/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L1939>


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This allows an user to implement shortcuts to open/close the devtools.
