### PR TITLE
Feat/impl wkwebview file upload panel, closes #305

### DIFF
--- a/examples/form.html
+++ b/examples/form.html
@@ -11,7 +11,9 @@
       <label for="fname">First name:</label><br />
       <input type="text" id="fname" name="fname" value="John" /><br />
       <label for="lname">Last name:</label><br />
-      <input type="text" id="lname" name="lname" value="Doe" /><br /><br />
+      <input type="text" id="lname" name="lname" value="Doe" /><br />
+      <label for="thumbnail">Thumbnail:</label><br />
+      <input type="file" id="thumbnail" name="thumbnail" value="Select your thumbnail image" /><br /><br />
       <input type="submit" value="Submit" />
     </form>
     <p>

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -11,7 +11,7 @@ pub use web_context::WebContextImpl;
 #[cfg(target_os = "macos")]
 use cocoa::appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable};
 use cocoa::{
-  base::{id, YES},
+  base::{id, nil, YES},
   foundation::{NSDictionary, NSFastEnumeration, NSInteger},
 };
 
@@ -26,7 +26,7 @@ use std::{
 use core_graphics::geometry::{CGPoint, CGRect, CGSize};
 use objc::{
   declare::ClassDecl,
-  runtime::{Class, Object, Sel},
+  runtime::{Class, Object, Sel, BOOL},
 };
 use objc_id::Id;
 
@@ -356,6 +356,47 @@ impl InnerWebView {
       } else {
         null_mut()
       };
+
+      // File upload panel handler
+      extern "C" fn run_file_upload_panel(
+        _this: &Object,
+        _: Sel,
+        _webview: id,
+        open_panel_params: id,
+        _frame: id,
+        handler: id,
+      ) {
+        unsafe {
+          let handler = handler as *mut block::Block<(id,), c_void>;
+          let cls = class!(NSOpenPanel);
+          let open_panel: id = msg_send![cls, openPanel];
+          let _: () = msg_send![open_panel, setCanChooseFiles: YES];
+          let allow_multi: BOOL = msg_send![open_panel_params, allowsMultipleSelection];
+          let _: () = msg_send![open_panel, setAllowsMultipleSelection: allow_multi];
+          let allow_dir: BOOL = msg_send![open_panel_params, allowsDirectories];
+          let _: () = msg_send![open_panel, setCanChooseDirectories: allow_dir];
+          let ok: NSInteger = msg_send![open_panel, runModal];
+          if ok == 1 {
+            let url: id = msg_send![open_panel, URLs];
+            (*handler).call((url,));
+          } else {
+            (*handler).call((nil,));
+          }
+        }
+      }
+
+      let ui_delegate = match ClassDecl::new("WebViewUIDelegate", class!(NSObject)) {
+        Some(mut ctl) => {
+          ctl.add_method(
+            sel!(webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:),
+            run_file_upload_panel as extern "C" fn(&Object, Sel, id, id, id, id),
+          );
+          ctl.register()
+        }
+        None => class!(UIFileUploadPanelController),
+      };
+      let ui_delegate: id = msg_send![ui_delegate, new];
+      let _: () = msg_send![webview, setUIDelegate: ui_delegate];
 
       // File drop handling
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

I fixed https://github.com/tauri-apps/wry/issues/305.

In this PR, file upload panel will be supported on MacOS.
Including the following features:

- We can select a file when webview get request like `<input type=file>`.
- We can select multiple files when webview get request like `<input type=file multiple>`.
- We can select a directory when webview get request like `<input type=file webkitdirectory>`.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
