### PR TITLE
chore: rename class name for ui delegate

### DIFF
--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -393,7 +393,7 @@ impl InnerWebView {
           );
           ctl.register()
         }
-        None => class!(UIFileUploadPanelController),
+        None => class!(WebViewUIDelegate),
       };
       let ui_delegate: id = msg_send![ui_delegate, new];
       let _: () = msg_send![webview, setUIDelegate: ui_delegate];


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

I'm sorry, I added file upload panel in https://github.com/tauri-apps/wry/pull/545 however I used undeclared class name.
In this PR, I fixed the following error.

```
thread 'main' panicked at 'Class with name UIFileUploadPanelController could not be found', src/webview/wkwebview/mod.rs:396:17
```

You can reproduce with the following steps.
1. run `cargo run --example multi_window`
2. click button
3. panicked

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
