### PR TITLE
fix: reset background process when webview is closed, closes #536

### DIFF
--- a/.changes/stop-background-process.md
+++ b/.changes/stop-background-process.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix to reset process on MacOS when webview is closed, closes #536.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -621,6 +621,11 @@ impl Drop for InnerWebView {
         }
       }
 
+      // WKWebview has a single WKProcessPool to manage web contents.
+      // The WKProcessPool is not reset even if WKWebview is deallocated.
+      // So we need to override the process by navigating to `about:blank`.
+      self.navigate("about:blank");
+
       let _: Id<_> = Id::from_ptr(self.webview);
       #[cfg(target_os = "macos")]
       let _: Id<_> = Id::from_ptr(self.ns_window);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

I fixed issue which didn't stop video when multiple window is closed.
I think this issue was caused by [WKProcessPool](https://developer.apple.com/documentation/webkit/wkprocesspool?language=objc) is singleton.
`WKProcessPool` is not reset even if wkwebview is deallocated.
And I could not find a feature to resolve this problem.
So I think we need to override the process.
But I think this is workaround. If you know a correct way, I will adopt your way.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
