### PR TITLE
fix: disalbe bounce option for macos, closes #557

### DIFF
--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -65,6 +65,8 @@ pub struct WebViewAttributes {
   pub visible: bool,
   /// Whether the WebView should be transparent. Not supported on Windows 7.
   pub transparent: bool,
+  /// Whether the WebView should be bounce. Supported on macOS only.
+  pub bounce: bool,
   /// Whether load the provided URL to [`WebView`].
   pub url: Option<Url>,
   /// Whether load the provided html string to [`WebView`].
@@ -160,6 +162,7 @@ impl Default for WebViewAttributes {
       user_agent: None,
       visible: true,
       transparent: false,
+      bounce: true,
       url: None,
       html: None,
       initialization_scripts: vec![],
@@ -206,6 +209,12 @@ impl<'a> WebViewBuilder<'a> {
   /// Sets whether the WebView should be transparent.
   pub fn with_visible(mut self, visible: bool) -> Self {
     self.webview.visible = visible;
+    self
+  }
+
+  /// Sets whether the WebView should be bounce. Supported on macOS only.
+  pub fn with_bounce(mut self, bounce: bool) -> Self {
+    self.webview.bounce = bounce;
     self
   }
 

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -201,6 +201,7 @@ impl InnerWebView {
       }
     }
     extern "C" fn stop_task(_: &Object, _: Sel, _webview: id, _task: id) {}
+    extern "C" fn scroll_wheel(_: &Object, _: Sel, _event: id) {}
 
     // Safety: objc runtime calls are unsafe
     unsafe {
@@ -244,6 +245,10 @@ impl InnerWebView {
         Some(mut decl) => {
           #[cfg(target_os = "macos")]
           add_file_drop_methods(&mut decl);
+          if !attributes.bounce {
+            #[cfg(target_os = "macos")]
+            decl.add_method(sel!(scrollWheel:), scroll_wheel as extern "C" fn(&Object, Sel, id));
+          }
           decl.register()
         }
         _ => class!(WryWebView),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

I fixed https://github.com/tauri-apps/wry/issues/557.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

For compatibility, bounce is On by default.
