### PR TITLE
Disable WebView2 mini menu ("OOUI") (fix #535)

### DIFF
--- a/.changes/webview2-mini-menu.md
+++ b/.changes/webview2-mini-menu.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Disable webview2 mini menu

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -94,15 +94,18 @@ impl InnerWebView {
 
     CreateCoreWebView2EnvironmentCompletedHandler::wait_for_async_operation(
       Box::new(move |environmentcreatedhandler| unsafe {
-        let options: ICoreWebView2EnvironmentOptions = CoreWebView2EnvironmentOptions::default().into();
+        let options: ICoreWebView2EnvironmentOptions =
+          CoreWebView2EnvironmentOptions::default().into();
 
         // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
         let additional_arguments = pwstr_from_str("--disable-features=msWebOOUI,msPdfOOUI");
         let _ = options.SetAdditionalBrowserArguments(additional_arguments);
-        
-        // if data_directory is None, we set it to a null PWSTR 
-        let data_directory: PWSTR = data_directory.map(|s| pwstr_from_str(&s)).unwrap_or_default();
-        
+
+        // if data_directory is None, we set it to a null PWSTR
+        let data_directory: PWSTR = data_directory
+          .map(|s| pwstr_from_str(&s))
+          .unwrap_or_default();
+
         let result = CreateCoreWebView2EnvironmentWithOptions(
           PWSTR::default(),
           data_directory,

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -94,19 +94,14 @@ impl InnerWebView {
 
     CreateCoreWebView2EnvironmentCompletedHandler::wait_for_async_operation(
       Box::new(move |environmentcreatedhandler| unsafe {
-        let options: ICoreWebView2EnvironmentOptions;
-        options = CoreWebView2EnvironmentOptions::default().into();
+        let options: ICoreWebView2EnvironmentOptions = CoreWebView2EnvironmentOptions::default().into();
 
         // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
         let additional_arguments = pwstr_from_str("--disable-features=msWebOOUI,msPdfOOUI");
         let _ = options.SetAdditionalBrowserArguments(additional_arguments);
         
         // if data_directory is None, we set it to a null PWSTR 
-        let data_directory: PWSTR =
-          match data_directory {
-            Some(s) => pwstr_from_str(&s),
-            None => PWSTR::default(),
-          };
+        let data_directory: PWSTR = data_directory.map(|s| pwstr_from_str(&s)).unwrap_or_default();
         
         let result = CreateCoreWebView2EnvironmentWithOptions(
           PWSTR::default(),

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -94,26 +94,30 @@ impl InnerWebView {
 
     CreateCoreWebView2EnvironmentCompletedHandler::wait_for_async_operation(
       Box::new(move |environmentcreatedhandler| unsafe {
-        if let Some(data_directory) = data_directory {
-          // If we have a custom data_directory, we need to use a call to `CreateCoreWebView2EnvironmentWithOptions`
-          // instead of the much simpler `CreateCoreWebView2Environment`.
-          let options: ICoreWebView2EnvironmentOptions =
-            CoreWebView2EnvironmentOptions::default().into();
-          let data_directory = pwstr_from_str(&data_directory);
-          let result = CreateCoreWebView2EnvironmentWithOptions(
-            PWSTR::default(),
-            data_directory,
-            options,
-            environmentcreatedhandler,
-          )
-          .map_err(webview2_com::Error::WindowsError);
-          let _ = take_pwstr(data_directory);
+        let options: ICoreWebView2EnvironmentOptions;
+        options = CoreWebView2EnvironmentOptions::default().into();
 
-          return result;
-        }
+        // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
+        let additional_arguments = pwstr_from_str("--disable-features=msWebOOUI,msPdfOOUI");
+        let _ = options.SetAdditionalBrowserArguments(additional_arguments);
+        
+        // if data_directory is None, we set it to a null PWSTR 
+        let data_directory: PWSTR =
+          match data_directory {
+            Some(s) => pwstr_from_str(&s),
+            None => PWSTR::default(),
+          };
+        
+        let result = CreateCoreWebView2EnvironmentWithOptions(
+          PWSTR::default(),
+          data_directory,
+          options,
+          environmentcreatedhandler,
+        )
+        .map_err(webview2_com::Error::WindowsError);
+        let _ = take_pwstr(data_directory);
 
-        CreateCoreWebView2Environment(environmentcreatedhandler)
-          .map_err(webview2_com::Error::WindowsError)
+        return result;
       }),
       Box::new(move |error_code, environment| {
         error_code?;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Other information
This disables the "mini menu" referenced in #535 by using the `AdditionalBrowserArguments` when creating the WebView2 environment. 

Previously, `CreateCoreWebView2EnvironmentWithOptions(..)` was only called when `data_directory` in `WebContext` was set, otherwise just `CreateCoreWebView2Environment(..)`. I have changed it a bit to always call it "with options", and passing `PWSTR::default()` as a data directory if none was given. 

Existing behaviour has not been changed, just the "mini menu" has been disabled.