### PR TITLE
fix(macos): set titlebar style to `none`

### DIFF
--- a/.changes/macos-remove-titlebar-separator.md
+++ b/.changes/macos-remove-titlebar-separator.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Set the titlebar separator style in macOS to `none`.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -411,7 +411,14 @@ impl InnerWebView {
 
       // ns window is required for the print operation
       #[cfg(target_os = "macos")]
-      let ns_window = window.ns_window() as id;
+      let ns_window = {
+        let ns_window = window.ns_window() as id;
+
+        // `1` means `none`, see https://developer.apple.com/documentation/appkit/nstitlebarseparatorstyle/none
+        let () = msg_send![ns_window, setTitlebarSeparatorStyle: 1];
+
+        ns_window
+      };
 
       let w = Self {
         webview,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This isn't exactly a bug, but it's also not something I could see in other macOS applications, so I just set it to `none`.

See https://github.com/tauri-apps/tauri/issues/3801