### PR TITLE
fix(macos): crash when custom protocol response is empty

### DIFF
--- a/.changes/fix-macos-protocol-crash.md
+++ b/.changes/fix-macos-protocol-crash.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes a crash when the custom protocol response is empty on macOS.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -11,7 +11,7 @@ pub use web_context::WebContextImpl;
 #[cfg(target_os = "macos")]
 use cocoa::appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable};
 use cocoa::{
-  base::{id, nil, YES},
+  base::{id, nil, NO, YES},
   foundation::{NSDictionary, NSFastEnumeration, NSInteger},
 };
 
@@ -183,8 +183,7 @@ impl InnerWebView {
             // Send data
             let bytes = content.as_ptr() as *mut c_void;
             let data: id = msg_send![class!(NSData), alloc];
-            let data: id =
-              msg_send![data, initWithBytesNoCopy:bytes length:content.len() freeWhenDone: YES];
+            let data: id = msg_send![data, initWithBytesNoCopy:bytes length:content.len() freeWhenDone: if content.len() == 0 { NO } else { YES }];
             let () = msg_send![task, didReceiveData: data];
           } else {
             let urlresponse: id = msg_send![class!(NSHTTPURLResponse), alloc];


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

I found this crash in the streaming example (tauri repo). When the response is empty (e.g. `return ResponseBuilder::new().mimetype("text/plain").status(404).body(Vec::new())`), the app was crashing with this report:
```
streaming(13585,0x103b90580) malloc: *** error for object 0x1: pointer being freed was not allocated
streaming(13585,0x103b90580) malloc: *** set a breakpoint in malloc_error_break to debug
```
This change fixes it, setting freeWhenDone to `NO` if the response buffer is empty.
