### PR TITLE
fix(macos): typo in the WebviewExtMacOS conditional compilation

### DIFF
--- a/.changes/fix-WebviewExtMacOS.md
+++ b/.changes/fix-WebviewExtMacOS.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes a typo in the `WebviewExtMacOS` conditional compilation.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -557,7 +557,7 @@ impl WebviewExtUnix for WebView {
 }
 
 /// Additional methods on `WebView` that are specific to macOS.
-#[cfg(target_os = "macOS")]
+#[cfg(target_os = "macos")]
 pub trait WebviewExtMacOS {
   /// Returns WKWebView handle
   fn webview(&self) -> cocoa::base::id;
@@ -567,7 +567,7 @@ pub trait WebviewExtMacOS {
   fn ns_window(&self) -> cocoa::base::id;
 }
 
-#[cfg(target_os = "macOS")]
+#[cfg(target_os = "macos")]
 impl WebviewExtMacOS for WebView {
   fn webview(&self) -> cocoa::base::id {
     self.webview.webview.clone()

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -52,10 +52,10 @@ use crate::http::{
 };
 
 pub struct InnerWebView {
-  webview: id,
+  pub(crate) webview: id,
   #[cfg(target_os = "macos")]
-  ns_window: id,
-  manager: id,
+  pub(crate) ns_window: id,
+  pub(crate) manager: id,
   // Note that if following functions signatures are changed in the future,
   // all fucntions pointer declarations in objc callbacks below all need to get updated.
   ipc_handler_ptr: *mut (Box<dyn Fn(&Window, String)>, Rc<Window>),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
