### PR TITLE
Change time format for benchmarks to match Electron and Tauri

### DIFF
--- a/bench/src/run_benchmark.rs
+++ b/bench/src/run_benchmark.rs
@@ -258,8 +258,11 @@ fn main() -> Result<()> {
   let target_dir = utils::target_dir();
   env::set_current_dir(&utils::bench_root_path())?;
 
+  let format = time::format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z").unwrap();
+  let now = time::OffsetDateTime::now_utc();
+
   let mut new_data = utils::BenchResult {
-    created_at: format!("{}", time::OffsetDateTime::now_utc()),
+    created_at: format!("{}", now.format(&format).unwrap()),
     sha1: utils::run_collect(&["git", "rev-parse", "HEAD"])
       .0
       .trim()


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Updated benchmark output format

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
This only changes the benchmark `created_at` formatting for the date/timestamp to match the output format from the Tauri and Electron benchmark repos. After this is approved, a manual change will most likely be performed on the historical benchmark data for this repo to update the old values up to this format. 