### PR TITLE
WebView2: Enable/disable platform default zooming shortcuts, closes #569

### DIFF
--- a/.changes/allow-zooming.md
+++ b/.changes/allow-zooming.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add option to enable/disable zoom shortcuts for WebView2, disabled by default.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -68,8 +68,11 @@ pub struct WebViewAttributes {
   /// Whether load the provided URL to [`WebView`].
   pub url: Option<Url>,
   /// Whether page zooming by hotkeys is enabled
-  /// Supported only on Windows (WebView2)
-  pub zoom_enabled: bool,
+  ///
+  /// ## Platform-specific
+  ///
+  /// **macOS / Linux / Android / iOS**: Unsupported
+  pub zoom_hotkeys_enabled: bool,
   /// Whether load the provided html string to [`WebView`].
   /// This will be ignored if the `url` is provided.
   ///
@@ -172,7 +175,7 @@ impl Default for WebViewAttributes {
       navigation_handler: None,
       clipboard: false,
       devtools: false,
-      zoom_enabled: false,
+      zoom_hotkeys_enabled: false,
     }
   }
 }
@@ -346,8 +349,8 @@ impl<'a> WebViewBuilder<'a> {
   ///   "*Two finger pinch*" on a touch screen or trackpad
   /// - Other: No effect
   #[cfg(target_os = "windows")]
-  pub fn with_zoom(mut self, zoom: bool) -> Self {
-    self.webview.zoom_enabled = zoom;
+  pub fn with_hotkeys_zoom(mut self, zoom: bool) -> Self {
+    self.webview.zoom_hotkeys_enabled = zoom;
     self
   }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -67,6 +67,9 @@ pub struct WebViewAttributes {
   pub transparent: bool,
   /// Whether load the provided URL to [`WebView`].
   pub url: Option<Url>,
+  /// Whether page zooming by hotkeys is enabled
+  /// Supported only on Windows (WebView2)
+  pub zoom_enabled: bool,
   /// Whether load the provided html string to [`WebView`].
   /// This will be ignored if the `url` is provided.
   ///
@@ -169,6 +172,7 @@ impl Default for WebViewAttributes {
       navigation_handler: None,
       clipboard: false,
       devtools: false,
+      zoom_enabled: false,
     }
   }
 }
@@ -330,6 +334,19 @@ impl<'a> WebViewBuilder<'a> {
   /// - iOS: Open Safari > Develop > [Your Device Name] > [Your WebView] to get the devtools window.
   pub fn with_devtools(mut self, devtools: bool) -> Self {
     self.webview.devtools = devtools;
+    self
+  }
+
+  /// Allow or disallow overriding the zoom level by platform dependant
+  /// shortcuts
+  /// 
+  /// ## Platform-specific
+  ///
+  /// - Windows: Enable/Disable zooming by `Ctrl` and `+` / `-`
+  /// - Other: No effect
+  #[cfg(target_os = "windows")]
+  pub fn with_zoom(mut self, zoom: bool) -> Self {
+    self.webview.zoom_enabled = zoom;
     self
   }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -338,11 +338,12 @@ impl<'a> WebViewBuilder<'a> {
   }
 
   /// Allow or disallow overriding the zoom level by platform dependant
-  /// shortcuts
-  /// 
+  /// shortcuts or gestures. By default, zoom overriding is disabled
+  ///
   /// ## Platform-specific
   ///
-  /// - Windows: Enable/Disable zooming by `Ctrl` and `+` / `-`
+  /// - Windows: Enable/Disable zooming by `Ctrl` and `+` / `-` or
+  ///   "*Two finger pinch*" on a touch screen or trackpad
   /// - Other: No effect
   #[cfg(target_os = "windows")]
   pub fn with_zoom(mut self, zoom: bool) -> Self {

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -345,7 +345,6 @@ impl<'a> WebViewBuilder<'a> {
   /// ## Platform-specific
   ///
   /// **macOS / Linux / Android / iOS**: Unsupported
-  #[cfg(target_os = "windows")]
   pub fn with_hotkeys_zoom(mut self, zoom: bool) -> Self {
     self.webview.zoom_hotkeys_enabled = zoom;
     self

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -340,14 +340,11 @@ impl<'a> WebViewBuilder<'a> {
     self
   }
 
-  /// Allow or disallow overriding the zoom level by platform dependant
-  /// shortcuts or gestures. By default, zoom overriding is disabled
+  /// Whether page zooming by hotkeys or gestures is enabled
   ///
   /// ## Platform-specific
   ///
-  /// - Windows: Enable/Disable zooming by `Ctrl` and `+` / `-` or
-  ///   "*Two finger pinch*" on a touch screen or trackpad
-  /// - Other: No effect
+  /// **macOS / Linux / Android / iOS**: Unsupported
   #[cfg(target_os = "windows")]
   pub fn with_hotkeys_zoom(mut self, zoom: bool) -> Self {
     self.webview.zoom_hotkeys_enabled = zoom;

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -222,10 +222,8 @@ impl InnerWebView {
         let _ = settings.SetAreDevToolsEnabled(true);
       }
 
-      let settings5 = settings.cast::<ICoreWebView2Settings5>();
-      if settings5.is_ok() {
-        let _ = settings5?.SetIsPinchZoomEnabled(attributes.zoom_hotkeys_enabled);
-      }
+      let settings5 = settings.cast::<ICoreWebView2Settings5>()?;
+      let _ = settings5.SetIsPinchZoomEnabled(attributes.zoom_hotkeys_enabled);
 
       let mut rect = RECT::default();
       GetClientRect(hwnd, &mut rect);

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -222,6 +222,11 @@ impl InnerWebView {
         let _ = settings.SetAreDevToolsEnabled(true);
       }
 
+      let settings5 = settings.cast::<ICoreWebView2Settings5>();
+      if settings5.is_ok() {
+        let _ = settings5?.SetIsPinchZoomEnabled(attributes.zoom_enabled);
+      }
+
       let mut rect = RECT::default();
       GetClientRect(hwnd, &mut rect);
       controller

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -213,7 +213,7 @@ impl InnerWebView {
         .SetAreDefaultContextMenusEnabled(true)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
-        .SetIsZoomControlEnabled(attributes.zoom_enabled)
+        .SetIsZoomControlEnabled(attributes.zoom_hotkeys_enabled)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
         .SetAreDevToolsEnabled(false)
@@ -224,7 +224,7 @@ impl InnerWebView {
 
       let settings5 = settings.cast::<ICoreWebView2Settings5>();
       if settings5.is_ok() {
-        let _ = settings5?.SetIsPinchZoomEnabled(attributes.zoom_enabled);
+        let _ = settings5?.SetIsPinchZoomEnabled(attributes.zoom_hotkeys_enabled);
       }
 
       let mut rect = RECT::default();

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -213,7 +213,7 @@ impl InnerWebView {
         .SetAreDefaultContextMenusEnabled(true)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
-        .SetIsZoomControlEnabled(false)
+        .SetIsZoomControlEnabled(attributes.zoom_enabled)
         .map_err(webview2_com::Error::WindowsError)?;
       settings
         .SetAreDevToolsEnabled(false)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
By default, platform default zoom is disabled. This will also disable zooming by trackpad or touchscreen which was previously not the case.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
I absolutely agree with wry's approach to have default zooming disabled by default. However, I think there are many valid use cases where it makes sense to have the option to enable it.

Thank you for considering.