### PR TITLE
Update windows-rs to 0.37.0 and webview2-com to 0.16.0 to match

### DIFF
--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -2,6 +2,6 @@
 "wry": patch
 ---
 
-Update the windows-rs crate to the latest 0.37.0 release and webview2-com to 0.16.0 to match.
+Update the `windows` crate to the latest 0.37.0 release and `webview2-com` to 0.16.0 to match.
 
-This version of windows-rs depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.
+The `#[implement]` macro in `windows-implement` depends on `const` generic features which were just stabilized in `rustc` version 1.61, so this change also adds a `rust-version` attribute to the manifest setting the MSRV to 1.61.

--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -2,6 +2,8 @@
 "wry": patch
 ---
 
-Update the windows-rs crate to the latest 0.37.0 release and webview2-com to 0.16.0 to match.
+Update the `windows` crate to the latest 0.37.0 release and `webview2-com` to 0.16.0 to match.
 
-This version of windows-rs depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.
+The `#[implement]` macro in `windows-implement` and the `implement` feature in `windows` depend on some `const` generic features which stabilized in `rustc` 1.61. The MSRV on Windows targets is effectively 1.61, but other targets do not require these features.
+
+The `webview2-com` crate specifies `rust-version = "1.61"`, so `wry` will inherit that MSRV and developers on Windows should get a clear error message telling them to update their toolchain when building `wry` or anything that depends on `wry`. Developers targeting other platforms should be able to continue using whatever toolchain they were using before.

--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -2,6 +2,6 @@
 "wry": patch
 ---
 
-Update the `windows` crate to the latest 0.37.0 release and `webview2-com` to 0.16.0 to match.
+Update the windows-rs crate to the latest 0.37.0 release and webview2-com to 0.16.0 to match.
 
-The `#[implement]` macro in `windows-implement` depends on `const` generic features which were just stabilized in `rustc` version 1.61, so this change also adds a `rust-version` attribute to the manifest setting the MSRV to 1.61.
+This version of windows-rs depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.

--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -1,0 +1,7 @@
+---
+"wry": patch
+---
+
+Update the windows-rs crate to the latest 0.37.0 release and webview2-com to 0.16.0 to match.
+
+This version of windows-rs depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ gtk = "0.15"
 gdk = "0.15"
 
 [target."cfg(target_os = \"windows\")".dependencies]
-webview2-com = "0.13.0"
+webview2-com = "0.14.0"
 windows-implement = "0.32.0"
 sys-info = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ name = "wry"
 version = "0.16.2"
 authors = [ "Tauri Programme within The Commons Conservancy" ]
 edition = "2021"
+rust-version = "1.61"
 license = "Apache-2.0 OR MIT"
 description = "Cross-platform WebView rendering library"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ devtool = [ ]
 transparent = [ ]
 fullscreen = [ ]
 
+[patch.crates-io]
+tao = { git = "https://github.com/wravery/tao", branch = "windows-0.32.0" }
+webview2-com = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.32.0" }
+webview2-com-macros = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.32.0" }
+webview2-com-sys = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.32.0" }
+
 [dependencies]
 libc = "0.2"
 log = "0.4"
@@ -57,14 +63,15 @@ gtk = "0.15"
 gdk = "0.15"
 
 [target."cfg(target_os = \"windows\")".dependencies]
-webview2-com = "0.11.0"
-windows_macros = "0.30.0"
+webview2-com = "0.13.0"
+windows-implement = "0.32.0"
 sys-info = "0.9"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.30.0"
+  version = "0.32.0"
   features = [
   "alloc",
+  "implement",
   "Win32_Foundation",
   "Win32_Graphics_Gdi",
   "Win32_System_Com",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,6 @@ devtools = [ ]
 transparent = [ ]
 fullscreen = [ ]
 
-[patch.crates-io]
-tao = { git = "https://github.com/wravery/tao", branch = "windows-0.37.0" }
-
 [dependencies]
 libc = "0.2"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ transparent = [ ]
 fullscreen = [ ]
 
 [patch.crates-io]
-tao = { git = "https://github.com/wravery/tao", branch = "windows-0.32.0" }
-webview2-com = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.32.0" }
-webview2-com-macros = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.32.0" }
-webview2-com-sys = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.32.0" }
+tao = { git = "https://github.com/wravery/tao", branch = "windows-0.33.0" }
+webview2-com = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.33.0" }
+webview2-com-macros = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.33.0" }
+webview2-com-sys = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.33.0" }
 
 [dependencies]
 libc = "0.2"
@@ -65,10 +65,10 @@ gdk = "0.15"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 webview2-com = "0.14.0"
-windows-implement = "0.32.0"
+windows-implement = "0.33.0"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.32.0"
+  version = "0.33.0"
   features = [
   "alloc",
   "implement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ transparent = [ ]
 fullscreen = [ ]
 
 [patch.crates-io]
-tao = { git = "https://github.com/wravery/tao", branch = "windows-0.33.0" }
-webview2-com = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.33.0" }
-webview2-com-macros = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.33.0" }
-webview2-com-sys = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.33.0" }
+tao = { git = "https://github.com/wravery/tao", branch = "windows-0.36.1" }
+webview2-com = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.36.1" }
+webview2-com-macros = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.36.1" }
+webview2-com-sys = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.36.1" }
 
 [dependencies]
 libc = "0.2"
@@ -71,11 +71,11 @@ gtk = "0.15"
 gdk = "0.15"
 
 [target."cfg(target_os = \"windows\")".dependencies]
-webview2-com = "0.14.0"
-windows-implement = "0.33.0"
+webview2-com = "0.16.0"
+windows-implement = "0.36.1"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.33.0"
+  version = "0.36.1"
   features = [
   "alloc",
   "implement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.2"
-tao = { version = "0.9.0", default-features = false, features = [ "serde" ] }
+tao = { version = "0.9.1", default-features = false, features = [ "serde" ] }
 http = "0.2.7"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,9 @@ windows-implement = "0.37.0"
   "Win32_Graphics_Gdi",
   "Win32_System_Com",
   "Win32_System_Com_StructuredStorage",
-  "Win32_System_SystemInformation",
+  "Win32_System_LibraryLoader",
   "Win32_System_Ole",
+  "Win32_System_SystemInformation",
   "Win32_System_SystemServices",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,7 @@ transparent = [ ]
 fullscreen = [ ]
 
 [patch.crates-io]
-tao = { git = "https://github.com/wravery/tao", branch = "windows-0.36.1" }
-webview2-com = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.36.1" }
-webview2-com-macros = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.36.1" }
-webview2-com-sys = { git = "https://github.com/wravery/webview2-rs", branch = "windows-0.36.1" }
+tao = { git = "https://github.com/wravery/tao", branch = "windows-0.37.0" }
 
 [dependencies]
 libc = "0.2"
@@ -72,10 +69,10 @@ gdk = "0.15"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 webview2-com = "0.16.0"
-windows-implement = "0.36.1"
+windows-implement = "0.37.0"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.36.1"
+  version = "0.37.0"
   features = [
   "alloc",
   "implement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ name = "wry"
 version = "0.16.2"
 authors = [ "Tauri Programme within The Commons Conservancy" ]
 edition = "2021"
-rust-version = "1.61"
 license = "Apache-2.0 OR MIT"
 description = "Cross-platform WebView rendering library"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.2"
-tao = { version = "0.8.4", default-features = false, features = [ "serde" ] }
+tao = { version = "0.9.0", default-features = false, features = [ "serde" ] }
 http = "0.2.7"
 
 [dev-dependencies]

--- a/src/webview/webview2/file_drop.rs
+++ b/src/webview/webview2/file_drop.rs
@@ -156,7 +156,7 @@ impl FileDropHandler {
 
           // Fill path_buf with the null-terminated file name
           let mut path_buf = Vec::with_capacity(str_len);
-          DragQueryFileW(hdrop, i, &mut path_buf);
+          DragQueryFileW(hdrop, i, std::mem::transmute(path_buf.spare_capacity_mut()));
           path_buf.set_len(str_len);
 
           paths.push(OsString::from_wide(&path_buf[0..character_count]).into());

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -16,9 +16,9 @@ use std::{collections::HashSet, rc::Rc, sync::mpsc};
 use once_cell::unsync::OnceCell;
 
 use windows::{
-  core::Interface,
+  core::{Interface, PCWSTR, PWSTR},
   Win32::{
-    Foundation::{BOOL, E_FAIL, E_POINTER, FARPROC, HWND, POINT, PWSTR, RECT},
+    Foundation::{BOOL, E_FAIL, E_POINTER, FARPROC, HWND, POINT, RECT},
     System::{
       Com::{IStream, StructuredStorage::CreateStreamOnHGlobal},
       LibraryLoader::{GetProcAddress, LoadLibraryA},
@@ -101,8 +101,8 @@ impl InnerWebView {
             CoreWebView2EnvironmentOptions::default().into();
           let data_directory = pwstr_from_str(&data_directory);
           let result = CreateCoreWebView2EnvironmentWithOptions(
-            PWSTR::default(),
-            data_directory,
+            PCWSTR::default(),
+            PCWSTR(data_directory.0),
             options,
             environmentcreatedhandler,
           )
@@ -589,7 +589,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
 pub fn platform_webview_version() -> Result<String> {
   let mut versioninfo = PWSTR::default();
-  unsafe { GetAvailableCoreWebView2BrowserVersionString(PWSTR::default(), &mut versioninfo) }
+  unsafe { GetAvailableCoreWebView2BrowserVersionString(PCWSTR::default(), &mut versioninfo) }
     .map_err(webview2_com::Error::WindowsError)?;
   Ok(take_pwstr(versioninfo))
 }

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -267,7 +267,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
                 let mut point = POINT::default();
                 GetCursorPos(&mut point);
-                let result = hit_test(HWND(window.hwnd() as _), point.x, point.y);
+                let result = hit_test(window.hwnd(), point.x, point.y);
                 let cursor = match result.0 as u32 {
                   win32wm::HTLEFT => CursorIcon::WResize,
                   win32wm::HTTOP => CursorIcon::NResize,

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -215,7 +215,9 @@ impl InnerWebView {
         .SetAreDevToolsEnabled(false)
         .map_err(webview2_com::Error::WindowsError)?;
       if attributes.devtool {
-        settings.SetAreDevToolsEnabled(true);
+        settings
+          .SetAreDevToolsEnabled(true)
+          .map_err(webview2_com::Error::WindowsError)?;
       }
 
       let mut rect = RECT::default();
@@ -577,8 +579,8 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
   /// Open the web insepctor which is usually called dev tool.
   pub fn devtool(&self) {
-    let _ = unsafe {
-      self.webview.OpenDevToolsWindow();
+    unsafe {
+      let _ = self.webview.OpenDevToolsWindow();
     };
   }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Starting as a draft PR because I still have a patch override in `Cargo.toml` to pull the matching version of `tao` in https://github.com/tauri-apps/tao/pull/400.

As in that PR, updating to this version of `windows-rs` raises the MSRV on Windows to 1.61, which was just released to the `stable` channel today. 🎉 