### PR TITLE
Fix dont panic on builtin protocol

### DIFF
--- a/.changes/fix-dont-panic-on-builtin-protocol.md
+++ b/.changes/fix-dont-panic-on-builtin-protocol.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Return `Error::DuplicateCustomProtocol` when trying to register a builtin protocol on macOS instead of panicking.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -205,10 +205,29 @@ impl InnerWebView {
 
     // Safety: objc runtime calls are unsafe
     unsafe {
+      // Webview
+      let cls = match ClassDecl::new("WryWebView", class!(WKWebView)) {
+        #[allow(unused_mut)]
+        Some(mut decl) => {
+          #[cfg(target_os = "macos")]
+          add_file_drop_methods(&mut decl);
+          decl.register()
+        }
+        _ => class!(WryWebView),
+      };
+      let webview: id = msg_send![cls, alloc];
+      
       // Config and custom protocol
       let config: id = msg_send![class!(WKWebViewConfiguration), new];
       let mut protocol_ptrs = Vec::new();
       for (name, function) in attributes.custom_protocols {
+        // Attempting to override builtin protocols would normally raise an exception. 
+        // We check here to gracefully handle these situations.
+        #[cfg(debug_assertions)]
+        if msg_send![webview, handlesURLScheme: NSString::new(&name)] {
+          return Err(crate::Error::DuplicateCustomProtocol(name));
+        }
+        
         let scheme_name = format!("{}URLSchemeHandler", name);
         let cls = ClassDecl::new(&scheme_name, class!(NSObject));
         let cls = match cls {
@@ -238,18 +257,8 @@ impl InnerWebView {
         let () = msg_send![config, setURLSchemeHandler:handler forURLScheme:NSString::new(&name)];
       }
 
-      // Webview and manager
+      // Manager
       let manager: id = msg_send![config, userContentController];
-      let cls = match ClassDecl::new("WryWebView", class!(WKWebView)) {
-        #[allow(unused_mut)]
-        Some(mut decl) => {
-          #[cfg(target_os = "macos")]
-          add_file_drop_methods(&mut decl);
-          decl.register()
-        }
-        _ => class!(WryWebView),
-      };
-      let webview: id = msg_send![cls, alloc];
       let _preference: id = msg_send![config, preferences];
       let _yes: id = msg_send![class!(NSNumber), numberWithBool:1];
 

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -221,7 +221,7 @@ impl InnerWebView {
       let config: id = msg_send![class!(WKWebViewConfiguration), new];
       let mut protocol_ptrs = Vec::new();
       for (name, function) in attributes.custom_protocols {
-        // Attempting to override builtin protocols would normally raise an exception. 
+        // Attempting to override builtin protocols would normally throw an exception. 
         // We check here to gracefully handle these situations.
         #[cfg(debug_assertions)]
         if msg_send![webview, handlesURLScheme: NSString::new(&name)] {

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -216,18 +216,18 @@ impl InnerWebView {
         _ => class!(WryWebView),
       };
       let webview: id = msg_send![cls, alloc];
-      
+
       // Config and custom protocol
       let config: id = msg_send![class!(WKWebViewConfiguration), new];
       let mut protocol_ptrs = Vec::new();
       for (name, function) in attributes.custom_protocols {
-        // Attempting to override builtin protocols would normally throw an exception. 
+        // Attempting to override builtin protocols would normally throw an exception.
         // We check here to gracefully handle these situations.
         #[cfg(debug_assertions)]
         if msg_send![webview, handlesURLScheme: NSString::new(&name)] {
           return Err(crate::Error::DuplicateCustomProtocol(name));
         }
-        
+
         let scheme_name = format!("{}URLSchemeHandler", name);
         let cls = ClassDecl::new(&scheme_name, class!(NSObject));
         let cls = match cls {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Attempting to override a builtin protocol (such as `ws://` or `http://`) will throw an objc exception. This PR adds a check that returns an error (`Error::DuplicateCustomProtocol`)