### PR TITLE
fix: add feature flag to enable private picture-in-picture flag on macos

### DIFF
--- a/.changes/pistureinpicture-feature-flag.md
+++ b/.changes/pistureinpicture-feature-flag.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Add feature flag to enable private picture-in-picture flag on macos.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tray = [ "tao/tray" ]
 devtools = [ ]
 transparent = [ ]
 fullscreen = [ ]
+pictureInPicture = [ ]
 
 [dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ tray = [ "tao/tray" ]
 devtools = [ ]
 transparent = [ ]
 fullscreen = [ ]
-pictureInPicture = [ ]
 
 [dependencies]
 libc = "0.2"

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -261,7 +261,6 @@ impl InnerWebView {
         let _: id = msg_send![_preference, setValue:_yes forKey:dev];
       }
 
-      #[cfg(feature = "pictureInPicture")]
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("allowsPictureInPictureMediaPlayback")];
 
       #[cfg(target_os = "macos")]

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -261,6 +261,9 @@ impl InnerWebView {
         let _: id = msg_send![_preference, setValue:_yes forKey:dev];
       }
 
+      #[cfg(feature = "pictureInPicture")]
+      let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("allowsPictureInPictureMediaPlayback")];
+
       #[cfg(target_os = "macos")]
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("tabFocusesLinks")];
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

issue is https://github.com/tauri-apps/wry/issues/644
