### PR TITLE
feat(mobile): configure URLs to be allowed to load with self signed cert

### DIFF
--- a/.changes/self-signed-cert.md
+++ b/.changes/self-signed-cert.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Added `WebViewBuilder::with_allowed_self_signed_cert_url` API to allow an URL with self signed certificate to be loaded on mobile, useful for development servers.

--- a/src/webview/android/binding.rs
+++ b/src/webview/android/binding.rs
@@ -2,14 +2,15 @@ use crate::http::{
   header::{HeaderName, HeaderValue},
   RequestBuilder,
 };
-use tao::platform::android::ndk_glue::jni::{
+pub use tao::platform::android::ndk_glue::jni::{
   errors::Error as JniError,
   objects::{JClass, JMap, JObject, JString},
-  sys::jobject,
+  sys::{jboolean, jobject},
   JNIEnv,
 };
+use url::Url;
 
-use super::{MainPipe, WebViewMessage, IPC, REQUEST_HANDLER};
+use super::{MainPipe, WebViewMessage, ALLOW_SSL_ERROR_HANDLER, IPC, REQUEST_HANDLER};
 
 #[allow(non_snake_case)]
 pub unsafe fn runInitializationScripts(_: JNIEnv, _: JClass, _: JObject) {
@@ -111,6 +112,23 @@ pub unsafe fn handleRequest(env: JNIEnv, _: JClass, request: JObject) -> jobject
       log::error!("Failed to handle request: {}", e);
       *JObject::null()
     }
+  }
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn allowSslError(env: JNIEnv, _: JClass, url: JString) -> jboolean {
+  if let Some(handler) = ALLOW_SSL_ERROR_HANDLER.get() {
+    if let Ok(url) = env
+      .get_string(url)
+      .map_err(|_| ())
+      .and_then(|url| Url::parse(&url.to_string_lossy()).map_err(|_| ()))
+    {
+      (handler.0)(url).into()
+    } else {
+      0
+    }
+  } else {
+    0
   }
 }
 

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -10,6 +10,7 @@ use tao::platform::android::ndk_glue::{
   jni::{objects::GlobalRef, JNIEnv},
   ndk::looper::{FdEvent, ForeignLooper},
 };
+use url::Url;
 
 pub(crate) mod binding;
 mod main_pipe;
@@ -42,12 +43,24 @@ macro_rules! android_binding {
       JObject,
       jobject
     );
+    android_fn!(
+      $domain,
+      $package,
+      RustWebViewClient,
+      allowSslError,
+      JString,
+      jboolean
+    );
     android_fn!($domain, $package, Ipc, ipc, JString);
   };
 }
 
 pub static IPC: OnceCell<UnsafeIpc> = OnceCell::new();
-pub static REQUEST_HANDLER: OnceCell<UnsafeRequestHandler> = OnceCell::new();
+pub static REQUEST_HANDLER: OnceCell<
+  UnsafeClosure<Box<dyn Fn(HttpRequest) -> Option<HttpResponse>>>,
+> = OnceCell::new();
+pub static ALLOW_SSL_ERROR_HANDLER: OnceCell<UnsafeClosure<Box<dyn Fn(Url) -> bool>>> =
+  OnceCell::new();
 
 pub struct UnsafeIpc(Box<dyn Fn(&Window, String)>, Rc<Window>);
 impl UnsafeIpc {
@@ -58,14 +71,14 @@ impl UnsafeIpc {
 unsafe impl Send for UnsafeIpc {}
 unsafe impl Sync for UnsafeIpc {}
 
-pub struct UnsafeRequestHandler(Box<dyn Fn(HttpRequest) -> Option<HttpResponse>>);
-impl UnsafeRequestHandler {
-  pub fn new(f: Box<dyn Fn(HttpRequest) -> Option<HttpResponse>>) -> Self {
+pub struct UnsafeClosure<T>(T);
+impl<T> UnsafeClosure<T> {
+  pub fn new(f: T) -> Self {
     Self(f)
   }
 }
-unsafe impl Send for UnsafeRequestHandler {}
-unsafe impl Sync for UnsafeRequestHandler {}
+unsafe impl<T> Send for UnsafeClosure<T> {}
+unsafe impl<T> Sync for UnsafeClosure<T> {}
 
 pub unsafe fn setup(env: JNIEnv, looper: &ForeignLooper, activity: GlobalRef) {
   let mut main_pipe = MainPipe {
@@ -107,6 +120,7 @@ impl InnerWebView {
       ipc_handler,
       devtools,
       custom_protocols,
+      allowed_self_signed_cert_urls,
       ..
     } = attributes;
 
@@ -130,8 +144,16 @@ impl InnerWebView {
       ));
     }
 
+    ALLOW_SSL_ERROR_HANDLER.get_or_init(move || {
+      UnsafeClosure::new(Box::new(move |url| {
+        allowed_self_signed_cert_urls
+          .iter()
+          .any(|u| u.host().is_some() && u.host() == url.host())
+      }))
+    });
+
     REQUEST_HANDLER.get_or_init(move || {
-      UnsafeRequestHandler::new(Box::new(move |mut request| {
+      UnsafeClosure::new(Box::new(move |mut request| {
         if let Some(custom_protocol) = custom_protocols
           .iter()
           .find(|(name, _)| request.uri().starts_with(&format!("https://{}.", name)))

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -166,7 +166,7 @@ pub struct WebViewAttributes {
   ///
   /// ## Platform-specific
   ///
-  /// - **macOS / Windows / Linux**: Not implemented.
+  /// - **Windows / Linux**: Not implemented.
   pub allowed_self_signed_cert_urls: Vec<Url>,
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -162,6 +162,12 @@ pub struct WebViewAttributes {
   /// - Android: Open `chrome://inspect/#devices` in Chrome to get the devtools window. Wry's `WebView` devtools API isn't supported on Android.
   /// - iOS: Open Safari > Develop > [Your Device Name] > [Your WebView] to get the devtools window.
   pub devtools: bool,
+  /// A list of URLs that are allowed to be loaded with a self-signed certificate.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **macOS / Windows / Linux**: Not implemented.
+  pub allowed_self_signed_cert_urls: Vec<Url>,
 }
 
 impl Default for WebViewAttributes {
@@ -181,6 +187,7 @@ impl Default for WebViewAttributes {
       clipboard: false,
       devtools: false,
       zoom_hotkeys_enabled: false,
+      allowed_self_signed_cert_urls: vec![],
     }
   }
 }
@@ -383,6 +390,17 @@ impl<'a> WebViewBuilder<'a> {
     callback: impl Fn(String) -> bool + 'static,
   ) -> Self {
     self.webview.new_window_req_handler = Some(Box::new(callback));
+    self
+  }
+
+  /// Configures the given URL to be allowed to load with a self-signed certificate.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **macOS / Windows / Linux**: Not implemented.
+  #[must_use]
+  pub fn with_allowed_self_signed_cert_url(mut self, url: Url) -> Self {
+    self.webview.allowed_self_signed_cert_urls.push(url);
     self
   }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -397,7 +397,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **macOS / Windows / Linux**: Not implemented.
+  /// - **Windows / Linux**: Not implemented.
   #[must_use]
   pub fn with_allowed_self_signed_cert_url(mut self, url: Url) -> Self {
     self.webview.allowed_self_signed_cert_urls.push(url);

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -6,6 +6,7 @@
 mod file_drop;
 mod web_context;
 
+use url::Url;
 pub use web_context::WebContextImpl;
 
 #[cfg(target_os = "macos")]
@@ -60,6 +61,7 @@ pub struct InnerWebView {
   // all functions pointer declarations in objc callbacks below all need to get updated.
   ipc_handler_ptr: *mut (Box<dyn Fn(&Window, String)>, Rc<Window>),
   navigation_decide_policy_ptr: *mut Box<dyn Fn(String, bool) -> bool>,
+  respond_auth_challenge_ptr: *mut Box<dyn Fn(String) -> bool>,
   #[cfg(target_os = "macos")]
   file_drop_ptr: *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>),
   protocol_ptrs: Vec<*mut Box<dyn Fn(&HttpRequest) -> Result<HttpResponse>>>,
@@ -331,6 +333,47 @@ impl InnerWebView {
         null_mut()
       };
 
+      // respond auth challenge
+      extern "C" fn respond_authentication_challenge(
+        this: &Object,
+        _: Sel,
+        _webview: id,
+        challenge: id,
+        completion_handler: id,
+      ) {
+        unsafe {
+          let url_credential: id = msg_send![class!(NSURLCredential), alloc];
+          let protection_space: id = msg_send![challenge, protectionSpace];
+          let server_trust: id = msg_send![protection_space, serverTrust];
+          let credential: id = msg_send![url_credential, initWithTrust: server_trust];
+          let completion_handler = completion_handler as *mut block::Block<(NSInteger, id), c_void>;
+
+          let function = this.get_ivar::<*mut c_void>("respond_auth_challenge_fn");
+          if !function.is_null() {
+            let protocol: id = msg_send![protection_space, protocol];
+            let protocol = if protocol == nil {
+              "".to_string()
+            } else {
+              format!("{}://", NSString(protocol).to_str())
+            };
+            let host: id = msg_send![protection_space, host];
+            let host = NSString(host);
+            let port: NSInteger = msg_send![protection_space, port];
+            let url = format!("{}{}:{}", protocol, host.to_str(), port);
+
+            let function = &mut *(*function as *mut Box<dyn for<'s> Fn(String) -> bool>);
+            match (function)(url) {
+              // `0` here means AuthChallengeDisposition.useCredential
+              true => (*completion_handler).call((0, credential)),
+              // `1` here means AuthChallengeDisposition.performDefaultHandling
+              false => (*completion_handler).call((1, credential)),
+            };
+          } else {
+            (*completion_handler).call((1, credential));
+          }
+        }
+      }
+
       // Navigation handler
       extern "C" fn navigation_policy(this: &Object, _: Sel, _: id, action: id, handler: id) {
         unsafe {
@@ -344,7 +387,7 @@ impl InnerWebView {
 
           let handler = handler as *mut block::Block<(NSInteger,), c_void>;
 
-          let function = this.get_ivar::<*mut c_void>("function");
+          let function = this.get_ivar::<*mut c_void>("navigation_policy_fn");
           if !function.is_null() {
             let function = &mut *(*function as *mut Box<dyn for<'s> Fn(String, bool) -> bool>);
             match (function)(url.to_str().to_string(), is_main_frame) {
@@ -352,27 +395,49 @@ impl InnerWebView {
               false => (*handler).call((0,)),
             };
           } else {
-            log::warn!("WebView instance is dropped! This navigation handler shouldn't be called.");
             (*handler).call((1,));
           }
         }
       }
 
+      let navigation_delegate_cls = match ClassDecl::new("MyUiViewController", class!(NSObject)) {
+        Some(mut cls) => {
+          cls.add_ivar::<*mut c_void>("navigation_policy_fn");
+          cls.add_ivar::<*mut c_void>("respond_auth_challenge_fn");
+          cls.add_method(
+            sel!(webView:decidePolicyForNavigationAction:decisionHandler:),
+            navigation_policy as extern "C" fn(&Object, Sel, id, id, id),
+          );
+          cls.add_method(
+            sel!(webView:didReceiveAuthenticationChallenge:completionHandler:),
+            respond_authentication_challenge as extern "C" fn(&Object, Sel, id, id, id),
+          );
+          cls.register()
+        }
+        None => class!(UIViewController),
+      };
+
+      let navigation_delegate: id = msg_send![navigation_delegate_cls, new];
+
+      let respond_auth_challenge_ptr = {
+        let allowed_self_signed_cert_urls = attributes.allowed_self_signed_cert_urls;
+        Box::into_raw(Box::new(Box::new(move |url: String| -> bool {
+          if let Ok(url) = Url::parse(&url) {
+            allowed_self_signed_cert_urls
+              .iter()
+              .any(|u| u.host().is_some() && u.host() == url.host())
+          } else {
+            false
+          }
+        }) as Box<dyn Fn(String) -> bool>))
+      };
+      (*navigation_delegate).set_ivar(
+        "respond_auth_challenge_fn",
+        respond_auth_challenge_ptr as *mut _ as *mut c_void,
+      );
+
       let navigation_decide_policy_ptr =
         if attributes.navigation_handler.is_some() || attributes.new_window_req_handler.is_some() {
-          let cls = match ClassDecl::new("UIViewController", class!(NSObject)) {
-            Some(mut cls) => {
-              cls.add_ivar::<*mut c_void>("function");
-              cls.add_method(
-                sel!(webView:decidePolicyForNavigationAction:decisionHandler:),
-                navigation_policy as extern "C" fn(&Object, Sel, id, id, id),
-              );
-              cls.register()
-            }
-            None => class!(UIViewController),
-          };
-
-          let handler: id = msg_send![cls, new];
           let function_ptr = {
             let navigation_handler = attributes.navigation_handler;
             let new_window_req_handler = attributes.new_window_req_handler;
@@ -390,13 +455,17 @@ impl InnerWebView {
               }) as Box<dyn Fn(String, bool) -> bool>,
             ))
           };
-          (*handler).set_ivar("function", function_ptr as *mut _ as *mut c_void);
+          (*navigation_delegate).set_ivar(
+            "navigation_policy_fn",
+            function_ptr as *mut _ as *mut c_void,
+          );
 
-          let _: () = msg_send![webview, setNavigationDelegate: handler];
           function_ptr
         } else {
           null_mut()
         };
+
+      let _: () = msg_send![webview, setNavigationDelegate: navigation_delegate];
 
       // File upload panel handler
       extern "C" fn run_file_upload_panel(
@@ -474,6 +543,7 @@ impl InnerWebView {
         manager,
         ipc_handler_ptr,
         navigation_decide_policy_ptr,
+        respond_auth_challenge_ptr,
         #[cfg(target_os = "macos")]
         file_drop_ptr,
         protocol_ptrs,
@@ -687,6 +757,9 @@ impl Drop for InnerWebView {
 
       if !self.navigation_decide_policy_ptr.is_null() {
         let _ = Box::from_raw(self.navigation_decide_policy_ptr);
+      }
+      if !self.respond_auth_challenge_ptr.is_null() {
+        let _ = Box::from_raw(self.respond_auth_challenge_ptr);
       }
 
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

On Android, it requires this change on RustWebClient.kt:

```
@SuppressLint("WebViewClientOnReceivedSslError")
    override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler, error: android.net.http.SslError) {
      if (allowSslError(error.url)) {
        handler.proceed()
      } else {
        handler.cancel()
      }
    }

    private external fun allowSslError(url: String): Boolean
```