### PR TITLE
feat(android): improve initialization scripts implementation

### DIFF
--- a/.changes/improve-init-scripts.md
+++ b/.changes/improve-init-scripts.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Improve Android initialization script implementation.

--- a/src/webview/android/binding.rs
+++ b/src/webview/android/binding.rs
@@ -9,12 +9,7 @@ use tao::platform::android::ndk_glue::jni::{
   JNIEnv,
 };
 
-use super::{MainPipe, WebViewMessage, IPC, REQUEST_HANDLER};
-
-#[allow(non_snake_case)]
-pub unsafe fn runInitializationScripts(_: JNIEnv, _: JClass, _: JObject) {
-  MainPipe::send(WebViewMessage::RunInitializationScripts);
-}
+use super::{IPC, REQUEST_HANDLER};
 
 fn handle_request(env: JNIEnv, request: JObject) -> Result<jobject, JniError> {
   let mut request_builder = RequestBuilder::new();

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -20,7 +20,6 @@ pub static MAIN_PIPE: Lazy<[RawFd; 2]> = Lazy::new(|| {
 pub struct MainPipe<'a> {
   pub env: JNIEnv<'a>,
   pub activity: GlobalRef,
-  pub initialization_scripts: Vec<String>,
   pub webview: Option<GlobalRef>,
 }
 
@@ -37,7 +36,7 @@ impl MainPipe<'_> {
     let activity = self.activity.as_obj();
     if let Ok(message) = CHANNEL.1.recv() {
       match message {
-        WebViewMessage::CreateWebView(url, mut initialization_scripts, devtools) => {
+        WebViewMessage::CreateWebView(url, initialization_scripts, devtools) => {
           // Create webview
           let class = env.find_class("android/webkit/WebView")?;
           let webview =
@@ -67,42 +66,36 @@ impl MainPipe<'_> {
             &[devtools.into()],
           )?;
 
-          // Initialize scripts
-          self
-            .initialization_scripts
-            .append(&mut initialization_scripts);
+          let string_class = env.find_class("java/lang/String")?;
+          let initialization_scripts_array = env.new_object_array(
+            initialization_scripts.len() as i32,
+            string_class,
+            env.new_string("")?,
+          )?;
+          for (i, script) in initialization_scripts.into_iter().enumerate() {
+            env.set_object_array_element(
+              initialization_scripts_array,
+              i as i32,
+              env.new_string(script)?,
+            )?;
+          }
 
           // Create and set webview client
-          println!(
-            "[RUST] webview client {}/RustWebViewClient",
-            PACKAGE.get().unwrap()
-          );
           let rust_webview_client_class = find_my_class(
             env,
             activity,
             format!("{}/RustWebViewClient", PACKAGE.get().unwrap()),
           )?;
-          let webview_client = env.new_object(rust_webview_client_class, "()V", &[])?;
+          let webview_client = env.new_object(
+            rust_webview_client_class,
+            "([Ljava/lang/String;)V",
+            &[initialization_scripts_array.into()],
+          )?;
           env.call_method(
             webview,
             "setWebViewClient",
             "(Landroid/webkit/WebViewClient;)V",
             &[webview_client.into()],
-          )?;
-
-          // Create and set webchrome client
-          println!("[RUST] chrome client");
-          let rust_webchrome_client_class = find_my_class(
-            env,
-            activity,
-            format!("{}/RustWebChromeClient", PACKAGE.get().unwrap()),
-          )?;
-          let webchrome_client = env.new_object(rust_webchrome_client_class, "()V", &[])?;
-          env.call_method(
-            webview,
-            "setWebChromeClient",
-            "(Landroid/webkit/WebChromeClient;)V",
-            &[webchrome_client.into()],
           )?;
 
           // Add javascript interface (IPC)
@@ -125,19 +118,6 @@ impl MainPipe<'_> {
           )?;
           let webview = env.new_global_ref(webview)?;
           self.webview = Some(webview);
-        }
-        WebViewMessage::RunInitializationScripts => {
-          if let Some(webview) = &self.webview {
-            for s in &self.initialization_scripts {
-              let s = env.new_string(s)?;
-              env.call_method(
-                webview.as_obj(),
-                "evaluateJavascript",
-                "(Ljava/lang/String;Landroid/webkit/ValueCallback;)V",
-                &[s.into(), JObject::null().into()],
-              )?;
-            }
-          }
         }
         WebViewMessage::Eval(script) => {
           if let Some(webview) = &self.webview {
@@ -176,6 +156,5 @@ fn find_my_class<'a>(
 #[derive(Debug)]
 pub enum WebViewMessage {
   CreateWebView(String, Vec<String>, bool),
-  RunInitializationScripts,
   Eval(String),
 }

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -31,12 +31,6 @@ macro_rules! android_binding {
     android_fn!(
       $domain,
       $package,
-      RustWebChromeClient,
-      runInitializationScripts
-    );
-    android_fn!(
-      $domain,
-      $package,
       RustWebViewClient,
       handleRequest,
       JObject,
@@ -71,7 +65,6 @@ pub unsafe fn setup(env: JNIEnv, looper: &ForeignLooper, activity: GlobalRef) {
   let mut main_pipe = MainPipe {
     env,
     activity,
-    initialization_scripts: vec![],
     webview: None,
   };
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Deleted `RustWebChromeClient` references, it's no longer needed.
The new RustWebViewClient.kt:

```java
package com.tauri.api

import android.graphics.Bitmap
import android.webkit.*

class RustWebViewClient(initScripts: Array<String>): WebViewClient() {
    private val initializationScripts: Array<String>
  
    init {
      initializationScripts = initScripts
    }

    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
        for (script in initializationScripts) {
          view?.evaluateJavascript(script, null)
        }
        super.onPageStarted(view, url, favicon)
    }
  
    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
        return false
    }

    override fun shouldInterceptRequest(
        view: WebView,
        request: WebResourceRequest
    ): WebResourceResponse? {
        return handleRequest(request)
    }

    companion object {
        init {
            System.loadLibrary("api")
        }
    }

    private external fun handleRequest(request: WebResourceRequest): WebResourceResponse?
}
```