### PR TITLE
fix(android): inject initialization scripts in HTML

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,7 @@ objc_id = "0.1"
 
 [target."cfg(target_os = \"android\")".dependencies]
 crossbeam-channel = "0.5"
+kuchiki = "0.8"
+html5ever = "0.25"
+sha2 = "0.10"
+base64 = "0.13"

--- a/build.rs
+++ b/build.rs
@@ -17,10 +17,12 @@ fn main() {
     use std::{fs, path::PathBuf};
 
     fn env_var(var: &str) -> String {
-      std::env::var(var).expect(&format!(
-        " `{}` is not set, which is needed to generate the kotlin files for android.",
-        var
-      ))
+      std::env::var(var).unwrap_or_else(|_| {
+        panic!(
+          " `{}` is not set, which is needed to generate the kotlin files for android.",
+          var
+        )
+      })
     }
 
     println!("cargo:rerun-if-env-changed=WRY_ANDROID_REVERSED_DOMAIN");

--- a/src/webview/android/kotlin/RustWebViewClient.kt
+++ b/src/webview/android/kotlin/RustWebViewClient.kt
@@ -1,22 +1,8 @@
 package {{app-domain-reversed}}.{{app-name-snake-case}}
 
-import android.graphics.Bitmap
 import android.webkit.*
 
-class RustWebViewClient(initScripts: Array<String>): WebViewClient() {
-    private val initializationScripts: Array<String>
-
-    init {
-      initializationScripts = initScripts
-    }
-
-    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-        for (script in initializationScripts) {
-          view?.evaluateJavascript(script, null)
-        }
-        super.onPageStarted(view, url, favicon)
-    }
-
+class RustWebViewClient: WebViewClient() {
     override fun shouldInterceptRequest(
         view: WebView,
         request: WebResourceRequest

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -36,7 +36,7 @@ impl MainPipe<'_> {
     let activity = self.activity.as_obj();
     if let Ok(message) = CHANNEL.1.recv() {
       match message {
-        WebViewMessage::CreateWebView(url, initialization_scripts, devtools) => {
+        WebViewMessage::CreateWebView(url, devtools) => {
           // Create webview
           let rust_webview_class = find_my_class(
             env,
@@ -63,31 +63,13 @@ impl MainPipe<'_> {
             &[devtools.into()],
           )?;
 
-          let string_class = env.find_class("java/lang/String")?;
-          let initialization_scripts_array = env.new_object_array(
-            initialization_scripts.len() as i32,
-            string_class,
-            env.new_string("")?,
-          )?;
-          for (i, script) in initialization_scripts.into_iter().enumerate() {
-            env.set_object_array_element(
-              initialization_scripts_array,
-              i as i32,
-              env.new_string(script)?,
-            )?;
-          }
-
           // Create and set webview client
           let rust_webview_client_class = find_my_class(
             env,
             activity,
             format!("{}/RustWebViewClient", PACKAGE.get().unwrap()),
           )?;
-          let webview_client = env.new_object(
-            rust_webview_client_class,
-            "([Ljava/lang/String;)V",
-            &[initialization_scripts_array.into()],
-          )?;
+          let webview_client = env.new_object(rust_webview_client_class, "()V", &[])?;
           env.call_method(
             webview,
             "setWebViewClient",
@@ -152,6 +134,6 @@ fn find_my_class<'a>(
 
 #[derive(Debug)]
 pub enum WebViewMessage {
-  CreateWebView(String, Vec<String>, bool),
+  CreateWebView(String, bool),
   Eval(String),
 }

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -1,10 +1,13 @@
 use super::{WebContext, WebViewAttributes};
 use crate::{
   application::window::Window,
-  http::{Request as HttpRequest, Response as HttpResponse},
+  http::{header::HeaderValue, Request as HttpRequest, Response as HttpResponse},
   Result,
 };
+use html5ever::{interface::QualName, namespace_url, ns, tendril::TendrilSink, LocalName};
+use kuchiki::NodeRef;
 use once_cell::sync::OnceCell;
+use sha2::{Digest, Sha256};
 use std::rc::Rc;
 use tao::platform::android::ndk_glue::{
   jni::{objects::GlobalRef, JNIEnv},
@@ -116,11 +119,7 @@ impl InnerWebView {
           .replace(&format!("{}://", name), &format!("https://{}.", name))
       }
 
-      MainPipe::send(WebViewMessage::CreateWebView(
-        url_string,
-        initialization_scripts,
-        devtools,
-      ));
+      MainPipe::send(WebViewMessage::CreateWebView(url_string, devtools));
     }
 
     REQUEST_HANDLER.get_or_init(move || {
@@ -134,7 +133,39 @@ impl InnerWebView {
             &format!("{}://", custom_protocol.0),
           );
 
-          if let Ok(response) = (custom_protocol.1)(&request) {
+          if let Ok(mut response) = (custom_protocol.1)(&request) {
+            if response.head.mimetype.as_deref() == Some("text/html") {
+              if !initialization_scripts.is_empty() {
+                let mut document =
+                  kuchiki::parse_html().one(String::from_utf8_lossy(&response.body).into_owned());
+                let csp = response.head.headers.get_mut("Content-Security-Policy");
+                let mut hashes = Vec::new();
+                with_html_head(&mut document, |head| {
+                  for script in &initialization_scripts {
+                    let script_el =
+                      NodeRef::new_element(QualName::new(None, ns!(html), "script".into()), None);
+                    script_el.append(NodeRef::new_text(script));
+                    head.prepend(script_el);
+                    if csp.is_some() {
+                      hashes.push(hash_script(script));
+                    }
+                  }
+                });
+
+                if let Some(csp) = csp {
+                  let csp_string = csp.to_str().unwrap().to_string();
+                  let csp_string = if csp_string.contains("script-src") {
+                    csp_string.replace("script-src", &format!("script-src {}", hashes.join(" ")))
+                  } else {
+                    format!("{} script-src {}", csp_string, hashes.join(" "))
+                  };
+                  println!("[CSP] {}", csp_string);
+                  *csp = HeaderValue::from_str(&csp_string).unwrap();
+                }
+
+                response.body = document.to_string().as_bytes().to_vec();
+              }
+            }
             return Some(response);
           }
         }
@@ -176,4 +207,24 @@ impl InnerWebView {
 
 pub fn platform_webview_version() -> Result<String> {
   todo!()
+}
+
+fn with_html_head<F: FnOnce(&NodeRef)>(document: &mut NodeRef, f: F) {
+  if let Ok(ref node) = document.select_first("head") {
+    f(node.as_node())
+  } else {
+    let node = NodeRef::new_element(
+      QualName::new(None, ns!(html), LocalName::from("head")),
+      None,
+    );
+    f(&node);
+    document.prepend(node)
+  }
+}
+
+fn hash_script(script: &str) -> String {
+  let mut hasher = Sha256::new();
+  hasher.update(script);
+  let hash = hasher.finalize();
+  format!("'sha256-{}'", base64::encode(hash))
 }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -89,6 +89,10 @@ pub struct WebViewAttributes {
   /// Initialize javascript code when loading new pages. When webview load a new page, this
   /// initialization code will be executed. It is guaranteed that code is executed before
   /// `window.onload`.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android:** The initialization scripts are only executed on custom protocol URLs.
   pub initialization_scripts: Vec<String>,
   /// Register custom file loading protocols with pairs of scheme uri string and a handling
   /// closure.
@@ -224,6 +228,10 @@ impl<'a> WebViewBuilder<'a> {
   /// Initialize javascript code when loading new pages. When webview load a new page, this
   /// initialization code will be executed. It is guaranteed that code is executed before
   /// `window.onload`.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android:** The initialization scripts are only executed on custom protocol URLs.
   pub fn with_initialization_script(mut self, js: &str) -> Self {
     self.webview.initialization_scripts.push(js.to_string());
     self

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -92,7 +92,8 @@ pub struct WebViewAttributes {
   ///
   /// ## Platform-specific
   ///
-  /// - **Android:** The initialization scripts are only executed on custom protocol URLs.
+  /// - **Android:** The Android WebView does not provide an API for initialization scripts,
+  /// so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
   pub initialization_scripts: Vec<String>,
   /// Register custom file loading protocols with pairs of scheme uri string and a handling
   /// closure.
@@ -231,7 +232,8 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Android:** The initialization scripts are only executed on custom protocol URLs.
+  /// - **Android:** The Android WebView does not provide an API for initialization scripts,
+  /// so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
   pub fn with_initialization_script(mut self, js: &str) -> Self {
     self.webview.initialization_scripts.push(js.to_string());
     self


### PR DESCRIPTION
The Android WebView does not have a reliable way to inject the initialization scripts. Using `onPageStarted` has some issues when running a production app, the script is executed too late. Until we can find a better solution, we'll inject the scripts in the HTML via the custom protocol.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
