### PR TITLE
fix(android): delay WebView#loadUrl call

### DIFF
--- a/src/webview/android/kotlin/RustWebView.kt
+++ b/src/webview/android/kotlin/RustWebView.kt
@@ -6,11 +6,19 @@ package {{app-domain-reversed}}.{{app-name-snake-case}}
 
 import android.webkit.*
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 
 class RustWebView(context: Context): WebView(context) {
     init {
         this.settings.javaScriptEnabled = true
         {{class-init}}
+    }
+
+    fun loadUrlMainThread(url: String) {
+        Handler(Looper.getMainLooper()).post {
+          super.loadUrl(url)
+        }
     }
 
     {{class-extension}}

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -55,7 +55,12 @@ impl MainPipe<'_> {
 
           // Load URL
           if let Ok(url) = env.new_string(url) {
-            env.call_method(webview, "loadUrl", "(Ljava/lang/String;)V", &[url.into()])?;
+            env.call_method(
+              webview,
+              "loadUrlMainThread",
+              "(Ljava/lang/String;)V",
+              &[url.into()],
+            )?;
           }
 
           // Enable devtools


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

In older webview versions, the `WebViewClient::shouldInterceptRequest` method is not invoked for the initial URL load. This is fixed if we delay the loadUrl() call by posting a message to the main thread. This was reported in Discord by a user testing on an emulator with API 28.
