### PR TITLE
refactor: android environment variables are now optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-apple-darwin, os: macos-latest }
           - { target: aarch64-apple-ios, os: macos-latest }
-          - {
-              target: aarch64-linux-android,
-              os: ubuntu-latest,
-              env: {
-                WRY_ANDROID_REVERSED_DOMAIN: "app.tauri",
-                WRY_ANDROID_APP_NAME_SNAKE_CASE: "wry",
-                WRY_ANDROID_KOTLIN_FILES_OUT_DIR: "out",
-              }
-            }
+          - { target: aarch64-linux-android, os: ubuntu-latest }
 
     runs-on: ${{ matrix.platform.os }}
 
@@ -34,7 +26,7 @@ jobs:
           target: ${{ matrix.platform.target }}
 
       - name: install webkit2gtk (ubuntu only)
-        if: contains(matrix.platform.target, 'gnu') 
+        if: contains(matrix.platform.target, 'gnu')
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.0 libgtksourceview-3.0-dev libayatana-appindicator3-dev
@@ -82,16 +74,8 @@ jobs:
             ${{ matrix.platform }}-stable-cargo-core-${{ hashFiles('Cargo.toml') }}
             ${{ matrix.platform }}-stable-cargo-core-
 
-      - name: create kotlin out dir
-        if: contains(matrix.platform.target, 'android')
-        run: mkdir out
-
       - name: build wry
         run: cargo build --features tray --target ${{ matrix.platform.target }}
-        env:
-          WRY_ANDROID_REVERSED_DOMAIN: ${{ matrix.platform.env.WRY_ANDROID_REVERSED_DOMAIN }}
-          WRY_ANDROID_APP_NAME_SNAKE_CASE: ${{ matrix.platform.env.WRY_ANDROID_APP_NAME_SNAKE_CASE }}
-          WRY_ANDROID_KOTLIN_FILES_OUT_DIR: ${{ matrix.platform.env.WRY_ANDROID_KOTLIN_FILES_OUT_DIR }}
 
       - name: build tests and examples
         shell: bash

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
     fn env_var(var: &str) -> String {
       std::env::var(var).unwrap_or_else(|_| {
         panic!(
-          " `{}` is not set, which is needed to generate the kotlin files for android.",
+          "`{}` is not set, which is needed to generate the kotlin files for android.",
           var
         )
       })
@@ -29,61 +29,62 @@ fn main() {
     println!("cargo:rerun-if-env-changed=WRY_ANDROID_APP_NAME_SNAKE_CASE");
     println!("cargo:rerun-if-env-changed=WRY_ANDROID_KOTLIN_FILES_OUT_DIR");
 
-    let reversed_domain = env_var("WRY_ANDROID_REVERSED_DOMAIN");
-    let app_name_snake_case = env_var("WRY_ANDROID_APP_NAME_SNAKE_CASE");
-    let kotlin_out_dir = env_var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR");
+    if let Ok(kotlin_out_dir) = std::env::var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") {
+      let reversed_domain = env_var("WRY_ANDROID_REVERSED_DOMAIN");
+      let app_name_snake_case = env_var("WRY_ANDROID_APP_NAME_SNAKE_CASE");
 
-    let kotlin_out_dir = PathBuf::from(kotlin_out_dir)
-      .canonicalize()
-      .expect("Failed to canonicalize path");
+      let kotlin_out_dir = PathBuf::from(kotlin_out_dir)
+        .canonicalize()
+        .expect("Failed to canonicalize path");
 
-    let kotlin_files_path =
-      PathBuf::from(env_var("CARGO_MANIFEST_DIR")).join("src/webview/android/kotlin");
-    println!("cargo:rerun-if-changed={}", kotlin_files_path.display());
-    let kotlin_files = fs::read_dir(kotlin_files_path).expect("failed to read kotlin directory");
+      let kotlin_files_path =
+        PathBuf::from(env_var("CARGO_MANIFEST_DIR")).join("src/webview/android/kotlin");
+      println!("cargo:rerun-if-changed={}", kotlin_files_path.display());
+      let kotlin_files = fs::read_dir(kotlin_files_path).expect("failed to read kotlin directory");
 
-    for file in kotlin_files {
-      let file = file.unwrap();
+      for file in kotlin_files {
+        let file = file.unwrap();
 
-      let class_extension_env = format!(
-        "WRY_{}_CLASS_EXTENSION",
-        file
-          .path()
-          .file_stem()
-          .unwrap()
-          .to_string_lossy()
-          .to_uppercase()
-      );
-      let class_init_env = format!(
-        "WRY_{}_CLASS_INIT",
-        file
-          .path()
-          .file_stem()
-          .unwrap()
-          .to_string_lossy()
-          .to_uppercase()
-      );
-
-      println!("cargo:rerun-if-env-changed={}", class_extension_env);
-      println!("cargo:rerun-if-env-changed={}", class_init_env);
-
-      let content = fs::read_to_string(file.path())
-        .expect("failed to read kotlin file as string")
-        .replace("{{app-domain-reversed}}", &reversed_domain)
-        .replace("{{app-name-snake-case}}", &app_name_snake_case)
-        .replace(
-          "{{class-extension}}",
-          &std::env::var(&class_extension_env).unwrap_or_default(),
-        )
-        .replace(
-          "{{class-init}}",
-          &std::env::var(&class_init_env).unwrap_or_default(),
+        let class_extension_env = format!(
+          "WRY_{}_CLASS_EXTENSION",
+          file
+            .path()
+            .file_stem()
+            .unwrap()
+            .to_string_lossy()
+            .to_uppercase()
+        );
+        let class_init_env = format!(
+          "WRY_{}_CLASS_INIT",
+          file
+            .path()
+            .file_stem()
+            .unwrap()
+            .to_string_lossy()
+            .to_uppercase()
         );
 
-      let mut out = String::from("/* THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!! */\n\n");
-      out.push_str(&content);
+        println!("cargo:rerun-if-env-changed={}", class_extension_env);
+        println!("cargo:rerun-if-env-changed={}", class_init_env);
 
-      fs::write(kotlin_out_dir.join(file.file_name()), out).expect("Failed to write kotlin file");
+        let content = fs::read_to_string(file.path())
+          .expect("failed to read kotlin file as string")
+          .replace("{{app-domain-reversed}}", &reversed_domain)
+          .replace("{{app-name-snake-case}}", &app_name_snake_case)
+          .replace(
+            "{{class-extension}}",
+            &std::env::var(&class_extension_env).unwrap_or_default(),
+          )
+          .replace(
+            "{{class-init}}",
+            &std::env::var(&class_init_env).unwrap_or_default(),
+          );
+
+        let mut out = String::from("/* THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!! */\n\n");
+        out.push_str(&content);
+
+        fs::write(kotlin_out_dir.join(file.file_name()), out).expect("Failed to write kotlin file");
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Forcing the environment variables to be set is boring for a quick `cargo build --target aarch64-linux-android` to test changes or a CI pipeline using cross. The relevant CLIs will always set this environment variable so we don't need to enforce it in wry.