### PR TITLE
Fix: Remove extra soft prompt asking for media permission on every app launch in macOS

### DIFF
--- a/.changes/fix-double-dialog.md
+++ b/.changes/fix-double-dialog.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Fix double permission dialog issue.
+Fix double permission dialog on macOS 12+ and iOS 15+.

--- a/.changes/fix-double-dialog.md
+++ b/.changes/fix-double-dialog.md
@@ -1,5 +1,5 @@
 ---
-"wry": minor
+"wry": patch
 ---
 
 Fix double permission dialog on macOS 12+ and iOS 15+.

--- a/.changes/fix-double-dialog.md
+++ b/.changes/fix-double-dialog.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Fix double permission dialog issue.


### PR DESCRIPTION
Fixes https://github.com/tauri-apps/tauri/issues/4750

Discord conversation: https://discord.com/channels/616186924390023171/731495028677148753/1020299521542082610

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
