### PR TITLE
fix(macos): remove IPC script message handler on drop

### DIFF
--- a/.cargo/remove-ipc.md
+++ b/.cargo/remove-ipc.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Remove the IPC script message handler when the WebView is dropped on macOS.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -679,10 +679,8 @@ impl Drop for InnerWebView {
       if !self.ipc_handler_ptr.is_null() {
         let _ = Box::from_raw(self.ipc_handler_ptr);
 
-        let config: id = msg_send![self.webview, configuration];
-        let manager: id = msg_send![config, userContentController];
         let ipc = NSString::new(IPC_MESSAGE_HANDLER_NAME);
-        let _: () = msg_send![manager, removeScriptMessageHandlerForName: ipc];
+        let _: () = msg_send![self.manager, removeScriptMessageHandlerForName: ipc];
       }
 
       if !self.navigation_decide_policy_ptr.is_null() {


### PR DESCRIPTION
This prevents a segfault on the did_receive hook - a race condition when closing the webview in the middle of a IPC call. I only saw this when closing the window immediately after creating it, though it could have more cases.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
