### PR TITLE
Use Arc for Window in WebView

### DIFF
--- a/.changes/window-arc.md
+++ b/.changes/window-arc.md
@@ -1,0 +1,7 @@
+---
+"wry": "minor"
+---
+
+This changes the Window held by WebView from `Rc<Window>` to `Arc<Window>`, so that the window can be
+accessed from other threads. This also changes the `WebView.window` method to return `&Arc<Window>` instead
+of `&Window`, which I think should be backwards compatible.

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -13,7 +13,7 @@ use http::{
 use kuchiki::NodeRef;
 use once_cell::sync::OnceCell;
 use sha2::{Digest, Sha256};
-use std::rc::Rc;
+use std::sync::Arc;
 use tao::platform::android::ndk_glue::{
   jni::{
     errors::Error as JniError,
@@ -56,9 +56,9 @@ macro_rules! android_binding {
 pub static IPC: OnceCell<UnsafeIpc> = OnceCell::new();
 pub static REQUEST_HANDLER: OnceCell<UnsafeRequestHandler> = OnceCell::new();
 
-pub struct UnsafeIpc(Box<dyn Fn(&Window, String)>, Rc<Window>);
+pub struct UnsafeIpc(Box<dyn Fn(&Window, String)>, Arc<Window>);
 impl UnsafeIpc {
-  pub fn new(f: Box<dyn Fn(&Window, String)>, w: Rc<Window>) -> Self {
+  pub fn new(f: Box<dyn Fn(&Window, String)>, w: Arc<Window>) -> Self {
     Self(f, w)
   }
 }
@@ -116,12 +116,12 @@ pub unsafe fn setup(env: JNIEnv, looper: &ForeignLooper, activity: GlobalRef) {
 
 pub(crate) struct InnerWebView {
   #[allow(unused)]
-  pub window: Rc<Window>,
+  pub window: Arc<Window>,
 }
 
 impl InnerWebView {
   pub fn new(
-    window: Rc<Window>,
+    window: Arc<Window>,
     attributes: WebViewAttributes,
     _pl_attrs: super::PlatformSpecificWebViewAttributes,
     _web_context: Option<&mut WebContext>,

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -48,7 +48,7 @@ use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 #[cfg(target_os = "windows")]
 use windows::{Win32::Foundation::HWND, Win32::UI::WindowsAndMessaging::DestroyWindow};
 
-use std::{path::PathBuf, rc::Rc};
+use std::{path::PathBuf, rc::Rc, sync::Arc};
 
 pub use url::Url;
 
@@ -471,7 +471,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// [`EventLoop`]: crate::application::event_loop::EventLoop
   pub fn build(self) -> Result<WebView> {
-    let window = Rc::new(self.window);
+    let window = Arc::new(self.window);
     let webview = InnerWebView::new(
       window.clone(),
       self.webview,
@@ -512,7 +512,7 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 /// [`WebView`] presents the actual WebView window and let you still able to perform actions
 /// during event handling to it. [`WebView`] also contains the associate [`Window`] with it.
 pub struct WebView {
-  window: Rc<Window>,
+  window: Arc<Window>,
   webview: InnerWebView,
 }
 
@@ -561,7 +561,7 @@ impl WebView {
 
   /// Get the [`Window`] associate with the [`WebView`]. This can let you perform window related
   /// actions.
-  pub fn window(&self) -> &Window {
+  pub fn window(&self) -> &Arc<Window> {
     &self.window
   }
 

--- a/src/webview/webkitgtk/file_drop.rs
+++ b/src/webview/webkitgtk/file_drop.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::{cell::Cell, path::PathBuf, rc::Rc};
+use std::{cell::Cell, path::PathBuf, sync::Arc};
 
 use gtk::prelude::*;
 use webkit2gtk::WebView;
@@ -11,7 +11,7 @@ use crate::{application::window::Window, webview::FileDropEvent};
 
 pub(crate) fn connect_drag_event(
   webview: Rc<WebView>,
-  window: Rc<Window>,
+  window: Arc<Window>,
   handler: Box<dyn Fn(&Window, FileDropEvent) -> bool>,
 ) {
   let listener = Rc::new((handler, Cell::new(None)));

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -46,7 +46,7 @@ pub(crate) struct InnerWebView {
 
 impl InnerWebView {
   pub fn new(
-    window: Rc<Window>,
+    window: Arc<Window>,
     mut attributes: WebViewAttributes,
     _pl_attrs: super::PlatformSpecificWebViewAttributes,
     web_context: Option<&mut WebContext>,

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -12,7 +12,7 @@ use std::{
   rc::Rc,
   sync::{
     atomic::{AtomicBool, Ordering::SeqCst},
-    Mutex,
+    Arc, Mutex,
   },
 };
 use url::Url;

--- a/src/webview/webview2/file_drop.rs
+++ b/src/webview/webview2/file_drop.rs
@@ -16,6 +16,7 @@ use std::{
   path::PathBuf,
   ptr,
   rc::Rc,
+  sync::Arc,
 };
 
 use windows::Win32::{
@@ -52,7 +53,7 @@ impl FileDropController {
   pub(crate) fn listen(
     &mut self,
     hwnd: HWND,
-    window: Rc<Window>,
+    window: Arc<Window>,
     handler: Box<dyn Fn(&Window, FileDropEvent) -> bool>,
   ) {
     let listener = Rc::new(handler);
@@ -66,7 +67,7 @@ impl FileDropController {
   fn inject(
     &mut self,
     hwnd: HWND,
-    window: Rc<Window>,
+    window: Arc<Window>,
     listener: Rc<dyn Fn(&Window, FileDropEvent) -> bool>,
   ) -> bool {
     // Safety: WinAPI calls are unsafe
@@ -105,7 +106,7 @@ unsafe extern "system" fn enumerate_callback(hwnd: HWND, lparam: LPARAM) -> BOOL
 
 #[implement(IDropTarget)]
 pub struct FileDropHandler {
-  window: Rc<Window>,
+  window: Arc<Window>,
   listener: Rc<dyn Fn(&Window, FileDropEvent) -> bool>,
   cursor_effect: UnsafeCell<u32>,
   hovered_is_valid: UnsafeCell<bool>, /* If the currently hovered item is not valid there must not be any `HoveredFileCancelled` emitted */
@@ -113,7 +114,7 @@ pub struct FileDropHandler {
 
 impl FileDropHandler {
   pub fn new(
-    window: Rc<Window>,
+    window: Arc<Window>,
     listener: Rc<dyn Fn(&Window, FileDropEvent) -> bool>,
   ) -> FileDropHandler {
     Self {

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -12,8 +12,13 @@ use crate::{
 use file_drop::FileDropController;
 
 use std::{
-  collections::HashSet, fmt::Write, iter::once, mem::MaybeUninit, os::windows::prelude::OsStrExt,
-  rc::Rc, sync::mpsc,
+  collections::HashSet,
+  fmt::Write,
+  iter::once,
+  mem::MaybeUninit,
+  os::windows::prelude::OsStrExt,
+  rc::Rc,
+  sync::{mpsc, Arc},
 };
 
 use once_cell::unsync::OnceCell;
@@ -58,7 +63,7 @@ pub(crate) struct InnerWebView {
 
 impl InnerWebView {
   pub fn new(
-    window: Rc<Window>,
+    window: Arc<Window>,
     mut attributes: WebViewAttributes,
     pl_attrs: super::PlatformSpecificWebViewAttributes,
     web_context: Option<&mut WebContext>,
@@ -183,7 +188,7 @@ impl InnerWebView {
   }
 
   fn init_webview(
-    window: Rc<Window>,
+    window: Arc<Window>,
     hwnd: HWND,
     mut attributes: WebViewAttributes,
     env: &ICoreWebView2Environment,

--- a/src/webview/wkwebview/file_drop.rs
+++ b/src/webview/wkwebview/file_drop.rs
@@ -6,6 +6,7 @@ use std::{
   ffi::{c_void, CStr},
   path::PathBuf,
   rc::Rc,
+  sync::Arc,
 };
 
 use cocoa::base::{id, BOOL, YES};
@@ -55,9 +56,9 @@ static OBJC_DRAGGING_UPDATED: Lazy<extern "C" fn(*const Object, Sel, id) -> NSDr
 // Safety: objc runtime calls are unsafe
 pub(crate) unsafe fn set_file_drop_handler(
   webview: *mut Object,
-  window: Rc<Window>,
+  window: Arc<Window>,
   handler: Box<dyn Fn(&Window, FileDropEvent) -> bool>,
-) -> *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>) {
+) -> *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Arc<Window>) {
   let listener = Box::into_raw(Box::new((handler, window)));
   (*webview).set_ivar("FileDropHandler", listener as *mut _ as *mut c_void);
   listener
@@ -66,9 +67,9 @@ pub(crate) unsafe fn set_file_drop_handler(
 #[allow(clippy::mut_from_ref)]
 unsafe fn get_handler(
   this: &Object,
-) -> &mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>) {
+) -> &mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Arc<Window>) {
   let delegate: *mut c_void = *this.get_ivar("FileDropHandler");
-  &mut *(delegate as *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>))
+  &mut *(delegate as *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Arc<Window>))
 }
 
 unsafe fn collect_paths(drag_info: id) -> Vec<PathBuf> {


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This changes the Window held by WebView from `Rc<Window>` to `Arc<Window>`, so that the window can be
accessed from other threads. This also changes the `WebView.window` method to return `&Arc<Window>` instead
of `&Window`, which I think should be backwards compatible.
