### PR TITLE
fix: restore webview2 visibility upon restoring a maximized window

### DIFF
--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -698,7 +698,9 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
             let _ = (*controller).SetIsVisible(false);
           }
 
-          if wparam == WPARAM(win32wm::SIZE_RESTORED as _) {
+          if wparam == WPARAM(win32wm::SIZE_RESTORED as _)
+            || wparam == WPARAM(win32wm::SIZE_MAXIMIZED as _)
+          {
             let _ = (*controller).SetIsVisible(true);
           }
         }


### PR DESCRIPTION
regression was introduce in https://github.com/tauri-apps/wry/pull/702

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
