### PR TITLE
fix(wkwebview): make webview first responder, closes #739

### DIFF
--- a/.changes/wkwebview-make-first-responder.md
+++ b/.changes/wkwebview-make-first-responder.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, make the webview first responder.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -679,6 +679,9 @@ r#"Object.defineProperty(window, 'ipc', {
         // expect tao::Window to hold a handle to it and release it for us
         // eventually.
         let _: () = msg_send![ns_window, setContentView: parent_view];
+        // Tell the webview receive keyboard events in the window.
+        // See https://github.com/tauri-apps/wry/issues/739
+        let _: () = msg_send![ns_window, makeFirstResponder: webview];
 
         // make sure the window is always on top when we create a new webview
         let app_class = class!(NSApplication);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I confirmed #739 was solved on my local machine (macOS 11).

Just after launching the application window, typing some keys is reflected:

<img width="912" alt="screenshot" src="https://user-images.githubusercontent.com/823277/198290041-b417c2ed-746f-438e-8fa2-37ffb45565cb.png">
