### PR TITLE
fix(macos): do not trigger unsupported key feedback sound on keypress

### DIFF
--- a/.changes/macos-key-feedback.md
+++ b/.changes/macos-key-feedback.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Keypress on non-input element no longer triggers unsupported key feedback sound.

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -31,7 +31,7 @@ fn main() -> wry::Result<()> {
       // Read the file content from file path
       let content = read(canonicalize(PathBuf::from("examples").join(
         if path == &"/" {
-          "index.html"
+          "custom_protocol_page1.html"
         } else {
           // remove leading slash
           &path[1..]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Ref https://github.com/tauri-apps/tauri/issues/2626