### PR TITLE
fix(macos): download breaking app on macOS older than 11.3, closes #755

### DIFF
--- a/.changes/download-macos-version.md
+++ b/.changes/download-macos-version.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix download implementation on macOS older than 11.3.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -377,7 +377,7 @@ impl InnerWebView {
           let should_download: BOOL = if can_download == YES {
             msg_send![action, shouldPerformDownload]
           } else {
-            false
+            NO
           };
           let request: id = msg_send![action, request];
           let url: id = msg_send![request, URL];
@@ -388,7 +388,7 @@ impl InnerWebView {
 
           let handler = handler as *mut block::Block<(NSInteger,), c_void>;
 
-          if should_download {
+          if should_download == YES {
             let has_download_handler = this.get_ivar::<*mut c_void>("HasDownloadHandler");
             if !has_download_handler.is_null() {
               let has_download_handler = &mut *(*has_download_handler as *mut Box<bool>);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
