### PR TITLE
Add the ability to navigate with swipe gesture

### DIFF
--- a/.changes/allow-back-forward-gesture.md
+++ b/.changes/allow-back-forward-gesture.md
@@ -2,8 +2,4 @@
 "wry": minor
 ---
 
-Add the ability to navigate with swipe gesture
-
 On macOS, add an API to enable or disable backward and forward navigation gestures.
-
-For details, see <https://developer.apple.com/documentation/webkit/wkwebview/1414995-allowsbackforwardnavigationgestu>

--- a/.changes/allow-back-forward-gesture.md
+++ b/.changes/allow-back-forward-gesture.md
@@ -1,0 +1,9 @@
+---
+"wry": minor
+---
+
+Add the ability to navigate with swipe gesture
+
+On macOS, add an API to enable or disable backward and forward navigation gestures.
+
+For details, see <https://developer.apple.com/documentation/webkit/wkwebview/1414995-allowsbackforwardnavigationgestu>

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -215,6 +215,14 @@ pub struct WebViewAttributes {
   ///
   /// This configuration only impacts macOS.
   pub accept_first_mouse: bool,
+
+  /// Indicates whether horizontal swipe gestures trigger backward and forward page navigation.
+  ///
+  /// ## Platform-specific
+  ///
+  /// This configuration only impacts macOS.
+  /// [Documentation](https://developer.apple.com/documentation/webkit/wkwebview/1414995-allowsbackforwardnavigationgestu).
+  pub back_forward_navigation_gestures: bool,
 }
 
 impl Default for WebViewAttributes {
@@ -241,6 +249,7 @@ impl Default for WebViewAttributes {
       devtools: false,
       zoom_hotkeys_enabled: false,
       accept_first_mouse: false,
+      back_forward_navigation_gestures: false,
     }
   }
 }
@@ -293,6 +302,17 @@ impl<'a> WebViewBuilder<'a> {
       window,
       platform_specific,
     })
+  }
+
+  /// Indicates whether horizontal swipe gestures trigger backward and forward page navigation.
+  ///
+  /// ## Platform-specific
+  ///
+  /// This configuration only impacts macOS.
+  /// [Documentation](https://developer.apple.com/documentation/webkit/wkwebview/1414995-allowsbackforwardnavigationgestu).
+  pub fn with_back_forward_navigation_gestures(mut self, gesture: bool) -> Self {
+    self.webview.back_forward_navigation_gestures = gesture;
+    self
   }
 
   /// Sets whether the WebView should be transparent.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -343,6 +343,13 @@ impl InnerWebView {
         let _: () = msg_send![webview, initWithFrame:frame configuration:config];
       }
 
+      // allowsBackForwardNavigation
+      #[cfg(target_os = "macos")]
+      {
+        let value = attributes.back_forward_navigation_gestures;
+        let _: () = msg_send![webview, setAllowsBackForwardNavigationGestures: value];
+      }
+
       // Message handler
       let ipc_handler_ptr = if let Some(ipc_handler) = attributes.ipc_handler {
         let cls = ClassDecl::new("WebViewDelegate", class!(NSObject));


### PR DESCRIPTION
On macOS, add an API to enable or disable backward and forward navigation gestures.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Demo video
https://user-images.githubusercontent.com/28441561/202171447-b6cb4750-0326-466f-8e19-3371d996784b.mov

### Other information
The documentation of this function can be seen on <https://developer.apple.com/documentation/webkit/wkwebview/1414995-allowsbackforwardnavigationgestu>.


