### PR TITLE
On macOS, fix keyinput missing by calling super class methods

### DIFF
--- a/.changes/fix-key.md
+++ b/.changes/fix-key.md
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+On macOS, fix keyinput missing by calling superclass methods.
+


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
fix https://github.com/tauri-apps/tauri/issues/5662
<img width="510" alt="截圖 2022-11-21 下午9 28 44" src="https://user-images.githubusercontent.com/8409985/203067501-26bb2255-7b08-41f6-91ff-1a60a186b0d3.png">
