### PR TITLE
On macOS, revert content view to NSView

### DIFF
--- a/.changes/revert-menu.mdn
+++ b/.changes/revert-menu.mdn
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+On macOS, revert content view to native NSView.
+

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -26,6 +26,8 @@ fn main() -> wry::Result<()> {
   file_menu.add_item(
     MenuItemAttributes::new("Quit").with_accelerators(&Accelerator::new(
       Some(ModifiersState::SUPER),
+      // Some(ModifiersState::SHIFT),
+      // None,
       KeyCode::KeyQ,
     )),
   );

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -26,7 +26,6 @@ use std::{
   slice, str,
 };
 
-use core_graphics::geometry::{CGRect, CGSize};
 use objc::{
   declare::ClassDecl,
   runtime::{Class, Object, Sel, BOOL},
@@ -328,8 +327,7 @@ impl InnerWebView {
 
       #[cfg(target_os = "macos")]
       {
-        let ns_view = window.ns_view() as id;
-        // let frame: CGRect = msg_send![ns_view, frame];
+        use core_graphics::geometry::{CGRect, CGSize};
         let frame: CGRect = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(0., 0.));
         let _: () = msg_send![webview, initWithFrame:frame configuration:config];
         // Auto-resize on macOS

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -13,7 +13,6 @@ pub use web_context::WebContextImpl;
 #[cfg(target_os = "macos")]
 use cocoa::appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable};
 use cocoa::{
-  appkit::CGPoint,
   base::{id, nil, NO, YES},
   foundation::{NSDictionary, NSFastEnumeration, NSInteger},
 };
@@ -26,6 +25,7 @@ use std::{
   slice, str,
 };
 
+use core_graphics::geometry::CGRect;
 use objc::{
   declare::ClassDecl,
   runtime::{Class, Object, Sel, BOOL},
@@ -327,7 +327,7 @@ impl InnerWebView {
 
       #[cfg(target_os = "macos")]
       {
-        use core_graphics::geometry::{CGRect, CGSize};
+        use core_graphics::geometry::{CGPoint, CGSize};
         let frame: CGRect = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(0., 0.));
         let _: () = msg_send![webview, initWithFrame:frame configuration:config];
         // Auto-resize on macOS

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -276,6 +276,22 @@ impl InnerWebView {
               sel!(acceptsFirstMouse:),
               accept_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
             );
+            decl.add_method(
+              sel!(keyDown:),
+              key_down as extern "C" fn(&mut Object, Sel, id),
+            );
+
+            extern "C" fn key_down(this: &mut Object, _sel: Sel, event: id) {
+              unsafe {
+                let app = cocoa::appkit::NSApp();
+                let menu: id = msg_send![app, mainMenu];
+                if !menu.is_null() {
+                  let () = msg_send![menu, performKeyEquivalent: event];
+                }
+
+                let () = msg_send![this, performKeyEquivalent: event];
+              }
+            }
 
             extern "C" fn accept_first_mouse(this: &Object, _sel: Sel, _event: id) -> BOOL {
               unsafe {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I have tested:
- no beep sound
- keyboard input working including IME
- menu accelerator works with: CMD+, SHIFT+, and single keyinput in menu example.
- keyinput only reigger once using sample in https://github.com/tauri-apps/tauri/issues/5741
- works with release build with this config:
```
[profile.release]
strip = true 
lto = true
opt-level = "z"
```

I haven't tested if intel mac release build is working. I need someone to test it.

This will bring back following regressions:
- Resized event won't emit

But it should fix #774 https://github.com/tauri-apps/tauri/issues/5669 https://github.com/tauri-apps/tauri/issues/5741