### PR TITLE
perf: reduce extra allocation at `WebViewBuilderExtWindows::with_additional_browser_args` argument

### DIFF
--- a/.changes/prefer-into-to-asref-to-reduce-alloc.md
+++ b/.changes/prefer-into-to-asref-to-reduce-alloc.md
@@ -1,0 +1,5 @@
+---
+"wry": "minor"
+---
+
+Change the type of `WebViewBuilderExtWindows::with_additional_browser_args` argument from `AsRef<str>` to `Into<String>` to reduce extra allocation.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -592,13 +592,13 @@ pub trait WebViewBuilderExtWindows {
   ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.
-  fn with_additional_browser_args<S: AsRef<str>>(self, additional_args: S) -> Self;
+  fn with_additional_browser_args<S: Into<String>>(self, additional_args: S) -> Self;
 }
 
 #[cfg(windows)]
 impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
-  fn with_additional_browser_args<S: AsRef<str>>(mut self, additional_args: S) -> Self {
-    self.platform_specific.additional_browser_args = Some(additional_args.as_ref().to_string());
+  fn with_additional_browser_args<S: Into<String>>(mut self, additional_args: S) -> Self {
+    self.platform_specific.additional_browser_args = Some(additional_args.into());
     self
   }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #783
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Currently `WebViewBuilderExtWindows::with_additional_browser_args` argument is typed with `AsRef<str>`. However the method converts the string slice into string buffer with heap allocation. This causes redundant allocation when `String` value is passed.

```rust
let args: String = ...; // We already have heap-allocated string buffer
builder = builder.with_additional_browser_args(args); // New buffer is allocated
```

This PR fixes the point.

Strictly speaking, changing from `AsRef<str>` to `Into<String>` is a breaking change, but it is very small because major string types like `&str`, `String`, and `Cow<'a, str>` can still be passed to the argument.