### PR TITLE
fix(macos): suppress `unused_variables` warning reported only in release build

### DIFF
--- a/.changes/suppress_unused_vars_warning_in_release.md
+++ b/.changes/suppress_unused_vars_warning_in_release.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+Suppress `unused_variables` warning reported only in release build.

--- a/src/webview/wkwebview/download.rs
+++ b/src/webview/wkwebview/download.rs
@@ -99,17 +99,19 @@ pub extern "C" fn download_did_finish(this: &Object, _: Sel, download: id) {
   }
 }
 
-pub extern "C" fn download_did_fail(this: &Object, _: Sel, download: id, error: id, _: id) {
+pub extern "C" fn download_did_fail(this: &Object, _: Sel, download: id, _error: id, _: id) {
   unsafe {
-    let description: id = msg_send![error, localizedDescription];
-    let description = NSString(description).to_str().to_string();
+    #[cfg(debug_assertions)]
+    {
+      let description: id = msg_send![_error, localizedDescription];
+      let description = NSString(description).to_str().to_string();
+      eprintln!("Download failed with error: {}", description);
+    }
+
     let original_request: id = msg_send![download, originalRequest];
     let url: id = msg_send![original_request, URL];
     let url: id = msg_send![url, absoluteString];
     let url = NSString(url).to_str().to_string();
-
-    #[cfg(debug_assertions)]
-    eprintln!("Download failed with error: {}", description);
 
     let function = this.get_ivar::<*mut c_void>("completed");
     if !function.is_null() {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This PR fixes the warning when building this crate in release mode as follows:

```
$ cargo build --release
   Compiling wry v0.23.1 (/Users/rhysd/Develop/github.com/tauri-apps/wry)
warning: unused variable: `description`
   --> src/webview/wkwebview/download.rs:105:9
    |
105 |     let description = NSString(description).to_str().to_string();
    |         ^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_description`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: `wry` (lib) generated 1 warning
    Finished release [optimized] target(s) in 2.31s
```

The `description` variable is used only when `debug_assertions` is enabled.