### PR TITLE
feat(windows): Allow disabling browser-specific accelerator keys (closes #791)

### DIFF
--- a/.changes/webview2_browser_accelerator_keys.md
+++ b/.changes/webview2_browser_accelerator_keys.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+Add `WebViewBuilderExtWindows::with_browser_accelerator_keys` method to allow disabling browser-specific accelerator keys enabled in WebView2 by default. When `false` is passed, it disables all accelerator keys that access features specific to a web browser. See [the official WebView2 document](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arebrowseracceleratorkeysenabled) for more details.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -255,9 +255,18 @@ impl Default for WebViewAttributes {
 }
 
 #[cfg(windows)]
-#[derive(Default)]
 pub(crate) struct PlatformSpecificWebViewAttributes {
   additional_browser_args: Option<String>,
+  browser_accelerator_keys: bool,
+}
+#[cfg(windows)]
+impl Default for PlatformSpecificWebViewAttributes {
+  fn default() -> Self {
+    Self {
+      additional_browser_args: None,
+      browser_accelerator_keys: true, // This is WebView2's default behavior
+    }
+  }
 }
 #[cfg(any(
   target_os = "linux",
@@ -593,12 +602,24 @@ pub trait WebViewBuilderExtWindows {
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.
   fn with_additional_browser_args<S: Into<String>>(self, additional_args: S) -> Self;
+
+  /// Determines whether browser-specific accelerator keys are enabled. When this setting is set to
+  /// `false`, it disables all accelerator keys that access features specific to a web browser.
+  /// The default value is `true`. See the following link to know more details.
+  ///
+  /// https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arebrowseracceleratorkeysenabled
+  fn with_browser_accelerator_keys(self, enabled: bool) -> Self;
 }
 
 #[cfg(windows)]
 impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
   fn with_additional_browser_args<S: Into<String>>(mut self, additional_args: S) -> Self {
     self.platform_specific.additional_browser_args = Some(additional_args.into());
+    self
+  }
+
+  fn with_browser_accelerator_keys(mut self, enabled: bool) -> Self {
+    self.platform_specific.browser_accelerator_keys = enabled;
     self
   }
 }

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -69,9 +69,17 @@ impl InnerWebView {
     let file_drop_handler = attributes.file_drop_handler.take();
     let file_drop_window = window.clone();
 
+    let browser_accelerator_keys = pl_attrs.browser_accelerator_keys;
     let env = Self::create_environment(&web_context, pl_attrs)?;
     let controller = Self::create_controller(hwnd, &env)?;
-    let webview = Self::init_webview(window, hwnd, attributes, &env, &controller)?;
+    let webview = Self::init_webview(
+      window,
+      hwnd,
+      attributes,
+      &env,
+      &controller,
+      browser_accelerator_keys,
+    )?;
 
     if let Some(file_drop_handler) = file_drop_handler {
       let mut controller = FileDropController::new();
@@ -190,6 +198,7 @@ impl InnerWebView {
     mut attributes: WebViewAttributes,
     env: &ICoreWebView2Environment,
     controller: &ICoreWebView2Controller,
+    browser_accelerator_keys: bool,
   ) -> webview2_com::Result<ICoreWebView2> {
     let webview =
       unsafe { controller.CoreWebView2() }.map_err(webview2_com::Error::WindowsError)?;
@@ -245,6 +254,13 @@ impl InnerWebView {
         settings
           .SetAreDevToolsEnabled(true)
           .map_err(webview2_com::Error::WindowsError)?;
+      }
+      if !browser_accelerator_keys {
+        if let Ok(settings3) = settings.cast::<ICoreWebView2Settings3>() {
+          settings3
+            .SetAreBrowserAcceleratorKeysEnabled(false)
+            .map_err(webview2_com::Error::WindowsError)?;
+        }
       }
 
       let settings5 = settings.cast::<ICoreWebView2Settings5>()?;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This PR fixes #791.

I confirmed the following code worked as intended on my Windows10 laptop. It disabled the accelerator keys when `false` was passed, and did nothing when `true` was passed.

```rust
fn main() -> wry::Result<()> {
  use wry::{
    application::{
      event::{Event, StartCause, WindowEvent},
      event_loop::{ControlFlow, EventLoop},
      window::WindowBuilder,
    },
    webview::{WebViewBuilder, WebViewBuilderExtWindows},
  };

  let event_loop = EventLoop::new();
  let window = WindowBuilder::new()
    .with_title("Hello World")
    .build(&event_loop)?;
  let _webview = WebViewBuilder::new(window)?
    .with_url("https://tauri.studio")?
    .with_browser_accelerator_keys(false) // ADDED
    .build()?;

  event_loop.run(move |event, _, control_flow| {
    *control_flow = ControlFlow::Wait;

    match event {
      Event::NewEvents(StartCause::Init) => println!("Wry has started!"),
      Event::WindowEvent {
        event: WindowEvent::CloseRequested,
        ..
      } => *control_flow = ControlFlow::Exit,
      _ => (),
    }
  });
}
```