### PR TITLE
Fix beep sound, closes #799

### DIFF
--- a/.changes/beepfix.md
+++ b/.changes/beepfix.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix the beep sound on macOS

--- a/examples/custom_protocol_page1.html
+++ b/examples/custom_protocol_page1.html
@@ -15,8 +15,14 @@
   <h1>Welcome to WRY!</h1>
   <p>Page 1</p>
   <textarea></textarea>
+  <p id="keypresses"></p>
   <a href="/custom_protocol_page2.html">Link</a>
   <script type="text/javascript" src="/custom_protocol_script.js"></script>
+  <script type="text/javascript">
+    document.body.addEventListener('keydown', (event) => {
+      document.querySelector('#keypresses').innerHTML += ' ' + event.key
+    })
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

All I did was have the `WryWebViewParent` call `performKeyEquivalent` on the `menu`. As far as I can tell, everything works:
- The frontend receives `Escape` keydown events
- There's no beep sound. Built-in menus like `Copy` can still beep, but that's correct behavior - Safari acts the same. You can prevent the menu (and by extension, the beep) from being called using `e.preventDefault()` in the frontend.
- `Q` and `Ctrl+Shift+Q` menus work
- Menus only fire once

Closes #799

@wusyong Is there anything I'm missing?