### PR TITLE
fix(bench): fix compile errors caused by breaking change in response body type

### DIFF
--- a/.changes/fix-benchmark.md
+++ b/.changes/fix-benchmark.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix compile errors when building benchmarks. This was caused by the breaking change that custom protocol handler's response body type was changed.

--- a/bench/tests/src/cpu_intensive.rs
+++ b/bench/tests/src/cpu_intensive.rs
@@ -23,26 +23,26 @@ fn main() -> wry::Result<()> {
       exit(0);
     }
   };
-  let webview = WebViewBuilder::new(window)
+  let _webview = WebViewBuilder::new(window)
     .unwrap()
     .with_custom_protocol("wrybench".into(), move |request| {
       let path = request.uri().to_string();
       let requested_asset_path = path.strip_prefix("wrybench://localhost").unwrap();
-      let (data, mimetype): (Vec<u8>, String) = match requested_asset_path {
+      let (data, mimetype): (_, String) = match requested_asset_path {
         "/index.css" => (
-          include_bytes!("static/index.css").to_vec(),
+          include_bytes!("static/index.css").as_slice().into(),
           "text/css".into(),
         ),
         "/site.js" => (
-          include_bytes!("static/site.js").to_vec(),
+          include_bytes!("static/site.js").as_slice().into(),
           "text/javascript".into(),
         ),
         "/worker.js" => (
-          include_bytes!("static/worker.js").to_vec(),
+          include_bytes!("static/worker.js").as_slice().into(),
           "text/javascript".into(),
         ),
         _ => (
-          include_bytes!("static/index.html").to_vec(),
+          include_bytes!("static/index.html").as_slice().into(),
           "text/html".into(),
         ),
       };

--- a/bench/tests/src/custom_protocol.rs
+++ b/bench/tests/src/custom_protocol.rs
@@ -5,6 +5,24 @@
 use serde::{Deserialize, Serialize};
 use std::process::exit;
 
+const INDEX_HTML: &[u8] = br#"
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+    <h1>Welcome to WRY!</h1>
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        ipc.postMessage('dom-loaded')
+    })
+    </script>
+</body>
+</html>"#;
+
 #[derive(Debug, Serialize, Deserialize)]
 struct MessageParameters {
   message: String,
@@ -33,27 +51,9 @@ fn main() -> wry::Result<()> {
     .unwrap()
     .with_ipc_handler(handler)
     .with_custom_protocol("wrybench".into(), move |_request| {
-      let index_html = r#"
-      <!DOCTYPE html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        </head>
-        <body>
-          <h1>Welcome to WRY!</h1>
-          <script>
-            document.addEventListener('DOMContentLoaded', () => {
-              ipc.postMessage('dom-loaded')
-            })
-          </script>
-        </body>
-      </html>"#;
-
       Response::builder()
         .header(CONTENT_TYPE, "text/html")
-        .body(index_html.into())
+        .body(INDEX_HTML.into())
         .map_err(Into::into)
     })
     .with_url("wrybench://localhost")?


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I'm sorry that #797 broke benchmarks. I didn't notice that benchmarks are implemented as nested non-member crate, so simply running `cargo check` did not check it.