### PR TITLE
perf: Remove redundant `.clone()` calls and avoid unnecessary heap allocations

### DIFF
--- a/.changes/avoid-redundant-clone.md
+++ b/.changes/avoid-redundant-clone.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Remove redundant `.clone()` calls and avoid unnecessary heap allocations.

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -143,11 +143,8 @@ impl InnerWebView {
     if let Some(u) = url {
       let mut url_string = String::from(u.as_str());
       let name = u.scheme();
-      let schemes = custom_protocols
-        .iter()
-        .map(|(name, _)| name.as_str())
-        .collect::<Vec<_>>();
-      if schemes.contains(&name) {
+      let is_custom_protocol = custom_protocols.iter().any(|(n, _)| n == name);
+      if is_custom_protocol {
         url_string = u
           .as_str()
           .replace(&format!("{}://", name), &format!("https://{}.", name))

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -853,15 +853,15 @@ pub trait WebviewExtMacOS {
 #[cfg(target_os = "macos")]
 impl WebviewExtMacOS for WebView {
   fn webview(&self) -> cocoa::base::id {
-    self.webview.webview.clone()
+    self.webview.webview
   }
 
   fn manager(&self) -> cocoa::base::id {
-    self.webview.manager.clone()
+    self.webview.manager
   }
 
   fn ns_window(&self) -> cocoa::base::id {
-    self.webview.ns_window.clone()
+    self.webview.ns_window
   }
 }
 

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -794,7 +794,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
     let uri = take_pwstr(pwstr);
 
-    Url::parse(&uri.to_string()).unwrap()
+    Url::parse(&uri).unwrap()
   }
 
   pub fn eval(&self, js: &str) -> Result<()> {


### PR DESCRIPTION


<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This patch removes redundant `.clone()` calls and unnecessary heap allocations.