### PR TITLE
fix(macos): fix crash on calling custom protocol handler, closes #813

### DIFF
--- a/.changes/fix-wkwebview-crash.md
+++ b/.changes/fix-wkwebview-crash.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix WKWebView crashes when calling a custom protocol handler. This bug was caused by change at #797 due to mismatch of function signature.

--- a/.changes/fix-wkwebview-crash.md
+++ b/.changes/fix-wkwebview-crash.md
@@ -1,5 +1,0 @@
----
-"wry": patch
----
-
-Fix WKWebView crashes when calling a custom protocol handler. This bug was caused by change at #797 due to mismatch of function signature.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -113,7 +113,7 @@ impl InnerWebView {
         let function = this.get_ivar::<*mut c_void>("function");
         if !function.is_null() {
           let function = &mut *(*function
-            as *mut Box<dyn for<'s> Fn(&'s Request<Vec<u8>>) -> Result<Response<Vec<u8>>>>);
+            as *mut Box<dyn Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>>>);
 
           // Get url request
           let request: id = msg_send![task, request];


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This bug was caused by the change at #797 due to function signature mismatch. Correct return type was `Cow<'static, [u8]>` but `Vec<u8>` was specified. Compiler could not catch this issue because the type was dynamically casted in unsafe operations.
