### PR TITLE
fix(unix): race condition on script eval

### DIFF
--- a/.changes/eval-race-condition.md
+++ b/.changes/eval-race-condition.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Evaluate scripts after the page load starts on Linux and macOS.

--- a/.changes/linux-eval-race-condition.md
+++ b/.changes/linux-eval-race-condition.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Evaluate scripts after the page load starts on Linux.

--- a/.changes/linux-eval-race-condition.md
+++ b/.changes/linux-eval-race-condition.md
@@ -1,5 +1,0 @@
----
-"wry": patch
----
-
-Evaluate scripts after the page load starts on Linux.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

When evaluating scripts immediately after creating a webview on Linux, the script runs before the page is ready, so it gets lost or fails to execute. This commit changes it to be similar to other platforms, where the evaluated scripts are executed after the initialization scripts. This issue was raised in https://github.com/tauri-apps/tauri/pull/5615