### PR TITLE
fix(ios): navigation delegate class name conflict, closes #817

### DIFF
--- a/.changes/navigation-delegate-class-name-conflict.md
+++ b/.changes/navigation-delegate-class-name-conflict.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Change class declare name from `UIViewController` to `WryNavigationDelegate` to avoid class name conflict on iOS.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -468,7 +468,8 @@ impl InnerWebView {
 
       let pending_scripts = Arc::new(Mutex::new(Some(Vec::new())));
 
-      let navigation_delegate_cls = match ClassDecl::new("UIViewController", class!(NSObject)) {
+      let navigation_delegate_cls = match ClassDecl::new("WryNavigationDelegate", class!(NSObject))
+      {
         Some(mut cls) => {
           cls.add_ivar::<*mut c_void>("pending_scripts");
           cls.add_ivar::<*mut c_void>("navigation_policy_function");
@@ -488,7 +489,7 @@ impl InnerWebView {
           add_download_methods(&mut cls);
           cls.register()
         }
-        None => class!(UIViewController),
+        None => class!(WryNavigationDelegate),
       };
 
       let navigation_policy_handler: id = msg_send![navigation_delegate_cls, new];


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
issue #817 

Class name `UIViewController` was used in iOS's `UIKit` thus `ClassDecl` will fail and return `None`. https://github.com/tauri-apps/wry/blob/ca7c8e44832b3236f08022f7ea3469be9a65aa3f/src/webview/wkwebview/mod.rs#L471-L492

Later `set_ivar` with `pending_scripts` to UIKit's UIViewController will panic because there is no ivar `pending_scripts` in it.
https://github.com/tauri-apps/wry/blob/ca7c8e44832b3236f08022f7ea3469be9a65aa3f/src/webview/wkwebview/mod.rs#L496-L498