### PR TITLE
fix(examples): fix WKWebView may not support `WebAssembly.instantiateStreaming` yet

### DIFF
--- a/.changes/fix-example-wasm.md
+++ b/.changes/fix-example-wasm.md
@@ -1,5 +1,0 @@
----
-"wry": patch
----
-
-Fix `custom_protocol` example caused an error when instantiating the Wasm module. `WebAssembly.instantiateStreaming` is not supported by WKWebView yet. `WebAssembly.instantiate` should be used instead.

--- a/.changes/fix-example-wasm.md
+++ b/.changes/fix-example-wasm.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix `custom_protocol` example caused an error when instantiating the Wasm module. `WebAssembly.instantiateStreaming` is not supported by WKWebView yet. `WebAssembly.instantiate` should be used instead.

--- a/examples/custom_protocol_script.js
+++ b/examples/custom_protocol_script.js
@@ -6,8 +6,18 @@ if (window.location.pathname.startsWith('/custom_protocol_page2')) {
 } else {
     console.log("hello from javascript in page1");
 
-    WebAssembly.instantiateStreaming(fetch("/custom_protocol_wasm.wasm"))
-        .then(wasm => {
-            console.log(wasm.instance.exports.main()); // should log 42
-        })
+    if (typeof WebAssembly.instantiateStreaming !== 'undefined') {
+        WebAssembly.instantiateStreaming(fetch("/custom_protocol_wasm.wasm"))
+            .then(wasm => {
+                console.log(wasm.instance.exports.main()); // should log 42
+            });
+    } else {
+        // Older WKWebView may not support `WebAssembly.instantiateStreaming` yet.
+        fetch("/custom_protocol_wasm.wasm")
+            .then(response => response.arrayBuffer())
+            .then(bytes => WebAssembly.instantiate(bytes))
+            .then(wasm => {
+                console.log(wasm.instance.exports.main()); // should log 42
+            });
+    }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I noticed `custom_protocol` instance does not work properly on my macOS desktop. Looking at DevTools console, `WebAssembly.instantiateStreaming` was missing.

<img width="678" alt="スクリーンショット 2022-12-28 21 49 36" src="https://user-images.githubusercontent.com/823277/209815596-8eefe8e0-a007-4538-b8e7-5e392f7a8a54.png">

I fixed the example using `WebAssembly.instantiate`. Now `42` is properly output as intended.

<img width="912" alt="スクリーンショット 2022-12-28 21 51 22" src="https://user-images.githubusercontent.com/823277/209815768-d6ab234e-cdaf-4171-b078-8f7b52b1781b.png">
