### PR TITLE
refactor: improve android env vars naming

### DIFF
--- a/.changes/android-env-vars.md
+++ b/.changes/android-env-vars.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Changed env vars used when building for Android; changed `WRY_ANDROID_REVERSED_DOMAIN` to `WRY_ANDROID_PACKAGE` and `WRY_ANDROID_APP_NAME_SNAKE_CASE` to `WRY_ANDROID_LIBRARY`.

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ WebView2 provided by Microsoft Edge Chromium is used. So wry supports Windows 7,
 We have experimental support of mobile ends. If you are interested in playing or hacking it, please follow this [note](https://hackmd.io/XIcEwk4GSxy8APZhSa0UnA?view).
 
 When building for Android, WRY generates kotlin files that are needed to run WRY on Android and you have to set the following environment variables:
-- `WRY_ANDROID_REVERSED_DOMAIN`
-- `WRY_ANDROID_APP_NAME_SNAKE_CASE`
+- `WRY_ANDROID_PACKAGE`
+- `WRY_ANDROID_LIBRARY`
 - `WRY_ANDROID_KOTLIN_FILES_OUT_DIR`
 
 You can skip setting these environment variables if you are using the WRY template from our [`cargo-mobile`](https://github.com/tauri-apps/cargo-mobile) fork.

--- a/build.rs
+++ b/build.rs
@@ -23,13 +23,13 @@ fn main() {
       })
     }
 
-    println!("cargo:rerun-if-env-changed=WRY_ANDROID_REVERSED_DOMAIN");
-    println!("cargo:rerun-if-env-changed=WRY_ANDROID_APP_NAME_SNAKE_CASE");
+    println!("cargo:rerun-if-env-changed=WRY_ANDROID_PACKAGE");
+    println!("cargo:rerun-if-env-changed=WRY_ANDROID_LIBRARY");
     println!("cargo:rerun-if-env-changed=WRY_ANDROID_KOTLIN_FILES_OUT_DIR");
 
     if let Ok(kotlin_out_dir) = std::env::var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") {
-      let reversed_domain = env_var("WRY_ANDROID_REVERSED_DOMAIN");
-      let app_name_snake_case = env_var("WRY_ANDROID_APP_NAME_SNAKE_CASE");
+      let package = env_var("WRY_ANDROID_PACKAGE");
+      let library = env_var("WRY_ANDROID_LIBRARY");
 
       let kotlin_out_dir = PathBuf::from(&kotlin_out_dir)
         .canonicalize()
@@ -69,8 +69,8 @@ fn main() {
 
         let content = fs::read_to_string(file.path())
           .expect("failed to read kotlin file as string")
-          .replace("{{app-domain-reversed}}", &reversed_domain)
-          .replace("{{app-name-snake-case}}", &app_name_snake_case)
+          .replace("{{package}}", &package)
+          .replace("{{library}}", &library)
           .replace(
             "{{class-extension}}",
             &std::env::var(&class_extension_env).unwrap_or_default(),

--- a/src/webview/android/kotlin/Ipc.kt
+++ b/src/webview/android/kotlin/Ipc.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 import android.webkit.*
 
@@ -14,7 +14,7 @@ class Ipc {
 
     companion object {
         init {
-            System.loadLibrary("{{app-name-snake-case}}")
+            System.loadLibrary("{{library}}")
         }
     }
 

--- a/src/webview/android/kotlin/Logger.kt
+++ b/src/webview/android/kotlin/Logger.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 // taken from https://github.com/ionic-team/capacitor/blob/6658bca41e78239347e458175b14ca8bd5c1d6e8/android/capacitor/src/main/java/com/getcapacitor/Logger.java
 

--- a/src/webview/android/kotlin/PermissionHelper.kt
+++ b/src/webview/android/kotlin/PermissionHelper.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 // taken from https://github.com/ionic-team/capacitor/blob/6658bca41e78239347e458175b14ca8bd5c1d6e8/android/capacitor/src/main/java/com/getcapacitor/PermissionHelper.java
 

--- a/src/webview/android/kotlin/RustWebChromeClient.kt
+++ b/src/webview/android/kotlin/RustWebChromeClient.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 // taken from https://github.com/ionic-team/capacitor/blob/6658bca41e78239347e458175b14ca8bd5c1d6e8/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
 
@@ -37,7 +37,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 
-class RustWebChromeClient(appActivity: AppCompatActivity) : WebChromeClient() {  
+class RustWebChromeClient(appActivity: AppCompatActivity) : WebChromeClient() {
   private interface PermissionListener {
     fun onPermissionSelect(isGranted: Boolean?)
   }
@@ -51,7 +51,7 @@ class RustWebChromeClient(appActivity: AppCompatActivity) : WebChromeClient() {
   private var activityLauncher: ActivityResultLauncher<Intent>
   private var permissionListener: PermissionListener? = null
   private var activityListener: ActivityResultListener? = null
-  
+
   init {
     activity = appActivity
     val permissionCallback =

--- a/src/webview/android/kotlin/RustWebView.kt
+++ b/src/webview/android/kotlin/RustWebView.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 import android.annotation.SuppressLint
 import android.webkit.*

--- a/src/webview/android/kotlin/RustWebViewClient.kt
+++ b/src/webview/android/kotlin/RustWebViewClient.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 import android.webkit.*
 
@@ -16,7 +16,7 @@ class RustWebViewClient: WebViewClient() {
 
     companion object {
         init {
-            System.loadLibrary("{{app-name-snake-case}}")
+            System.loadLibrary("{{library}}")
         }
     }
 

--- a/src/webview/android/kotlin/TauriActivity.kt
+++ b/src/webview/android/kotlin/TauriActivity.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package {{app-domain-reversed}}.{{app-name-snake-case}}
+package {{package}}
 
 import android.annotation.SuppressLint
 import android.os.Build
@@ -96,7 +96,7 @@ abstract class TauriActivity : AppCompatActivity() {
 
     companion object {
         init {
-            System.loadLibrary("{{app-name-snake-case}}")
+            System.loadLibrary("{{library}}")
         }
     }
 


### PR DESCRIPTION
Renames the wry environment variables to `WRY_ANDROID_PACKAGE` and `WRY_ANDROID_LIBRARY`. These make the intent clearer. Also avoids wry adding an unwanted postfix to the package name (app-snake-case-name).