### PR TITLE
fix empty string bug (fix: #833)

### DIFF
--- a/.changes/check-for-empty-init-scripts.md
+++ b/.changes/check-for-empty-init-scripts.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+Ensures that the script passed to `.with_initialization_script("here")` is not empty.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -374,7 +374,9 @@ impl<'a> WebViewBuilder<'a> {
   /// - **Android:** The Android WebView does not provide an API for initialization scripts,
   /// so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
   pub fn with_initialization_script(mut self, js: &str) -> Self {
-    self.webview.initialization_scripts.push(js.to_string());
+    if !js.is_empty() {
+      self.webview.initialization_scripts.push(js.to_string());
+    }
     self
   }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #833
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary (not necessary - otherwise look at #833)
- [x] It can be built on all targets and pass CI/CD. (I imagine so. I changed one line, and forgot to enable CI/CD before pushing to my branch.)

### Other information
The bug appears to only affect Windows (macOS untested, but highly unlikely to be affected). The change catches empty strings higher in the call-chain - specifically in the "userland" function - as a just in case.