### PR TITLE
fix: make the Content-Type check spec compliant

### DIFF
--- a/.changes/fix-android-content-type-check.md
+++ b/.changes/fix-android-content-type-check.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-Make the `Content-Type` spec compliant. This fixes the injection of `intialization_scripts` for devServers where the `Content-Type` header includes more information than just `"text/plain"`.
+On Android, fix the injection of `intialization_scripts` for devServers where the `Content-Type` header includes more information than just `"text/plain"`.

--- a/.changes/fix-android-content-type-check.md
+++ b/.changes/fix-android-content-type-check.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Make the `Content-Type` spec compliant. This fixes the injection of `intialization_scripts` for devServers where the `Content-Type` header includes more information than just `"text/plain"`.

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -197,8 +197,18 @@ impl InnerWebView {
             .unwrap();
 
           if let Ok(mut response) = (custom_protocol.1)(&request) {
-            if response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static("text/html"))
-            {
+            let should_inject_scripts = response
+              .headers()
+              .get(CONTENT_TYPE)
+              // Content-Type must begin with the media type, but is case-insensitive. 
+              // It may also be followed by any number of semicolon-delimited key value pairs.
+              // We don't care about these here.
+              // source: https://httpwg.org/specs/rfc9110.html#rfc.section.8.3.1
+              .and_then(|content_type| content_type.to_str().ok())
+              .map(|content_type_str| content_type_str.to_lowercase().starts_with("text/html"))
+              .unwrap_or_default();
+
+            if should_inject_scripts {
               if !initialization_scripts.is_empty() {
                 let mut document =
                   kuchiki::parse_html().one(String::from_utf8_lossy(response.body()).into_owned());

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -200,7 +200,7 @@ impl InnerWebView {
             let should_inject_scripts = response
               .headers()
               .get(CONTENT_TYPE)
-              // Content-Type must begin with the media type, but is case-insensitive. 
+              // Content-Type must begin with the media type, but is case-insensitive.
               // It may also be followed by any number of semicolon-delimited key value pairs.
               // We don't care about these here.
               // source: https://httpwg.org/specs/rfc9110.html#rfc.section.8.3.1


### PR DESCRIPTION
This fixes the injection of intialization_scripts for devServers where the Content-Type header includes more information than just "text/plain"

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve tauri-apps/tauri#6053
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
