### PR TITLE
fix(android): restore asset loading functionality to android (fix: #846)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[build]
-target = "aarch64-linux-android"
+# [build]
+# target = "aarch64-linux-android"
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-mmacosx-version-min=10.12"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-#[build]
-#target = "aarch64-linux-android"
+[build]
+target = "aarch64-linux-android"
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-mmacosx-version-min=10.12"]

--- a/.changes/fix-android-asset-loading.md
+++ b/.changes/fix-android-asset-loading.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On Android, `wry` can again load assets from the apk's `asset` folder via a custom protocol. This is set by `WebViewBuilder`'s method `with_asset_loader`, which is exclusive to Android (by virtue of existing within `WebViewBuilderExtAndroid`).

--- a/src/webview/android/binding.rs
+++ b/src/webview/android/binding.rs
@@ -179,11 +179,9 @@ pub unsafe fn withAssetLoader(_: JNIEnv, _: JClass, _: jboolean) -> jboolean {
 #[allow(non_snake_case)]
 pub unsafe fn assetLoaderDomain(env: JNIEnv, _: JClass, _: jboolean) -> jstring {
   // the _: jboolean parameter is here simply because of android_fn!
-  let domain = ASSET_LOADER_DOMAIN
-    .get()
-    .unwrap_or(&None)
-    .clone()
-    .unwrap_or(String::from("wry.assets"));
-
-  env.new_string(domain).unwrap().into_raw()
+  if let Some(domain) = ASSET_LOADER_DOMAIN.get() {
+    env.new_string(domain).unwrap().into_raw()
+  } else {
+    env.new_string("wry.assets").unwrap().into_raw()
+  }
 }

--- a/src/webview/android/binding.rs
+++ b/src/webview/android/binding.rs
@@ -6,6 +6,7 @@ use http::{
   header::{HeaderName, HeaderValue, CONTENT_TYPE},
   Request,
 };
+pub use tao::platform::android::ndk_glue::jni::sys::{jboolean, jstring};
 use tao::platform::android::ndk_glue::jni::{
   errors::Error as JniError,
   objects::{JClass, JMap, JObject, JString, JValue},
@@ -13,7 +14,10 @@ use tao::platform::android::ndk_glue::jni::{
   JNIEnv,
 };
 
-use super::{create_headers_map, IPC, REQUEST_HANDLER, TITLE_CHANGE_HANDLER};
+use super::{
+  create_headers_map, ASSET_LOADER_DOMAIN, IPC, REQUEST_HANDLER, TITLE_CHANGE_HANDLER,
+  WITH_ASSET_LOADER,
+};
 
 fn handle_request(env: JNIEnv, request: JObject) -> Result<jobject, JniError> {
   let mut request_builder = Request::builder();
@@ -164,4 +168,22 @@ pub unsafe fn handleReceivedTitle(env: JNIEnv, _: JClass, _webview: JObject, tit
     }
     Err(e) => log::warn!("Failed to parse JString: {}", e),
   }
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn withAssetLoader(_: JNIEnv, _: JClass, _: jboolean) -> jboolean {
+  // the _: jboolean parameter is here simply because of android_fn!
+  (*WITH_ASSET_LOADER.get().unwrap_or(&false)).into()
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn assetLoaderDomain(env: JNIEnv, _: JClass, _: jboolean) -> jstring {
+  // the _: jboolean parameter is here simply because of android_fn!
+  let domain = ASSET_LOADER_DOMAIN
+    .get()
+    .unwrap_or(&None)
+    .clone()
+    .unwrap_or(String::from("wry.assets"));
+
+  env.new_string(domain).unwrap().into_raw()
 }

--- a/src/webview/android/binding.rs
+++ b/src/webview/android/binding.rs
@@ -171,14 +171,12 @@ pub unsafe fn handleReceivedTitle(env: JNIEnv, _: JClass, _webview: JObject, tit
 }
 
 #[allow(non_snake_case)]
-pub unsafe fn withAssetLoader(_: JNIEnv, _: JClass, _: jboolean) -> jboolean {
-  // the _: jboolean parameter is here simply because of android_fn!
+pub unsafe fn withAssetLoader(_: JNIEnv, _: JClass) -> jboolean {
   (*WITH_ASSET_LOADER.get().unwrap_or(&false)).into()
 }
 
 #[allow(non_snake_case)]
-pub unsafe fn assetLoaderDomain(env: JNIEnv, _: JClass, _: jboolean) -> jstring {
-  // the _: jboolean parameter is here simply because of android_fn!
+pub unsafe fn assetLoaderDomain(env: JNIEnv, _: JClass) -> jstring {
   if let Some(domain) = ASSET_LOADER_DOMAIN.get() {
     env.new_string(domain).unwrap().into_raw()
   } else {

--- a/src/webview/android/kotlin/RustWebViewClient.kt
+++ b/src/webview/android/kotlin/RustWebViewClient.kt
@@ -5,13 +5,24 @@
 package {{package}}
 
 import android.webkit.*
+import android.content.Context
+import androidx.webkit.WebViewAssetLoader
 
-class RustWebViewClient: WebViewClient() {
+class RustWebViewClient(context: Context): WebViewClient() {
+    private val assetLoader = WebViewAssetLoader.Builder()
+        .setDomain(assetLoaderDomain())
+        .addPathHandler("/", WebViewAssetLoader.AssetsPathHandler(context))
+        .build()
+
     override fun shouldInterceptRequest(
         view: WebView,
         request: WebResourceRequest
     ): WebResourceResponse? {
-        return handleRequest(request)
+        if (withAssetLoader()) {
+            return assetLoader.shouldInterceptRequest(request.url)
+        } else {
+            return handleRequest(request)
+        }
     }
 
     companion object {
@@ -20,6 +31,8 @@ class RustWebViewClient: WebViewClient() {
         }
     }
 
+    private external fun assetLoaderDomain(): String
+    private external fun withAssetLoader(): Boolean
     private external fun handleRequest(request: WebResourceRequest): WebResourceResponse?
 
     {{class-extension}}

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -51,7 +51,7 @@ impl MainPipe<'_> {
             transparent,
             background_color,
             headers,
-            pl_attrs,
+            on_webview_created,
           } = attrs;
           // Create webview
           let rust_webview_class = find_class(
@@ -132,7 +132,7 @@ impl MainPipe<'_> {
             &[webview.into()],
           )?;
 
-          if let Some(on_webview_created) = pl_attrs.on_webview_created {
+          if let Some(on_webview_created) = on_webview_created {
             if let Err(e) = on_webview_created(super::Context {
               env,
               activity,
@@ -266,5 +266,12 @@ pub(crate) struct CreateWebViewAttributes {
   pub transparent: bool,
   pub background_color: Option<RGBA>,
   pub headers: Option<http::HeaderMap>,
-  pub pl_attrs: crate::webview::PlatformSpecificWebViewAttributes,
+  pub on_webview_created: Option<
+    Box<
+      dyn Fn(
+          super::Context,
+        ) -> std::result::Result<(), tao::platform::android::ndk_glue::jni::errors::Error>
+        + Send,
+    >,
+  >,
 }

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -92,7 +92,11 @@ impl MainPipe<'_> {
             activity,
             format!("{}/RustWebViewClient", PACKAGE.get().unwrap()),
           )?;
-          let webview_client = env.new_object(rust_webview_client_class, "()V", &[])?;
+          let webview_client = env.new_object(
+            rust_webview_client_class,
+            "(Landroid/content/Context;)V",
+            &[activity.into()],
+          )?;
           env.call_method(
             webview,
             "setWebViewClient",

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -62,7 +62,7 @@ macro_rules! android_binding {
       $package,
       RustWebViewClient,
       withAssetLoader,
-      [jboolean] // this is unnecessary but I could not find a way to pass an empty args
+      [],
       jboolean
     );
     android_fn!(
@@ -70,7 +70,7 @@ macro_rules! android_binding {
       $package,
       RustWebViewClient,
       assetLoaderDomain,
-      [jboolean] // this is unnecessary but I could not find a way to pass an empty args
+      [],
       jstring
     );
     android_fn!($domain, $package, Ipc, ipc, [JString]);

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -82,7 +82,7 @@ pub static IPC: OnceCell<UnsafeIpc> = OnceCell::new();
 pub static REQUEST_HANDLER: OnceCell<UnsafeRequestHandler> = OnceCell::new();
 pub static TITLE_CHANGE_HANDLER: OnceCell<UnsafeTitleHandler> = OnceCell::new();
 pub static WITH_ASSET_LOADER: OnceCell<bool> = OnceCell::new();
-pub static ASSET_LOADER_DOMAIN: OnceCell<Option<String>> = OnceCell::new();
+pub static ASSET_LOADER_DOMAIN: OnceCell<String> = OnceCell::new();
 
 pub struct UnsafeIpc(Box<dyn Fn(&Window, String)>, Rc<Window>);
 impl UnsafeIpc {
@@ -203,7 +203,8 @@ impl InnerWebView {
     }
 
     WITH_ASSET_LOADER.get_or_init(move || with_asset_loader);
-    ASSET_LOADER_DOMAIN.get_or_init(move || asset_loader_domain);
+    ASSET_LOADER_DOMAIN
+      .get_or_init(move || asset_loader_domain.unwrap_or(String::from("wry.assets")));
 
     REQUEST_HANDLER.get_or_init(move || {
       UnsafeRequestHandler::new(Box::new(move |mut request| {

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -184,9 +184,9 @@ impl InnerWebView {
     } = attributes;
 
     let super::PlatformSpecificWebViewAttributes {
+      on_webview_created,
       with_asset_loader,
       asset_loader_domain,
-      ..
     } = pl_attrs;
 
     if let Some(u) = url {
@@ -205,7 +205,7 @@ impl InnerWebView {
         background_color,
         transparent,
         headers,
-        pl_attrs,
+        on_webview_created,
       }));
     }
 

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -210,8 +210,9 @@ impl InnerWebView {
     }
 
     WITH_ASSET_LOADER.get_or_init(move || with_asset_loader);
-    ASSET_LOADER_DOMAIN
-      .get_or_init(move || asset_loader_domain.unwrap_or(String::from("wry.assets")));
+    if let Some(domain) = asset_loader_domain {
+      ASSET_LOADER_DOMAIN.get_or_init(move || domain);
+    }
 
     REQUEST_HANDLER.get_or_init(move || {
       UnsafeRequestHandler::new(Box::new(move |mut request| {


### PR DESCRIPTION
Implements WebViewAssetLoader to load assets from the asset folder in Android when `with_asset_loader` is called in the builder. The function also sets the desired protocol for use in `with_url`, although the url must always be `<protocol>://assets/<path>`.

Refs: #846

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #846 
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
I am willing to provide an update to the `wry` template in [`tauri-mobile`](https://github.com/tauri-apps/tauri-mobile) showcasing the correct form of asset loading on Android.