### PR TITLE
Fix: WebViewBuilder.with_url crash in widows release when used with mimalloc (fix #863)

### DIFF
--- a/.changes/fix-with_url.txt
+++ b/.changes/fix-with_url.txt
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix the WebViewBuilder::with_url when the projet use mimalloc (https://github.com/tauri-apps/wry/issues/863)

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -702,10 +702,9 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
         if let Some(headers) = attributes.headers {
           load_url_with_headers(&webview, env, &url_string, headers);
         } else {
-          let url = PCWSTR::from_raw(encode_wide(url_string).as_ptr());
           unsafe {
             webview
-              .Navigate(url)
+              .Navigate(PCWSTR::from_raw(encode_wide(url_string).as_ptr()))
               .map_err(webview2_com::Error::WindowsError)?;
           }
         }


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #863
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
