### PR TITLE
Async custom uri protocol

### DIFF
--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -203,6 +203,10 @@ impl InnerWebView {
             .parse()
             .unwrap();
 
+          // (custom_protocol.1)(WryRequest(request, &|resp| {
+          // }));
+
+          // TODO: Convert this to be async
           if let Ok(mut response) = (custom_protocol.1)(&request) {
             let should_inject_scripts = response
               .headers()

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -111,7 +111,7 @@ pub trait WebContextExt {
   /// relying on the platform's implementation to properly handle duplicated scheme handlers.
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
+    F: Fn(WryRequest) + 'static;
 
   /// Register a custom protocol to the web context, only if it is not a duplicate scheme.
   ///
@@ -119,7 +119,7 @@ pub trait WebContextExt {
   /// function will return `Err(Error::DuplicateCustomProtocol)`.
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
+    F: Fn(WryRequest) + 'static;
 
   /// Add a [`WebView`] to the queue waiting to be opened.
   ///
@@ -325,41 +325,44 @@ where
         }
       };
 
-      match handler(&http_request) {
-        Ok(http_response) => {
-          let buffer = http_response.body();
-          let input = gio::MemoryInputStream::from_bytes(&glib::Bytes::from(buffer));
-          let content_type = http_response
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|h| h.to_str().ok());
-          #[cfg(feature = "linux-headers")]
-          {
-            use soup::{MessageHeaders, MessageHeadersType};
-            use webkit2gtk::URISchemeResponse;
+      handler(WryRequest(
+        http_request,
+        &|resp| match handler(&http_request) {
+          Ok(http_response) => {
+            let buffer = http_response.body();
+            let input = gio::MemoryInputStream::from_bytes(&glib::Bytes::from(buffer));
+            let content_type = http_response
+              .headers()
+              .get(CONTENT_TYPE)
+              .and_then(|h| h.to_str().ok());
+            #[cfg(feature = "linux-headers")]
+            {
+              use soup::{MessageHeaders, MessageHeadersType};
+              use webkit2gtk::URISchemeResponse;
 
-            let response = URISchemeResponse::new(&input, buffer.len() as i64);
-            response.set_status(http_response.status().as_u16() as u32, None);
-            if let Some(content_type) = content_type {
-              response.set_content_type(content_type);
+              let response = URISchemeResponse::new(&input, buffer.len() as i64);
+              response.set_status(http_response.status().as_u16() as u32, None);
+              if let Some(content_type) = content_type {
+                response.set_content_type(content_type);
+              }
+
+              let mut headers = MessageHeaders::new(MessageHeadersType::Response);
+              for (name, value) in http_response.headers().into_iter() {
+                headers.append(name.as_str(), value.to_str().unwrap_or(""));
+              }
+              response.set_http_headers(&mut headers);
+
+              request.finish_with_response(&response);
             }
-
-            let mut headers = MessageHeaders::new(MessageHeadersType::Response);
-            for (name, value) in http_response.headers().into_iter() {
-              headers.append(name.as_str(), value.to_str().unwrap_or(""));
-            }
-            response.set_http_headers(&mut headers);
-
-            request.finish_with_response(&response);
+            #[cfg(not(feature = "linux-headers"))]
+            request.finish(&input, buffer.len() as i64, content_type)
           }
-          #[cfg(not(feature = "linux-headers"))]
-          request.finish(&input, buffer.len() as i64, content_type)
-        }
-        Err(_) => request.finish_error(&mut glib::Error::new(
-          FileError::Exist,
-          "Could not get requested file.",
-        )),
-      }
+          Err(_) => request.finish_error(&mut glib::Error::new(
+            FileError::Exist,
+            "Could not get requested file.",
+          )),
+        },
+      ));
     } else {
       request.finish_error(&mut glib::Error::new(
         FileError::Exist,

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -299,7 +299,7 @@ where
       {
         use http::{header::HeaderName, HeaderValue};
 
-        if let Some(mut headers) = request.http_headers() {
+        if let Some(headers) = request.http_headers() {
           if let Some(map) = http_request.headers_mut() {
             headers.foreach(move |k, v| {
               if let Ok(name) = HeaderName::from_bytes(k.as_bytes()) {

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -5,7 +5,7 @@
 mod file_drop;
 
 use crate::{
-  webview::{WebContext, WebViewAttributes, RGBA},
+  webview::{WebContext, WebViewAttributes, WryRequest, RGBA},
   Error, Result,
 };
 
@@ -604,8 +604,8 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
                         let mut body_sent = None;
                         if !content.is_empty() {
-                          let stream = CreateStreamOnHGlobal(0, true)?;
-                          stream.SetSize(content.len() as u64)?;
+                          let stream = CreateStreamOnHGlobal(0, true).unwrap();
+                          stream.SetSize(content.len() as u64).unwrap();
                           let mut cb_write = MaybeUninit::uninit();
                           if stream
                             .Write(
@@ -622,16 +622,18 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
                         // FIXME: Set http response version
 
-                        let response = env.CreateWebResourceResponse(
-                          body_sent.as_ref(),
-                          status_code.as_u16() as i32,
-                          PCWSTR::from_raw(
-                            encode_wide(status_code.canonical_reason().unwrap_or("OK")).as_ptr(),
-                          ),
-                          PCWSTR::from_raw(encode_wide(headers_map).as_ptr()),
-                        )?;
+                        let response = env
+                          .CreateWebResourceResponse(
+                            body_sent.as_ref(),
+                            status_code.as_u16() as i32,
+                            PCWSTR::from_raw(
+                              encode_wide(status_code.canonical_reason().unwrap_or("OK")).as_ptr(),
+                            ),
+                            PCWSTR::from_raw(encode_wide(headers_map).as_ptr()),
+                          )
+                          .unwrap();
 
-                        args.SetResponse(&response)?;
+                        args.SetResponse(&response).unwrap();
                       }
                       Err(_) => {
                         // TODO: Handle this error
@@ -639,7 +641,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
                       }
                     }
 
-                    let _ = unsafe { deferral.Complete()? }; // TODO: This ignores the error which is bad, but given this is an async operation I don't know what we should do?
+                    let _ = deferral.Complete().unwrap(); // TODO: This ignores the error which is bad, but given this is an async operation I don't know what we should do?
                   }));
                 }
               }

--- a/src/webview/wkwebview/web_context.rs
+++ b/src/webview/wkwebview/web_context.rs
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::Result;
+use crate::webview::WryRequest;
 
 use crate::webview::web_context::WebContextData;
-use http::{Request, Response};
-use std::borrow::Cow;
 
 #[derive(Debug)]
 pub struct WebContextImpl {
-  protocols: Vec<*mut Box<dyn Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>>>>,
+  protocols: Vec<*mut Box<dyn Fn(WryRequest)>>,
 }
 
 impl WebContextImpl {
@@ -22,10 +20,7 @@ impl WebContextImpl {
 
   pub fn set_allows_automation(&mut self, _flag: bool) {}
 
-  pub fn registered_protocols(
-    &mut self,
-    handler: *mut Box<dyn Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>>>,
-  ) {
+  pub fn registered_protocols(&mut self, handler: *mut Box<dyn Fn(WryRequest)>) {
     self.protocols.push(handler);
   }
 }


### PR DESCRIPTION
Some discussion has been done previously but I wanted to attempt implementing support for asynchronous custom URI protocols into Wry. This would be the precursor to adding support into Tauri. Related issue: #420

As Wry is async runtime agnostic this system can't work on `Future`'s so I have built it to use callbacks. 

This PR is currently still a work in progress and was created to gather feedback before I commit more time to finish it so let me know if it matches your vision or not.

## Limitation - Forgetting to call `respond`.

If the user forgets to call the `req.respond` callback the webview will crash on macOS and i'm sure it will be similar on other operating systems. Without an async executor to know when handling the request is finished I can't think of a way to prevent this behavior.

One way we could proceed here is to expose the `with_custom_protocol_async` function under a feature like `unstable_async_protocol` to reinforce to the user that the API is a more advanced and dangerous API. This issue doesn't affect the existing `with_custom_protocol` API because that calls `req.respond` inside of Wry so it can be guaranteed.

In the context of Tauri this API would be able to be used with the async executor to make it safe from crashing.

## Issue

Required to be done before merge:
 - [x] macOS Support
 - [x] Linux Support
 - [x] Windows Support
 - [ ] Android Support - Not Implemented
 - [ ] It can be built on all targets and pass CI/CD.
 - [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).

### What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No