### PR TITLE
fix: Added thread sleep to resize event to hack around bad resize performance (fix #tauri/issues/4012)

### DIFF
--- a/.changes/resize-delay.md
+++ b/.changes/resize-delay.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Added resize-delay feature for better resize performance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ devtools = [ ]
 transparent = [ ]
 fullscreen = [ ]
 linux-headers = [ "webkit2gtk/v2_36" ]
+resize-delay = [ ]
 
 [dependencies]
 libc = "0.2"

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -730,6 +730,10 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
           let controller = dwrefdata as *mut ICoreWebView2Controller;
           let mut client_rect = RECT::default();
           win32wm::GetClientRect(hwnd, &mut client_rect);
+
+          #[cfg(feature = "resize-delay")]
+          std::thread::sleep(std::time::Duration::from_nanos(1));
+
           let _ = (*controller).SetBounds(RECT {
             left: 0,
             top: 0,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve https://github.com/tauri-apps/tauri/issues/4012
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
Also kind of related to another issue https://github.com/tauri-apps/tauri/issues/6322
