### PR TITLE
fix(ios): set scroll bounce default to NO

### DIFF
--- a/.changes/ios-default-scroll-bounce.md
+++ b/.changes/ios-default-scroll-bounce.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On iOS, set webview scroll bounce default to NO.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -345,6 +345,10 @@ impl InnerWebView {
         // set all autoresizingmasks
         let () = msg_send![webview, setAutoresizingMask: 31];
         let _: () = msg_send![webview, initWithFrame:frame configuration:config];
+
+        // disable scroll bounce by default
+        let scroll: id = msg_send![webview, scrollView];
+        let _: () = msg_send![scroll, setBounces: NO];
       }
 
       // allowsBackForwardNavigation


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

Relates to #557, this PR will set scroll bounce to default as NO on iOS.

Prior to this PR, scroll bounce was set to default as YES. With this patch, the behavior will be changed. Given the usage scenario and the fact that the mobile platform is still in the alpha stage, I believe it's acceptable to implement this change at this time.
