### PR TITLE
fix(windows): Ignore resize event when minimizing frameless windows

### DIFF
--- a/.changes/frameless-minimize-windows.md
+++ b/.changes/frameless-minimize-windows.md
@@ -2,6 +2,4 @@
 "wry": patch
 ---
 
-On Windows when a frameless window (decorations set to false) is minimized it will be resized to a 
-small resolution. This resize can cause a significant delay when un-minimizing and redrawing the 
-content of the webview after the original window dimensions are restored.
+Revert [`51b49c54`](https://github.com/tauri-apps/wry/commit/51b49c54e41c71d1c5f03b568094d43fb9dc32ac) which hid the webview when minimized on Windows.

--- a/.changes/frameless-minimize-windows.md
+++ b/.changes/frameless-minimize-windows.md
@@ -1,0 +1,7 @@
+---
+"wry": patch
+---
+
+On Windows when a frameless window (decorations set to false) is minimized it will be resized to a 
+small resolution. This resize can cause a significant delay when un-minimizing and redrawing the 
+content of the webview after the original window dimensions are restored.

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -738,16 +738,6 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
             right: client_rect.right - client_rect.left,
             bottom: client_rect.bottom - client_rect.top,
           });
-
-          if wparam == WPARAM(win32wm::SIZE_MINIMIZED as _) {
-            let _ = (*controller).SetIsVisible(false);
-          }
-
-          if wparam == WPARAM(win32wm::SIZE_RESTORED as _)
-            || wparam == WPARAM(win32wm::SIZE_MAXIMIZED as _)
-          {
-            let _ = (*controller).SetIsVisible(true);
-          }
         }
 
         win32wm::WM_SETFOCUS | win32wm::WM_ENTERSIZEMOVE => {


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
I am by no means an experienced Rust programmer so if there's a better way of getting the `Rc<Window>` into the `SetWindowSubclass` callback let me know.

Here is the issue that this PR resolves, it is very noticeable here because I'm displaying a large image in the webview.

https://user-images.githubusercontent.com/1155344/227256624-a5901c7c-e4ba-4239-8aa5-e25fd58c2b0d.mp4

----

And with these changes it looks like this:

https://user-images.githubusercontent.com/1155344/227256702-06173bfb-3cea-45fa-8fb4-a63ddbf35551.mp4