### PR TITLE
feat: Add setting to enable autoplay

### DIFF
--- a/.changes/autoplay.md
+++ b/.changes/autoplay.md
@@ -1,0 +1,5 @@
+---
+'wry': patch
+---
+
+Add Webview attribute to enable/disable autoplay. Enabled by default.

--- a/src/webview/android/kotlin/RustWebView.kt
+++ b/src/webview/android/kotlin/RustWebView.kt
@@ -16,6 +16,7 @@ class RustWebView(context: Context): WebView(context) {
         settings.domStorageEnabled = true
         settings.setGeolocationEnabled(true)
         settings.databaseEnabled = true
+        // TODO: Make this configurable
         settings.mediaPlaybackRequiresUserGesture = false
         settings.javaScriptCanOpenWindowsAutomatically = true
         {{class-init}}

--- a/src/webview/android/kotlin/RustWebView.kt
+++ b/src/webview/android/kotlin/RustWebView.kt
@@ -16,7 +16,6 @@ class RustWebView(context: Context): WebView(context) {
         settings.domStorageEnabled = true
         settings.setGeolocationEnabled(true)
         settings.databaseEnabled = true
-        // TODO: Make this configurable
         settings.mediaPlaybackRequiresUserGesture = false
         settings.javaScriptCanOpenWindowsAutomatically = true
         {{class-init}}
@@ -31,6 +30,13 @@ class RustWebView(context: Context): WebView(context) {
     fun loadUrlMainThread(url: String, additionalHttpHeaders: Map<String, String>) {
         post {
           super.loadUrl(url, additionalHttpHeaders)
+        }
+    }
+
+    fun setAutoPlay(enable: Boolean) {
+        post {
+          val settings = super.getSettings()
+          settings.setMediaPlaybackRequiresUserGesture(!enable)
         }
     }
 

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -52,6 +52,7 @@ impl MainPipe<'_> {
             background_color,
             headers,
             on_webview_created,
+            autoplay,
           } = attrs;
           // Create webview
           let rust_webview_class = find_class(
@@ -64,6 +65,9 @@ impl MainPipe<'_> {
             "(Landroid/content/Context;)V",
             &[activity.into()],
           )?;
+
+          // set media autoplay
+          env.call_method(webview, "setAutoPlay", "(Z)V", &[autoplay.into()])?;
 
           // Load URL
           if let Ok(url) = env.new_string(url) {
@@ -268,6 +272,7 @@ pub(crate) struct CreateWebViewAttributes {
   pub transparent: bool,
   pub background_color: Option<RGBA>,
   pub headers: Option<http::HeaderMap>,
+  pub autoplay: bool,
   pub on_webview_created: Option<
     Box<
       dyn Fn(

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -180,6 +180,7 @@ impl InnerWebView {
       background_color,
       transparent,
       headers,
+      autoplay,
       ..
     } = attributes;
 
@@ -206,6 +207,7 @@ impl InnerWebView {
         transparent,
         headers,
         on_webview_created,
+        autoplay,
       }));
     }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -229,6 +229,10 @@ pub struct WebViewAttributes {
   pub document_title_changed_handler: Option<Box<dyn Fn(&Window, String)>>,
 
   /// Whether all media can be played without user interaction.
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Android:** Autoplay will always be enabled on window creation.
   pub autoplay: bool,
 }
 
@@ -653,6 +657,7 @@ pub trait WebViewBuilderExtWindows {
   ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.
+  /// Furthermore you need to add `--autoplay-policy=no-user-gesture-required` if autoplay is enabled.
   fn with_additional_browser_args<S: Into<String>>(self, additional_args: S) -> Self;
 
   /// Determines whether browser-specific accelerator keys are enabled. When this setting is set to

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -232,7 +232,7 @@ pub struct WebViewAttributes {
   ///
   /// ## Platform-specific:
   ///
-  /// - **Android:** Autoplay will always be enabled on window creation.
+  /// - **Android:** Unsupported. Autoplay will always be enabled in new windows.
   pub autoplay: bool,
 }
 
@@ -656,8 +656,8 @@ pub trait WebViewBuilderExtWindows {
   /// ## Warning
   ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
-  /// so if you use this method, you also need to disable these components by yourself if you want.
-  /// Furthermore you need to add `--autoplay-policy=no-user-gesture-required` if autoplay is enabled.
+  /// and `--autoplay-policy=no-user-gesture-required` if autoplay is enabled
+  /// so if you use this method, you have to add these arguments yourself if you want to keep the same behavior.
   fn with_additional_browser_args<S: Into<String>>(self, additional_args: S) -> Self;
 
   /// Determines whether browser-specific accelerator keys are enabled. When this setting is set to

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -229,10 +229,6 @@ pub struct WebViewAttributes {
   pub document_title_changed_handler: Option<Box<dyn Fn(&Window, String)>>,
 
   /// Whether all media can be played without user interaction.
-  ///
-  /// ## Platform-specific:
-  ///
-  /// - **Android:** Unsupported. Autoplay will always be enabled in new windows.
   pub autoplay: bool,
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -227,6 +227,9 @@ pub struct WebViewAttributes {
 
   /// Set a handler closure to process the change of the webview's document title.
   pub document_title_changed_handler: Option<Box<dyn Fn(&Window, String)>>,
+
+  /// Whether all media can be played without user interaction.
+  pub autoplay: bool,
 }
 
 impl Default for WebViewAttributes {
@@ -256,6 +259,7 @@ impl Default for WebViewAttributes {
       accept_first_mouse: false,
       back_forward_navigation_gestures: false,
       document_title_changed_handler: None,
+      autoplay: true,
     }
   }
 }
@@ -374,6 +378,12 @@ impl<'a> WebViewBuilder<'a> {
   /// Sets whether the WebView should be transparent.
   pub fn with_visible(mut self, visible: bool) -> Self {
     self.webview.visible = visible;
+    self
+  }
+
+  /// Sets whether all media can be played without user interaction.
+  pub fn with_autoplay(mut self, autoplay: bool) -> Self {
+    self.webview.autoplay = autoplay;
     self
   }
 

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -16,8 +16,9 @@ use std::{
 };
 use url::Url;
 use webkit2gtk::{
-  traits::*, LoadEvent, NavigationPolicyDecision, PolicyDecisionType, URIRequest,
+  traits::*, AutoplayPolicy, LoadEvent, NavigationPolicyDecision, PolicyDecisionType, URIRequest,
   UserContentInjectedFrames, UserScript, UserScriptInjectionTime, WebView, WebViewBuilder,
+  WebsitePoliciesBuilder,
 };
 use webkit2gtk_sys::{
   webkit_get_major_version, webkit_get_micro_version, webkit_get_minor_version,
@@ -70,6 +71,13 @@ impl InnerWebView {
       webview = webview.user_content_manager(web_context.manager());
       webview = webview.web_context(web_context.context());
       webview = webview.is_controlled_by_automation(web_context.allows_automation());
+      if attributes.autoplay {
+        webview = webview.website_policies(
+          &WebsitePoliciesBuilder::new()
+            .autoplay(AutoplayPolicy::Allow)
+            .build(),
+        );
+      }
       webview.build()
     };
 

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -72,7 +72,7 @@ impl InnerWebView {
     let file_drop_handler = attributes.file_drop_handler.take();
     let file_drop_window = window.clone();
 
-    let env = Self::create_environment(&web_context, pl_attrs.clone())?;
+    let env = Self::create_environment(&web_context, pl_attrs.clone(), attributes.autoplay)?;
     let controller = Self::create_controller(hwnd, &env)?;
     let webview = Self::init_webview(window, hwnd, attributes, &env, &controller, pl_attrs)?;
 
@@ -93,6 +93,7 @@ impl InnerWebView {
   fn create_environment(
     web_context: &Option<&mut WebContext>,
     pl_attrs: super::PlatformSpecificWebViewAttributes,
+    autoplay: bool,
   ) -> webview2_com::Result<ICoreWebView2Environment> {
     let (tx, rx) = mpsc::channel();
 
@@ -127,7 +128,14 @@ impl InnerWebView {
           encode_wide(pl_attrs.additional_browser_args.unwrap_or_else(|| {
             // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
             // and "smart screen" - See https://github.com/tauri-apps/tauri/issues/1345
-            "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection".to_string()
+            format!(
+              "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection{}",
+              if autoplay {
+                " --autoplay-policy=no-user-gesture-required"
+              } else {
+                ""
+              }
+            )
           }))
           .as_ptr(),
         ));

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -301,6 +301,7 @@ impl InnerWebView {
       let webview: id = msg_send![cls, alloc];
       let _preference: id = msg_send![config, preferences];
       let _yes: id = msg_send![class!(NSNumber), numberWithBool:1];
+      let _no: id = msg_send![class!(NSNumber), numberWithBool:0];
 
       #[cfg(target_os = "macos")]
       (*webview).set_ivar(ACCEPT_FIRST_MOUSE, attributes.accept_first_mouse);
@@ -315,15 +316,19 @@ impl InnerWebView {
 
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("allowsPictureInPictureMediaPlayback")];
 
+      if attributes.autoplay {
+        // FIXME: No idea how to make this not crash the webview, we need to set it to `WKAudiovisualMediaTypeNone` which _should_ be `0` https://developer.apple.com/documentation/webkit/wkaudiovisualmediatypes/wkaudiovisualmediatypenone
+        let _: id = msg_send![config, setValue:_no forKey:NSString::new("mediaTypesRequiringUserActionForPlayback")];
+      }
+
       #[cfg(target_os = "macos")]
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("tabFocusesLinks")];
 
       #[cfg(feature = "transparent")]
       if attributes.transparent {
-        let no: id = msg_send![class!(NSNumber), numberWithBool:0];
         // Equivalent Obj-C:
         // [config setValue:@NO forKey:@"drawsBackground"];
-        let _: id = msg_send![config, setValue:no forKey:NSString::new("drawsBackground")];
+        let _: id = msg_send![config, setValue:_no forKey:NSString::new("drawsBackground")];
       }
 
       #[cfg(feature = "fullscreen")]

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -14,7 +14,7 @@ pub use web_context::WebContextImpl;
 use cocoa::appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable};
 use cocoa::{
   base::{id, nil, NO, YES},
-  foundation::{NSDictionary, NSFastEnumeration, NSInteger},
+  foundation::{NSDictionary, NSFastEnumeration, NSInteger, NSUInteger},
 };
 
 use std::{
@@ -301,7 +301,6 @@ impl InnerWebView {
       let webview: id = msg_send![cls, alloc];
       let _preference: id = msg_send![config, preferences];
       let _yes: id = msg_send![class!(NSNumber), numberWithBool:1];
-      let _no: id = msg_send![class!(NSNumber), numberWithBool:0];
 
       #[cfg(target_os = "macos")]
       (*webview).set_ivar(ACCEPT_FIRST_MOUSE, attributes.accept_first_mouse);
@@ -317,8 +316,9 @@ impl InnerWebView {
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("allowsPictureInPictureMediaPlayback")];
 
       if attributes.autoplay {
+        let none: NSUInteger = 0;
         // FIXME: No idea how to make this not crash the webview, we need to set it to `WKAudiovisualMediaTypeNone` which _should_ be `0` https://developer.apple.com/documentation/webkit/wkaudiovisualmediatypes/wkaudiovisualmediatypenone
-        let _: id = msg_send![config, setValue:_no forKey:NSString::new("mediaTypesRequiringUserActionForPlayback")];
+        let _: id = msg_send![config, setValue:none forKey:NSString::new("mediaTypesRequiringUserActionForPlayback")];
       }
 
       #[cfg(target_os = "macos")]
@@ -326,9 +326,10 @@ impl InnerWebView {
 
       #[cfg(feature = "transparent")]
       if attributes.transparent {
+        let no: id = msg_send![class!(NSNumber), numberWithBool:0];
         // Equivalent Obj-C:
         // [config setValue:@NO forKey:@"drawsBackground"];
-        let _: id = msg_send![config, setValue:_no forKey:NSString::new("drawsBackground")];
+        let _: id = msg_send![config, setValue:no forKey:NSString::new("drawsBackground")];
       }
 
       #[cfg(feature = "fullscreen")]

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -14,7 +14,7 @@ pub use web_context::WebContextImpl;
 use cocoa::appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable};
 use cocoa::{
   base::{id, nil, NO, YES},
-  foundation::{NSDictionary, NSFastEnumeration, NSInteger, NSUInteger},
+  foundation::{NSDictionary, NSFastEnumeration, NSInteger},
 };
 
 use std::{
@@ -316,9 +316,7 @@ impl InnerWebView {
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("allowsPictureInPictureMediaPlayback")];
 
       if attributes.autoplay {
-        let none: NSUInteger = 0;
-        // FIXME: No idea how to make this not crash the webview, we need to set it to `WKAudiovisualMediaTypeNone` which _should_ be `0` https://developer.apple.com/documentation/webkit/wkaudiovisualmediatypes/wkaudiovisualmediatypenone
-        let _: id = msg_send![config, setValue:none forKey:NSString::new("mediaTypesRequiringUserActionForPlayback")];
+        let _: id = msg_send![config, setMediaTypesRequiringUserActionForPlayback:0];
       }
 
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
3 Open tasks/questions i need help with:
- I have no idea how to make the android one configurable
- The macos implementation didn't work the last time we tested the autoplay-0.19 branch. I can't test it myself because either the webview or my whole vm crashses every time media is involved.
- I'm not sure what the default should be. For actual apps enabling autoplay makes sense, but for displaying external URLs not so much, i went with enabling it by default since this is what was used in android already.

Tauri request: https://github.com/tauri-apps/tauri/issues/3478

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD. -> Not yet

### Other information
