### PR TITLE
feat(macos): use WKWebView's inspectable property

### DIFF
--- a/.changes/inspector-ios-16.4-macos-13.3.md
+++ b/.changes/inspector-ios-16.4-macos-13.3.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Use the new WKWebView `inspectable` property if available (iOS 16.4, macOS 13.3).

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -308,14 +308,6 @@ impl InnerWebView {
       #[cfg(target_os = "macos")]
       (*webview).set_ivar(ACCEPT_FIRST_MOUSE, attributes.accept_first_mouse);
 
-      #[cfg(any(debug_assertions, feature = "devtools"))]
-      if attributes.devtools {
-        // Equivalent Obj-C:
-        // [[config preferences] setValue:@YES forKey:@"developerExtrasEnabled"];
-        let dev = NSString::new("developerExtrasEnabled");
-        let _: id = msg_send![_preference, setValue:_yes forKey:dev];
-      }
-
       let _: id = msg_send![_preference, setValue:_yes forKey:NSString::new("allowsPictureInPictureMediaPlayback")];
 
       if attributes.autoplay {
@@ -358,6 +350,18 @@ impl InnerWebView {
         // disable scroll bounce by default
         let scroll: id = msg_send![webview, scrollView];
         let _: () = msg_send![scroll, setBounces: NO];
+      }
+
+      #[cfg(any(debug_assertions, feature = "devtools"))]
+      if attributes.devtools {
+        let has_inspectable_property: BOOL =
+          msg_send![webview, respondsToSelector: sel!(setInspectable:)];
+        if has_inspectable_property == YES {
+          let _: () = msg_send![webview, setInspectable: YES];
+        }
+        // this cannot be on an `else` statement, it does not work on macOS :(
+        let dev = NSString::new("developerExtrasEnabled");
+        let _: id = msg_send![_preference, setValue:_yes forKey:dev];
       }
 
       // allowsBackForwardNavigation


### PR DESCRIPTION
Ref https://github.com/tauri-apps/tauri/issues/6658

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [x] This PR will resolve [tauri-apps/tauri#6658](https://github.com/tauri-apps/tauri/issues/6658)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
