### PR TITLE
fix(android): use `getContext` getter instead of direct access

### DIFF
--- a/src/webview/android/kotlin/RustWebView.kt
+++ b/src/webview/android/kotlin/RustWebView.kt
@@ -35,8 +35,8 @@ class RustWebView(context: Context): WebView(context) {
 
     fun clearAllBrowsingData() {
         try {
-            super.context.deleteDatabase("webviewCache.db");
-            super.context.deleteDatabase("webview.db");
+            super.getContext().deleteDatabase("webviewCache.db");
+            super.getContext().deleteDatabase("webview.db");
             super.clearCache(true);
             super.clearHistory();
             super.clearFormData();


### PR DESCRIPTION
continuation of #932

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
