### PR TITLE
refactor(build): adjust rerun-if-changed instruction for Android files

### DIFF
--- a/.changes/simplify-rerun-if-changed.md
+++ b/.changes/simplify-rerun-if-changed.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Adjust `cargo:rerun-if-changed` instruction for Android files.

--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,6 @@ fn main() {
 
       let kotlin_files_path =
         PathBuf::from(env_var("CARGO_MANIFEST_DIR")).join("src/webview/android/kotlin");
-      println!("cargo:rerun-if-changed={}", kotlin_files_path.display());
       let kotlin_files = fs::read_dir(kotlin_files_path).expect("failed to read kotlin directory");
 
       for file in kotlin_files {
@@ -96,7 +95,9 @@ fn main() {
         let mut out = String::from(auto_generated_comment);
         out.push_str(&content);
 
-        fs::write(kotlin_out_dir.join(file.file_name()), out).expect("Failed to write kotlin file");
+        let out_path = kotlin_out_dir.join(file.file_name());
+        fs::write(&out_path, out).expect("Failed to write kotlin file");
+        println!("cargo:rerun-if-changed={}", out_path.display());
       }
     }
   }

--- a/build.rs
+++ b/build.rs
@@ -31,8 +31,6 @@ fn main() {
       let package = env_var("WRY_ANDROID_PACKAGE");
       let library = env_var("WRY_ANDROID_LIBRARY");
 
-      println!("cargo:rerun-if-changed={kotlin_out_dir}");
-
       let kotlin_out_dir = PathBuf::from(&kotlin_out_dir)
         .canonicalize()
         .unwrap_or_else(move |_| {
@@ -41,6 +39,7 @@ fn main() {
 
       let kotlin_files_path =
         PathBuf::from(env_var("CARGO_MANIFEST_DIR")).join("src/webview/android/kotlin");
+      println!("cargo:rerun-if-changed={}", kotlin_files_path.display());
       let kotlin_files = fs::read_dir(kotlin_files_path).expect("failed to read kotlin directory");
 
       for file in kotlin_files {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

Tauri will also need to write to the `WRY_ANDROID_KOTLIN_FILES_OUT_DIR` path, so watching for changes in the entire directory will result in unnecessary builds being triggered (always). Changing the instruction to be per file fixes this problem.