### PR TITLE
fix(macos): remove `webview` ivar in `WryWebView`

### DIFF
--- a/.changes/remove-webview-ivar.md
+++ b/.changes/remove-webview-ivar.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Remove redundant webview ivar in WryWebView.

--- a/.changes/remove-webview-ivar.md
+++ b/.changes/remove-webview-ivar.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-Remove redundant webview ivar in WryWebView.
+On iOS, fix panic at runtime due to setting webview ivar.

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -280,7 +280,6 @@ impl InnerWebView {
         Some(mut decl) => {
           #[cfg(target_os = "macos")]
           {
-            decl.add_ivar::<id>("webview");
             add_file_drop_methods(&mut decl);
             synthetic_mouse_events::setup(&mut decl);
             decl.add_ivar::<bool>(ACCEPT_FIRST_MOUSE);
@@ -305,7 +304,6 @@ impl InnerWebView {
         _ => class!(WryWebView),
       };
       let webview: id = msg_send![cls, alloc];
-      (*webview).set_ivar("webview", webview);
 
       let () = msg_send![config, setWebsiteDataStore: data_store];
       let _preference: id = msg_send![config, preferences];

--- a/src/webview/wkwebview/synthetic_mouse_events.rs
+++ b/src/webview/wkwebview/synthetic_mouse_events.rs
@@ -12,63 +12,56 @@ use std::{ffi::c_void, ptr::null};
 pub unsafe fn setup(decl: &mut ClassDecl) {
   decl.add_method(
     sel!(otherMouseDown:),
-    other_mouse_down as extern "C" fn(&Object, Sel, id),
+    other_mouse_down as extern "C" fn(&mut Object, Sel, id),
   );
   decl.add_method(
     sel!(otherMouseUp:),
-    other_mouse_up as extern "C" fn(&Object, Sel, id),
+    other_mouse_up as extern "C" fn(&mut Object, Sel, id),
   );
 }
 
-extern "C" fn other_mouse_down(this: &Object, _sel: Sel, event: id) {
+extern "C" fn other_mouse_down(this: &mut Object, _sel: Sel, event: id) {
   unsafe {
     if event.eventType() == NSEventType::NSOtherMouseDown {
-      let webview = this.get_ivar::<id>("webview");
-      if *webview != nil {
-        let button_number = event.buttonNumber();
-        match button_number {
-          // back button
-          3 => {
-            let js = create_js_mouse_event(*webview, event, true, true);
-            let _: id = msg_send![*webview, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
-            return;
-          }
-          // forward button
-          4 => {
-            let js = create_js_mouse_event(*webview, event, true, false);
-            let _: id = msg_send![*webview, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
-            return;
-          }
-
-          _ => {}
+      let button_number = event.buttonNumber();
+      match button_number {
+        // back button
+        3 => {
+          let js = create_js_mouse_event(this, event, true, true);
+          let _: id = msg_send![this, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
+          return;
         }
+        // forward button
+        4 => {
+          let js = create_js_mouse_event(this, event, true, false);
+          let _: id = msg_send![this, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
+          return;
+        }
+        _ => {}
       }
     }
 
     let _: () = msg_send![this, mouseDown: event];
   }
 }
-extern "C" fn other_mouse_up(this: &Object, _sel: Sel, event: id) {
+extern "C" fn other_mouse_up(this: &mut Object, _sel: Sel, event: id) {
   unsafe {
     if event.eventType() == NSEventType::NSOtherMouseUp {
-      let webview = this.get_ivar::<id>("webview");
-      if *webview != nil {
-        let button_number = event.buttonNumber();
-        match button_number {
-          // back button
-          3 => {
-            let js = create_js_mouse_event(*webview, event, false, true);
-            let _: id = msg_send![*webview, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
-            return;
-          }
-          // forward button
-          4 => {
-            let js = create_js_mouse_event(*webview, event, false, false);
-            let _: id = msg_send![*webview, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
-            return;
-          }
-          _ => {}
+      let button_number = event.buttonNumber();
+      match button_number {
+        // back button
+        3 => {
+          let js = create_js_mouse_event(this, event, false, true);
+          let _: id = msg_send![this, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
+          return;
         }
+        // forward button
+        4 => {
+          let js = create_js_mouse_event(this, event, false, false);
+          let _: id = msg_send![this, evaluateJavaScript:NSString::new(&js) completionHandler:null::<*const c_void>()];
+          return;
+        }
+        _ => {}
       }
     }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #942 
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

`webview` ivar on set on macos, thus ios will panic on runtime when building innerwebview.

Synthesize mouse event is good after replacing `webview` with `this`, also fixing ios runtime panic.

