### PR TITLE
fix(linux):fix fcitx input method wrong positioning

### DIFF
--- a/.changes/fix_fcitxPositioning.md
+++ b/.changes/fix_fcitxPositioning.md
@@ -1,0 +1,8 @@
+---
+"wry": patch
+---
+
+The bug was reported in tauri repo: https://github.com/tauri-apps/tauri/issues/5986
+
+With input method preedit disabled,fcitx can anchor at edit cursor position.
+the pre-edit text will not disappear,instead it shows in the fcitx selection window below the input area.

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -4,6 +4,7 @@
 
 use gdk::EventMask;
 use gio::Cancellable;
+use glib::ffi::GFALSE;
 use gtk::prelude::*;
 #[cfg(any(debug_assertions, feature = "devtools"))]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -86,6 +87,16 @@ impl InnerWebView {
       }
       webview.build()
     };
+
+    // Disable input preedit,fcitx input editor can anchor at edit cursor position
+    if let Some(input_context) = webview.input_method_context() {
+      unsafe {
+        webkit2gtk::ffi::webkit_input_method_context_set_enable_preedit(
+          input_context.as_ptr(),
+          GFALSE,
+        )
+      };
+    }
 
     web_context.register_automation(webview.clone());
 

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -4,7 +4,6 @@
 
 use gdk::EventMask;
 use gio::Cancellable;
-use glib::ffi::GFALSE;
 use gtk::prelude::*;
 #[cfg(any(debug_assertions, feature = "devtools"))]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -90,12 +89,7 @@ impl InnerWebView {
 
     // Disable input preedit,fcitx input editor can anchor at edit cursor position
     if let Some(input_context) = webview.input_method_context() {
-      unsafe {
-        webkit2gtk::ffi::webkit_input_method_context_set_enable_preedit(
-          input_context.as_ptr(),
-          GFALSE,
-        )
-      };
+      input_context.set_enable_preedit(false);
     }
 
     web_context.register_automation(webview.clone());


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve  [IME window is not positioning](https://github.com/tauri-apps/tauri/issues/5986)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
