### PR TITLE
feat(android): read request body on Android

### DIFF
--- a/.changes/android-custom-protocol-req-body.md
+++ b/.changes/android-custom-protocol-req-body.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Load the custom protocol request body when it is a string on Android.

--- a/src/webview/android/kotlin/RustWebViewClient.kt
+++ b/src/webview/android/kotlin/RustWebViewClient.kt
@@ -8,7 +8,7 @@ import android.webkit.*
 import android.content.Context
 import androidx.webkit.WebViewAssetLoader
 
-class RustWebViewClient(context: Context): WebViewClient() {
+class RustWebViewClient(context: Context, private val requestBodyMap: Map<String, String>): WebViewClient() {
     private val assetLoader = WebViewAssetLoader.Builder()
         .setDomain(assetLoaderDomain())
         .addPathHandler("/", WebViewAssetLoader.AssetsPathHandler(context))
@@ -21,7 +21,7 @@ class RustWebViewClient(context: Context): WebViewClient() {
         return if (withAssetLoader()) {
             assetLoader.shouldInterceptRequest(request.url)
         } else {
-            handleRequest(request)
+            handleRequest(request, requestBodyMap[request.url.toString()] ?: "")
         }
     }
 
@@ -33,7 +33,7 @@ class RustWebViewClient(context: Context): WebViewClient() {
 
     private external fun assetLoaderDomain(): String
     private external fun withAssetLoader(): Boolean
-    private external fun handleRequest(request: WebResourceRequest): WebResourceResponse?
+    private external fun handleRequest(request: WebResourceRequest, body: String): WebResourceResponse?
 
     {{class-extension}}
 }

--- a/src/webview/android/main_pipe.rs
+++ b/src/webview/android/main_pipe.rs
@@ -119,24 +119,6 @@ impl MainPipe<'_> {
             }
           }
 
-          // Create and set webview client
-          let rust_webview_client_class = find_class(
-            env,
-            activity,
-            format!("{}/RustWebViewClient", PACKAGE.get().unwrap()),
-          )?;
-          let webview_client = env.new_object(
-            rust_webview_client_class,
-            "(Landroid/content/Context;)V",
-            &[activity.into()],
-          )?;
-          env.call_method(
-            webview,
-            "setWebViewClient",
-            "(Landroid/webkit/WebViewClient;)V",
-            &[webview_client.into()],
-          )?;
-
           // set webchrome client
           env.call_method(
             webview,

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -55,7 +55,7 @@ macro_rules! android_binding {
       $package,
       RustWebViewClient,
       handleRequest,
-      [JObject],
+      [JObject, JString],
       jobject
     );
     android_fn!(
@@ -175,7 +175,7 @@ impl InnerWebView {
     let WebViewAttributes {
       url,
       html,
-      initialization_scripts,
+      mut initialization_scripts,
       ipc_handler,
       #[cfg(any(debug_assertions, feature = "devtools"))]
       devtools,
@@ -187,6 +187,8 @@ impl InnerWebView {
       user_agent,
       ..
     } = attributes;
+
+    initialization_scripts.insert(0, include_str!("./request-interceptor.js").into());
 
     let super::PlatformSpecificWebViewAttributes {
       on_webview_created,

--- a/src/webview/android/request-interceptor.js
+++ b/src/webview/android/request-interceptor.js
@@ -1,0 +1,46 @@
+(function () {
+  XMLHttpRequest.prototype.__originalOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (
+    method,
+    url,
+    async,
+    user,
+    password
+  ) {
+    this.__wryUrl = url;
+    this.__originalOpen(method, url, async, user, password);
+  };
+
+  XMLHttpRequest.prototype.__originalSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function (body) {
+    if (typeof body === "string") {
+      __WRY_INTERCEPTOR__.onRequest(this.__wryUrl, body);
+    }
+    this.__originalSend(body);
+  };
+
+  function getFullUrl(url) {
+    if (url.startsWith("/")) {
+      return location.protocol + "//" + location.host + url;
+    } else {
+      return url;
+    }
+  }
+
+  const __originalFetch = window.fetch;
+  window.fetch = function () {
+    const url = getFullUrl(
+      typeof arguments[0] === "string"
+        ? arguments[0]
+        : arguments[1] && "url" in arguments[1]
+        ? arguments[1]["url"]
+        : "/"
+    );
+    const body =
+      arguments[1] && "body" in arguments[1] ? arguments[1]["body"] : "";
+    if (typeof body === "string") {
+      __WRY_INTERCEPTOR__.onRequest(url, body);
+    }
+    return __originalFetch.apply(this, arguments);
+  };
+})();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

The Android's [WebResourceRequest](https://developer.android.com/reference/android/webkit/WebResourceRequest) class does not have an option to read the request body. I had to research and find [request_data_webviewclient](https://github.com/KonstantinSchubert/request_data_webviewclient) and [Android-Request-Inspector-WebView](https://github.com/acsbendi/Android-Request-Inspector-WebView) to find a way to implement it.

I've decided to only support string because byte array performance is bad, see https://stackoverflow.com/a/45506857