### PR TITLE
fix(windows): ignore resize events when minimized

### DIFF
--- a/.changes/ignore-resize-when-minimized-windows.md
+++ b/.changes/ignore-resize-when-minimized-windows.md
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+On Windows when a window is minimized it is resized to a minimum size.
+This event would cause the webview to fire off undesirable events.

--- a/.changes/ignore-resize-when-minimized-windows.md
+++ b/.changes/ignore-resize-when-minimized-windows.md
@@ -2,5 +2,4 @@
 "wry": patch
 ---
 
-On Windows when a window is minimized it is resized to a minimum size.
-This event would cause the webview to fire off undesirable events.
+On Windows, avoid resizing the webview when the window gets minimized to avoid unnecessary `resize` event on JS side.

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -743,15 +743,17 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
     ) -> LRESULT {
       match msg {
         win32wm::WM_SIZE => {
-          let controller = dwrefdata as *mut ICoreWebView2Controller;
-          let mut client_rect = RECT::default();
-          win32wm::GetClientRect(hwnd, &mut client_rect);
-          let _ = (*controller).SetBounds(RECT {
-            left: 0,
-            top: 0,
-            right: client_rect.right - client_rect.left,
-            bottom: client_rect.bottom - client_rect.top,
-          });
+          if wparam.0 != win32wm::SIZE_MINIMIZED as usize {
+            let controller = dwrefdata as *mut ICoreWebView2Controller;
+            let mut client_rect = RECT::default();
+            win32wm::GetClientRect(hwnd, &mut client_rect);
+            let _ = (*controller).SetBounds(RECT {
+              left: 0,
+              top: 0,
+              right: client_rect.right - client_rect.left,
+              bottom: client_rect.bottom - client_rect.top,
+            });
+          }
         }
 
         win32wm::WM_SETFOCUS | win32wm::WM_ENTERSIZEMOVE => {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

On Windows when a window is minimized it is set to a minimum size, this size change event and subsequent resize of the webview causes events within the webview contents such as ResizeObervers to fire.

The resizing of the window when minimizing dates back to when Windows did not have a taskbar, and is still used today for cases when the taskbar is unavailable or for MDI (windows within windows).  A quick explanation can be found [here](https://devblogs.microsoft.com/oldnewthing/20050210-00/?p=36483).

Neither Chrome or Firefox fire off ResizeObserver or DOM resize events when they are minimized on Windows.
