### PR TITLE
refactor(windows): use `http` scheme by default for custom protocols and add option to change it

### DIFF
--- a/.changes/windows-http.md
+++ b/.changes/windows-http.md
@@ -2,4 +2,4 @@
 "wry": "minor"
 ---
 
-Add `WebViewBuilderExtWindows::with_http_scheme` to be able to choose between `http` and `https` for custom protocols on Windows.
+Add `WebViewBuilderExtWindows::with_http_scheme` to be able to choose between `http` and `https` for custom protocols on Windows. **Wry now uses `http` by default!**

--- a/.changes/windows-http.md
+++ b/.changes/windows-http.md
@@ -1,0 +1,5 @@
+---
+"wry": "minor"
+---
+
+Add `WebViewBuilderExtWindows::with_http_scheme` to be able to choose between `http` and `https` for custom protocols on Windows.

--- a/.changes/windows-http.md
+++ b/.changes/windows-http.md
@@ -2,4 +2,4 @@
 "wry": "minor"
 ---
 
-Add `WebViewBuilderExtWindows::with_http_scheme` to be able to choose between `http` and `https` for custom protocols on Windows. **Wry now uses `http` by default!**
+**Breaking change** Wry now defaults to `http://<scheme>.localhost/` for custom protocols on Windows.

--- a/.changes/windows-with-https-scheme.md
+++ b/.changes/windows-with-https-scheme.md
@@ -1,0 +1,5 @@
+---
+"wry": "minor"
+---
+
+Add `WebViewBuilderExtWindows::with_https_scheme` to be able to choose between `http` and `https` for custom protocols on Windows.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -700,7 +700,7 @@ pub trait WebViewBuilderExtWindows {
 
   /// Determines whether the custom protocols should use `http://<scheme>.localhost` instead of the default `https://<scheme>.localhost`.
   ///
-  /// Using a `http` scheme will allow mixed content warnings when trying to fetch `http` endpoints
+  /// Using a `http` scheme will allow mixed content when trying to fetch `http` endpoints
   /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols on macOS and Linux.
   ///
   /// The default value is `true`.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -277,6 +277,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   additional_browser_args: Option<String>,
   browser_accelerator_keys: bool,
   theme: Option<Theme>,
+  http_scheme: bool,
 }
 #[cfg(windows)]
 impl Default for PlatformSpecificWebViewAttributes {
@@ -285,6 +286,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       additional_browser_args: None,
       browser_accelerator_keys: true, // This is WebView2's default behavior
       theme: None,
+      http_scheme: false,
     }
   }
 }
@@ -695,6 +697,14 @@ pub trait WebViewBuilderExtWindows {
   ///
   /// Defaults to [`Theme::Auto`] which will follow the OS defaults.
   fn with_theme(self, theme: Theme) -> Self;
+
+  /// Determines whether the custom protocols should use `http://<scheme>.localhost` instead of `http://<scheme>.localhost`.
+  ///
+  /// Using a `http` scheme will prevent mixed content warnings when trying to fetch `http` endpoints
+  /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols on macOS and Linux.
+  ///
+  /// The default value is `false`.
+  fn with_http_scheme(self, enabled: bool) -> Self;
 }
 
 #[cfg(windows)]
@@ -711,6 +721,11 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 
   fn with_theme(mut self, theme: Theme) -> Self {
     self.platform_specific.theme = Some(theme);
+    self
+  }
+
+  fn with_http_scheme(mut self, enabled: bool) -> Self {
+    self.platform_specific.http_scheme = enabled;
     self
   }
 }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -277,7 +277,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   additional_browser_args: Option<String>,
   browser_accelerator_keys: bool,
   theme: Option<Theme>,
-  http_scheme: bool,
+  https_scheme: bool,
 }
 #[cfg(windows)]
 impl Default for PlatformSpecificWebViewAttributes {
@@ -286,7 +286,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       additional_browser_args: None,
       browser_accelerator_keys: true, // This is WebView2's default behavior
       theme: None,
-      http_scheme: true, // To match macOS & Linux behavior in the context of mixed content.
+      https_scheme: false, // To match macOS & Linux behavior in the context of mixed content.
     }
   }
 }
@@ -698,13 +698,13 @@ pub trait WebViewBuilderExtWindows {
   /// Defaults to [`Theme::Auto`] which will follow the OS defaults.
   fn with_theme(self, theme: Theme) -> Self;
 
-  /// Determines whether the custom protocols should use `http://<scheme>.localhost` or `https://<scheme>.localhost`.
+  /// Determines whether the custom protocols should use `https://<scheme>.localhost` instead of the default `http://<scheme>.localhost`.
   ///
   /// Using a `http` scheme will allow mixed content when trying to fetch `http` endpoints
   /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols used on macOS and Linux.
   ///
-  /// The default value is `true`, meaning it will use `http`.
-  fn with_http_scheme(self, enabled: bool) -> Self;
+  /// The default value is `false`.
+  fn with_https_scheme(self, enabled: bool) -> Self;
 }
 
 #[cfg(windows)]
@@ -724,8 +724,8 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
     self
   }
 
-  fn with_http_scheme(mut self, enabled: bool) -> Self {
-    self.platform_specific.http_scheme = enabled;
+  fn with_https_scheme(mut self, enabled: bool) -> Self {
+    self.platform_specific.https_scheme = enabled;
     self
   }
 }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -286,7 +286,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       additional_browser_args: None,
       browser_accelerator_keys: true, // This is WebView2's default behavior
       theme: None,
-      http_scheme: false,
+      http_scheme: true, // To match macOS & Linux behavior in the context of mixed content.
     }
   }
 }
@@ -700,10 +700,10 @@ pub trait WebViewBuilderExtWindows {
 
   /// Determines whether the custom protocols should use `http://<scheme>.localhost` instead of the default `https://<scheme>.localhost`.
   ///
-  /// Using a `http` scheme will prevent mixed content warnings when trying to fetch `http` endpoints
+  /// Using a `http` scheme will allow mixed content warnings when trying to fetch `http` endpoints
   /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols on macOS and Linux.
   ///
-  /// The default value is `false`.
+  /// The default value is `true`.
   fn with_http_scheme(self, enabled: bool) -> Self;
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -698,12 +698,12 @@ pub trait WebViewBuilderExtWindows {
   /// Defaults to [`Theme::Auto`] which will follow the OS defaults.
   fn with_theme(self, theme: Theme) -> Self;
 
-  /// Determines whether the custom protocols should use `http://<scheme>.localhost` instead of the default `https://<scheme>.localhost`.
+  /// Determines whether the custom protocols should use `http://<scheme>.localhost` or `https://<scheme>.localhost`.
   ///
   /// Using a `http` scheme will allow mixed content when trying to fetch `http` endpoints
-  /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols on macOS and Linux.
+  /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols used on macOS and Linux.
   ///
-  /// The default value is `true`.
+  /// The default value is `true`, meaning it will use `http`.
   fn with_http_scheme(self, enabled: bool) -> Self;
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -698,7 +698,7 @@ pub trait WebViewBuilderExtWindows {
   /// Defaults to [`Theme::Auto`] which will follow the OS defaults.
   fn with_theme(self, theme: Theme) -> Self;
 
-  /// Determines whether the custom protocols should use `http://<scheme>.localhost` instead of `http://<scheme>.localhost`.
+  /// Determines whether the custom protocols should use `http://<scheme>.localhost` instead of the default `https://<scheme>.localhost`.
   ///
   /// Using a `http` scheme will prevent mixed content warnings when trying to fetch `http` endpoints
   /// and is therefore less secure but will match the behavior of the `<scheme>://localhost` protocols on macOS and Linux.

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -537,15 +537,20 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
       }
     }
 
+    let scheme = if pl_attrs.http_scheme {
+      "http"
+    } else {
+      "https"
+    };
     let mut custom_protocol_names = HashSet::new();
     if !attributes.custom_protocols.is_empty() {
       for (name, _) in &attributes.custom_protocols {
-        // WebView2 doesn't support non-standard protocols yet, so we have to use this workaround
+        // WebView2 supports non-standard protocols only on Windows 10+, so we have to use this workaround
         // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
         custom_protocol_names.insert(name.clone());
         unsafe {
           webview.AddWebResourceRequestedFilter(
-            PCWSTR::from_raw(encode_wide(format!("https://{}.*", name)).as_ptr()),
+            PCWSTR::from_raw(encode_wide(format!("{scheme}://{name}.*")).as_ptr()),
             COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL,
           )
         }
@@ -616,11 +621,11 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
                 if let Some(custom_protocol) = custom_protocols
                   .iter()
-                  .find(|(name, _)| uri.starts_with(&format!("https://{}.", name)))
+                  .find(|(name, _)| uri.starts_with(&format!("{scheme}://{name}.")))
                 {
                   // Undo the protocol workaround when giving path to resolver
                   let path = uri.replace(
-                    &format!("https://{}.", custom_protocol.0),
+                    &format!("{scheme}://{}.", custom_protocol.0),
                     &format!("{}://", custom_protocol.0),
                   );
 
@@ -741,11 +746,11 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
         let mut url_string = String::from(url.as_str());
         let name = url.scheme();
         if custom_protocol_names.contains(name) {
-          // WebView2 doesn't support non-standard protocols yet, so we have to use this workaround
+          // WebView2 supports non-standard protocols only on Windows 10+, so we have to use this workaround
           // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
           url_string = url
             .as_str()
-            .replace(&format!("{}://", name), &format!("https://{}.", name))
+            .replace(&format!("{}://", name), &format!("{scheme}://{name}."))
         }
 
         if let Some(headers) = attributes.headers {

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -538,9 +538,9 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
     }
 
     let scheme = if pl_attrs.https_scheme {
-      "http"
-    } else {
       "https"
+    } else {
+      "http"
     };
     let mut custom_protocol_names = HashSet::new();
     if !attributes.custom_protocols.is_empty() {

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -537,7 +537,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
       }
     }
 
-    let scheme = if pl_attrs.http_scheme {
+    let scheme = if pl_attrs.https_scheme {
       "http"
     } else {
       "https"


### PR DESCRIPTION
We get pretty much daily requests/complains about https://github.com/tauri-apps/tauri/issues/3007 and since http://localhost is still a secure context and using http will now match the behavior when using custom schemes (on Linux&macOS) i think this is honestly a no-brainer at this point.

I do plan to backport this to the version used in tauri 1.x after we polished&merged this PR :)

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve https://github.com/tauri-apps/tauri/issues/3007
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
