### PR TITLE
fix(android): handle request freezes due to wrong usage of iterator

### DIFF
--- a/.changes/fix-endless-loop-handle-request.md
+++ b/.changes/fix-endless-loop-handle-request.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes Android freezing when handling request due to endless iteration when reading request headers.

--- a/src/webview/android/binding.rs
+++ b/src/webview/android/binding.rs
@@ -49,7 +49,8 @@ fn handle_request(env: &mut JNIEnv, request: JObject) -> Result<jobject, JniErro
     .call_method(request, "getRequestHeaders", "()Ljava/util/Map;", &[])?
     .l()?;
   let request_headers = JMap::from_env(env, &request_headers)?;
-  while let Some((header, value)) = request_headers.iter(env)?.next(env)? {
+  let mut iter = request_headers.iter(env)?;
+  while let Some((header, value)) = iter.next(env)? {
     let header = JString::from(header);
     let value = JString::from(value);
     let header = env.get_string(&header)?;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
