### PR TITLE
refactor(protocol): respond with a function call instead of return value

### DIFF
--- a/.changes/custom-protocol-responder.md
+++ b/.changes/custom-protocol-responder.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Change the custom protocol closure signature to take a second parameter with an API to resolve the request instead of returning the response inline.

--- a/.changes/custom-protocol-responder.md
+++ b/.changes/custom-protocol-responder.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-Change the custom protocol closure signature to take a second parameter with an API to resolve the request instead of returning the response inline.
+Added `WebViewBuilder::with_asynchronous_custom_protocol` to allow implementing a protocol handler that resolves asynchronously.

--- a/.changes/with-custom-protocol-rturn-value.md
+++ b/.changes/with-custom-protocol-rturn-value.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+**Breaking change:** `WebViewBuidler::with_custom_protocol` closure now returns `http::Response` instead of `Result<http::Response>`.

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -28,7 +28,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_custom_protocol("wry".into(), move |request| {
+    .with_custom_protocol("wry".into(), move |request, api| {
       let path = request.uri().path();
       // Read the file content from file path
       let content = if path == "/" {
@@ -53,10 +53,13 @@ fn main() -> wry::Result<()> {
         unimplemented!();
       };
 
-      Response::builder()
+      let response = Response::builder()
         .header(CONTENT_TYPE, mimetype)
-        .body(content)
-        .map_err(Into::into)
+        .body(content)?;
+
+      api.respond(response);
+
+      Ok(())
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost")?

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -29,18 +29,17 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_asynchronous_custom_protocol(
-      "wry".into(),
-      move |request, response| match get_wry_response(request) {
-        Ok(http_response) => response.respond(http_response),
-        Err(e) => response.respond(
+    .with_asynchronous_custom_protocol("wry".into(), move |request, responder| {
+      match get_wry_response(request) {
+        Ok(http_response) => responder.respond(http_response),
+        Err(e) => responder.respond(
           http::Response::builder()
             .header(CONTENT_TYPE, "text/plain")
             .body(e.to_string().as_bytes().to_vec())
             .unwrap(),
         ),
-      },
-    )
+      }
+    })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost")?
     .build()?;

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -2,24 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use std::{
+  fs::{canonicalize, read},
+  path::PathBuf,
+};
+
+use http::Request;
+use wry::{
+  application::{
+    event::{Event, StartCause, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+  },
+  http::{header::CONTENT_TYPE, Response},
+  webview::WebViewBuilder,
+};
+
 const PAGE1_HTML: &[u8] = include_bytes!("custom_protocol_page1.html");
 
 fn main() -> wry::Result<()> {
-  use std::{
-    fs::{canonicalize, read},
-    path::PathBuf,
-  };
-
-  use wry::{
-    application::{
-      event::{Event, StartCause, WindowEvent},
-      event_loop::{ControlFlow, EventLoop},
-      window::WindowBuilder,
-    },
-    http::{header::CONTENT_TYPE, Response},
-    webview::WebViewBuilder,
-  };
-
   let event_loop = EventLoop::new();
   let window = WindowBuilder::new()
     .with_title("Custom Protocol")
@@ -28,39 +29,18 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_asynchronous_custom_protocol("wry".into(), move |request, response| {
-      let path = request.uri().path();
-      // Read the file content from file path
-      let content = if path == "/" {
-        PAGE1_HTML.into()
-      } else {
-        // `1..` for removing leading slash
-        read(canonicalize(PathBuf::from("examples").join(&path[1..]))?)?
-      };
-
-      // Return asset contents and mime types based on file extentions
-      // If you don't want to do this manually, there are some crates for you.
-      // Such as `infer` and `mime_guess`.
-      let mimetype = if path.ends_with(".html") || path == "/" {
-        "text/html"
-      } else if path.ends_with(".js") {
-        "text/javascript"
-      } else if path.ends_with(".png") {
-        "image/png"
-      } else if path.ends_with(".wasm") {
-        "application/wasm"
-      } else {
-        unimplemented!();
-      };
-
-      let http_response = Response::builder()
-        .header(CONTENT_TYPE, mimetype)
-        .body(content)?;
-
-      response.respond(http_response);
-
-      Ok(())
-    })
+    .with_asynchronous_custom_protocol(
+      "wry".into(),
+      move |request, response| match get_wry_response(request) {
+        Ok(http_response) => response.respond(http_response),
+        Err(e) => response.respond(
+          http::Response::builder()
+            .header(CONTENT_TYPE, "text/plain")
+            .body(e.to_string().as_bytes().to_vec())
+            .unwrap(),
+        ),
+      },
+    )
     // tell the webview to load the custom protocol
     .with_url("wry://localhost")?
     .build()?;
@@ -77,4 +57,37 @@ fn main() -> wry::Result<()> {
       _ => (),
     }
   });
+}
+
+fn get_wry_response(
+  request: Request<Vec<u8>>,
+) -> Result<http::Response<Vec<u8>>, Box<dyn std::error::Error>> {
+  let path = request.uri().path();
+  // Read the file content from file path
+  let content = if path == "/" {
+    PAGE1_HTML.into()
+  } else {
+    // `1..` for removing leading slash
+    read(canonicalize(PathBuf::from("examples").join(&path[1..]))?)?
+  };
+
+  // Return asset contents and mime types based on file extentions
+  // If you don't want to do this manually, there are some crates for you.
+  // Such as `infer` and `mime_guess`.
+  let mimetype = if path.ends_with(".html") || path == "/" {
+    "text/html"
+  } else if path.ends_with(".js") {
+    "text/javascript"
+  } else if path.ends_with(".png") {
+    "image/png"
+  } else if path.ends_with(".wasm") {
+    "application/wasm"
+  } else {
+    unimplemented!();
+  };
+
+  Response::builder()
+    .header(CONTENT_TYPE, mimetype)
+    .body(content)
+    .map_err(Into::into)
 }

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -28,14 +28,14 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_asynchronous_custom_protocol("wry".into(), move |request, api| {
+    .with_asynchronous_custom_protocol("wry".into(), move |request, response| {
       let path = request.uri().path();
       // Read the file content from file path
       let content = if path == "/" {
         PAGE1_HTML.into()
       } else {
         // `1..` for removing leading slash
-        read(canonicalize(PathBuf::from("examples").join(&path[1..]))?)?.into()
+        read(canonicalize(PathBuf::from("examples").join(&path[1..]))?)?
       };
 
       // Return asset contents and mime types based on file extentions
@@ -53,11 +53,11 @@ fn main() -> wry::Result<()> {
         unimplemented!();
       };
 
-      let response = Response::builder()
+      let http_response = Response::builder()
         .header(CONTENT_TYPE, mimetype)
         .body(content)?;
 
-      api.respond(response);
+      response.respond(http_response);
 
       Ok(())
     })

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -35,7 +35,7 @@ fn main() -> wry::Result<()> {
         Err(e) => responder.respond(
           http::Response::builder()
             .header(CONTENT_TYPE, "text/plain")
-			.status(500)
+            .status(500)
             .body(e.to_string().as_bytes().to_vec())
             .unwrap(),
         ),

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -28,7 +28,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_custom_protocol("wry".into(), move |request, api| {
+    .with_asynchronous_custom_protocol("wry".into(), move |request, api| {
       let path = request.uri().path();
       // Read the file content from file path
       let content = if path == "/" {

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -35,6 +35,7 @@ fn main() -> wry::Result<()> {
         Err(e) => responder.respond(
           http::Response::builder()
             .header(CONTENT_TYPE, "text/plain")
+			.status(500)
             .body(e.to_string().as_bytes().to_vec())
             .unwrap(),
         ),

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -23,7 +23,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_custom_protocol("wry".into(), move |request, api| {
+    .with_custom_protocol("wry".into(), move |request| {
       if request.method() == Method::POST {
         let body_string = String::from_utf8_lossy(request.body());
         for body in body_string.split('&') {
@@ -38,9 +38,7 @@ fn main() -> wry::Result<()> {
         .header(CONTENT_TYPE, "text/html")
         .body(read(canonicalize(path)?)?.into())?;
 
-      api.respond(response);
-
-      Ok(())
+      Ok(response)
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/form.html")?

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -34,11 +34,10 @@ fn main() -> wry::Result<()> {
       // remove leading slash
       let path = &request.uri().path()[1..];
 
-      let response = Response::builder()
+      Response::builder()
         .header(CONTENT_TYPE, "text/html")
-        .body(read(canonicalize(path)?)?.into())?;
-
-      Ok(response)
+        .body(read(canonicalize(path)?)?.into())
+        .map_err(Into::into)
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/form.html")?

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -23,7 +23,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_custom_protocol("wry".into(), move |request| {
+    .with_custom_protocol("wry".into(), move |request, api| {
       if request.method() == Method::POST {
         let body_string = String::from_utf8_lossy(request.body());
         for body in body_string.split('&') {
@@ -34,10 +34,13 @@ fn main() -> wry::Result<()> {
       // remove leading slash
       let path = &request.uri().path()[1..];
 
-      Response::builder()
+      let response = Response::builder()
         .header(CONTENT_TYPE, "text/html")
-        .body(read(canonicalize(path)?)?.into())
-        .map_err(Into::into)
+        .body(read(canonicalize(path)?)?.into())?;
+
+      api.respond(response);
+
+      Ok(())
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/form.html")?

--- a/examples/stream_range.rs
+++ b/examples/stream_range.rs
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use wry::http::Response;
+use http_range::HttpRange;
+use std::{
+  borrow::Cow,
+  fs::{canonicalize, File},
+  io::{Read, Seek, SeekFrom},
+  path::PathBuf,
+  process::{Command, Stdio},
+};
+use wry::{
+  application::{
+    event::{Event, StartCause, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+  },
+  http::{header::CONTENT_TYPE, status::StatusCode, Response},
+  webview::WebViewBuilder,
+};
 
 fn main() -> wry::Result<()> {
-  use http_range::HttpRange;
-  use std::{
-    fs::{canonicalize, File},
-    io::{Read, Seek, SeekFrom},
-    path::PathBuf,
-    process::{Command, Stdio},
-  };
-  use wry::{
-    application::{
-      event::{Event, StartCause, WindowEvent},
-      event_loop::{ControlFlow, EventLoop},
-      window::WindowBuilder,
-    },
-    http::{header::CONTENT_TYPE, status::StatusCode},
-    webview::WebViewBuilder,
-  };
-
   let video_file = PathBuf::from("examples/test_video.mp4");
   let video_url =
     "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4";
@@ -53,80 +52,13 @@ fn main() -> wry::Result<()> {
   let _webview = WebViewBuilder::new(window)
     .unwrap()
     .with_custom_protocol("wry".into(), move |request| {
-      // remove leading slash
-      let path = &request.uri().path()[1..];
-
-      // Read the file content from file path
-      let mut content = File::open(canonicalize(path)?)?;
-
-      // Return asset contents and mime types based on file extentions
-      // If you don't want to do this manually, there are some crates for you.
-      // Such as `infer` and `mime_guess`.
-      let mut status_code = StatusCode::OK;
-      let mut buf = Vec::new();
-
-      // guess our mimetype from the path
-      let mimetype = if path.ends_with(".html") {
-        "text/html"
-      } else if path.ends_with(".mp4") {
-        "video/mp4"
-      } else {
-        unimplemented!();
-      };
-
-      // prepare our http response
-      let mut response = Response::builder();
-
-      // read our range header if it exist, so we can return partial content
-      if let Some(range) = request.headers().get("range") {
-        // Get the file size
-        let file_size = content.metadata().unwrap().len();
-
-        // we parse the range header
-        let range = HttpRange::parse(range.to_str().unwrap(), file_size).unwrap();
-
-        // let support only 1 range for now
-        let first_range = range.first();
-        if let Some(range) = first_range {
-          let mut real_length = range.length;
-
-          // prevent max_length;
-          // specially on webview2
-          if range.length > file_size / 3 {
-            // max size sent (400ko / request)
-            // as it's local file system we can afford to read more often
-            real_length = 1024 * 400;
-          }
-
-          // last byte we are reading, the length of the range include the last byte
-          // who should be skipped on the header
-          let last_byte = range.start + real_length - 1;
-          status_code = StatusCode::PARTIAL_CONTENT;
-
-          response = response.header("Connection", "Keep-Alive");
-          response = response.header("Accept-Ranges", "bytes");
-          // we need to overwrite our content length
-          response = response.header("Content-Length", real_length);
-          response = response.header(
-            "Content-Range",
-            format!("bytes {}-{}/{}", range.start, last_byte, file_size),
-          );
-
-          // seek our file bytes
-          content.seek(SeekFrom::Start(range.start))?;
-          content.take(real_length).read_to_end(&mut buf)?;
-        } else {
-          content.read_to_end(&mut buf)?;
-        }
-      } else {
-        content.read_to_end(&mut buf)?;
-      }
-
-      response
-        .header(CONTENT_TYPE, mimetype)
-        .status(status_code)
-        .body(buf.into())
-        .map_err(Into::into)
+      get_stream_response(request).unwrap_or_else(|error| {
+        http::Response::builder()
+          .status(http::StatusCode::BAD_REQUEST)
+          .header(CONTENT_TYPE, "text/plain")
+          .body(error.to_string().as_bytes().to_vec().into())
+          .unwrap()
+      })
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/stream.html")?
@@ -144,4 +76,83 @@ fn main() -> wry::Result<()> {
       _ => {}
     }
   });
+}
+
+fn get_stream_response(
+  request: http::Request<Vec<u8>>,
+) -> Result<http::Response<Cow<'static, [u8]>>, Box<dyn std::error::Error>> {
+  // remove leading slash
+  let path = &request.uri().path()[1..];
+
+  // Read the file content from file path
+  let mut content = File::open(canonicalize(path)?)?;
+
+  // Return asset contents and mime types based on file extentions
+  // If you don't want to do this manually, there are some crates for you.
+  // Such as `infer` and `mime_guess`.
+  let mut status_code = StatusCode::OK;
+  let mut buf = Vec::new();
+
+  // guess our mimetype from the path
+  let mimetype = if path.ends_with(".html") {
+    "text/html"
+  } else if path.ends_with(".mp4") {
+    "video/mp4"
+  } else {
+    unimplemented!();
+  };
+
+  // prepare our http response
+  let mut response = Response::builder();
+
+  // read our range header if it exist, so we can return partial content
+  if let Some(range) = request.headers().get("range") {
+    // Get the file size
+    let file_size = content.metadata().unwrap().len();
+
+    // we parse the range header
+    let range = HttpRange::parse(range.to_str().unwrap(), file_size).unwrap();
+
+    // let support only 1 range for now
+    let first_range = range.first();
+    if let Some(range) = first_range {
+      let mut real_length = range.length;
+
+      // prevent max_length;
+      // specially on webview2
+      if range.length > file_size / 3 {
+        // max size sent (400ko / request)
+        // as it's local file system we can afford to read more often
+        real_length = 1024 * 400;
+      }
+
+      // last byte we are reading, the length of the range include the last byte
+      // who should be skipped on the header
+      let last_byte = range.start + real_length - 1;
+      status_code = StatusCode::PARTIAL_CONTENT;
+
+      response = response.header("Connection", "Keep-Alive");
+      response = response.header("Accept-Ranges", "bytes");
+      // we need to overwrite our content length
+      response = response.header("Content-Length", real_length);
+      response = response.header(
+        "Content-Range",
+        format!("bytes {}-{}/{}", range.start, last_byte, file_size),
+      );
+
+      // seek our file bytes
+      content.seek(SeekFrom::Start(range.start))?;
+      content.take(real_length).read_to_end(&mut buf)?;
+    } else {
+      content.read_to_end(&mut buf)?;
+    }
+  } else {
+    content.read_to_end(&mut buf)?;
+  }
+
+  response
+    .header(CONTENT_TYPE, mimetype)
+    .status(status_code)
+    .body(buf.into())
+    .map_err(Into::into)
 }

--- a/examples/stream_range.rs
+++ b/examples/stream_range.rs
@@ -122,12 +122,11 @@ fn main() -> wry::Result<()> {
         content.read_to_end(&mut buf)?;
       }
 
-      let response = response
+      response
         .header(CONTENT_TYPE, mimetype)
         .status(status_code)
-        .body(buf.into())?;
-
-      Ok(response)
+        .body(buf.into())
+        .map_err(Into::into)
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/stream.html")?

--- a/examples/stream_range.rs
+++ b/examples/stream_range.rs
@@ -52,7 +52,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_custom_protocol("wry".into(), move |request, api| {
+    .with_custom_protocol("wry".into(), move |request| {
       // remove leading slash
       let path = &request.uri().path()[1..];
 
@@ -127,9 +127,7 @@ fn main() -> wry::Result<()> {
         .status(status_code)
         .body(buf.into())?;
 
-      api.respond(response);
-
-      Ok(())
+      Ok(response)
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/stream.html")?

--- a/examples/stream_range.rs
+++ b/examples/stream_range.rs
@@ -52,7 +52,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = WebViewBuilder::new(window)
     .unwrap()
-    .with_custom_protocol("wry".into(), move |request| {
+    .with_custom_protocol("wry".into(), move |request, api| {
       // remove leading slash
       let path = &request.uri().path()[1..];
 
@@ -122,11 +122,14 @@ fn main() -> wry::Result<()> {
         content.read_to_end(&mut buf)?;
       }
 
-      response
+      let response = response
         .header(CONTENT_TYPE, mimetype)
         .status(status_code)
-        .body(buf.into())
-        .map_err(Into::into)
+        .body(buf.into())?;
+
+      api.respond(response);
+
+      Ok(())
     })
     // tell the webview to load the custom protocol
     .with_url("wry://localhost/examples/stream.html")?

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use super::{PageLoadEvent, WebContext, WebViewAttributes, RGBA};
-use crate::{application::window::Window, webview::Response, Result};
+use crate::{application::window::Window, webview::RequestAsyncResponder, Result};
 use base64::{engine::general_purpose, Engine};
 use crossbeam_channel::*;
 use html5ever::{interface::QualName, namespace_url, ns, tendril::TendrilSink, LocalName};
@@ -341,7 +341,7 @@ impl InnerWebView {
               tx.send(response).unwrap();
             });
 
-          match (custom_protocol.1)(request, Response { responder }) {
+          match (custom_protocol.1)(request, RequestAsyncResponder { responder }) {
             Ok(_) => return Some(rx.recv().unwrap()),
             Err(_) => return None,
           }

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -236,10 +236,8 @@ impl InnerWebView {
               tx.send(response).unwrap();
             });
 
-          match (custom_protocol.1)(request, RequestAsyncResponder { responder }) {
-            Ok(_) => return Some(rx.recv().unwrap()),
-            Err(_) => return None,
-          }
+          (custom_protocol.1)(request, RequestAsyncResponder { responder });
+          return Some(rx.recv().unwrap());
         }
         None
       }))

--- a/src/webview/android/mod.rs
+++ b/src/webview/android/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use super::{PageLoadEvent, WebContext, WebViewAttributes, RGBA};
-use crate::{application::window::Window, Result};
+use crate::{application::window::Window, webview::RequestApi, Result};
 use base64::{engine::general_purpose, Engine};
 use crossbeam_channel::*;
 use html5ever::{interface::QualName, namespace_url, ns, tendril::TendrilSink, LocalName};
@@ -14,7 +14,7 @@ use http::{
 use kuchiki::NodeRef;
 use once_cell::sync::OnceCell;
 use sha2::{Digest, Sha256};
-use std::{borrow::Cow, rc::Rc};
+use std::{borrow::Cow, rc::Rc, sync::mpsc::channel};
 use tao::platform::android::ndk_glue::{
   jni::{
     errors::Error as JniError,
@@ -292,52 +292,60 @@ impl InnerWebView {
             .parse()
             .unwrap();
 
-          if let Ok(mut response) = (custom_protocol.1)(&request) {
-            let should_inject_scripts = response
-              .headers()
-              .get(CONTENT_TYPE)
-              // Content-Type must begin with the media type, but is case-insensitive.
-              // It may also be followed by any number of semicolon-delimited key value pairs.
-              // We don't care about these here.
-              // source: https://httpwg.org/specs/rfc9110.html#rfc.section.8.3.1
-              .and_then(|content_type| content_type.to_str().ok())
-              .map(|content_type_str| content_type_str.to_lowercase().starts_with("text/html"))
-              .unwrap_or_default();
+          let (tx, rx) = channel();
+          let initialization_scripts = initialization_scripts.clone();
+          let responder: Box<dyn FnOnce(Response<Cow<'static, [u8]>>)> =
+            Box::new(move |mut response| {
+              let should_inject_scripts = response
+                .headers()
+                .get(CONTENT_TYPE)
+                // Content-Type must begin with the media type, but is case-insensitive.
+                // It may also be followed by any number of semicolon-delimited key value pairs.
+                // We don't care about these here.
+                // source: https://httpwg.org/specs/rfc9110.html#rfc.section.8.3.1
+                .and_then(|content_type| content_type.to_str().ok())
+                .map(|content_type_str| content_type_str.to_lowercase().starts_with("text/html"))
+                .unwrap_or_default();
 
-            if should_inject_scripts && !initialization_scripts.is_empty() {
-              let mut document =
-                kuchiki::parse_html().one(String::from_utf8_lossy(response.body()).into_owned());
-              let csp = response.headers_mut().get_mut(CONTENT_SECURITY_POLICY);
-              let mut hashes = Vec::new();
-              with_html_head(&mut document, |head| {
-                // iterate in reverse order since we are prepending each script to the head tag
-                for script in initialization_scripts.iter().rev() {
-                  let script_el =
-                    NodeRef::new_element(QualName::new(None, ns!(html), "script".into()), None);
-                  script_el.append(NodeRef::new_text(script));
-                  head.prepend(script_el);
-                  if csp.is_some() {
-                    hashes.push(hash_script(script));
+              if should_inject_scripts && !initialization_scripts.is_empty() {
+                let mut document =
+                  kuchiki::parse_html().one(String::from_utf8_lossy(response.body()).into_owned());
+                let csp = response.headers_mut().get_mut(CONTENT_SECURITY_POLICY);
+                let mut hashes = Vec::new();
+                with_html_head(&mut document, |head| {
+                  // iterate in reverse order since we are prepending each script to the head tag
+                  for script in initialization_scripts.iter().rev() {
+                    let script_el =
+                      NodeRef::new_element(QualName::new(None, ns!(html), "script".into()), None);
+                    script_el.append(NodeRef::new_text(script));
+                    head.prepend(script_el);
+                    if csp.is_some() {
+                      hashes.push(hash_script(script));
+                    }
                   }
-                }
-              });
+                });
 
-              if let Some(csp) = csp {
-                let csp_string = csp.to_str().unwrap().to_string();
-                let csp_string = if csp_string.contains("script-src") {
-                  csp_string.replace("script-src", &format!("script-src {}", hashes.join(" ")))
-                } else {
-                  format!("{} script-src {}", csp_string, hashes.join(" "))
-                };
-                *csp = HeaderValue::from_str(&csp_string).unwrap();
+                if let Some(csp) = csp {
+                  let csp_string = csp.to_str().unwrap().to_string();
+                  let csp_string = if csp_string.contains("script-src") {
+                    csp_string.replace("script-src", &format!("script-src {}", hashes.join(" ")))
+                  } else {
+                    format!("{} script-src {}", csp_string, hashes.join(" "))
+                  };
+                  *csp = HeaderValue::from_str(&csp_string).unwrap();
+                }
+
+                *response.body_mut() = document.to_string().into_bytes().into();
               }
 
-              *response.body_mut() = document.to_string().into_bytes().into();
-            }
-            return Some(response);
+              tx.send(response).unwrap();
+            });
+
+          match (custom_protocol.1)(request, RequestApi { responder }) {
+            Ok(_) => return Some(rx.recv().unwrap()),
+            Err(_) => return None,
           }
         }
-
         None
       }))
     });

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -67,8 +67,10 @@ pub struct RequestAsyncResponder {
   pub(crate) responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)>,
 }
 
+// SAFETY: even though the webview bindings do not indicate the responder is Send,
+// it actually is and we need it in order to let the user do the protocol computation
+// on a separate thread or async task.
 unsafe impl Send for RequestAsyncResponder {}
-unsafe impl Sync for RequestAsyncResponder {}
 
 impl RequestAsyncResponder {
   /// Resolves the request with the given response.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -877,7 +877,7 @@ impl WebViewBuilderExtAndroid for WebViewBuilder<'_> {
     self.webview.custom_protocols.push((
       protocol.clone(),
       Box::new(|_, api| {
-        api.respond(HttpResponse::builder().body(Vec::new().into())?);
+        api.respond(HttpResponse::builder().body(Vec::new())?);
         Ok(())
       }),
     ));

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -828,7 +828,10 @@ impl WebViewBuilderExtAndroid for WebViewBuilder<'_> {
     // in WebViewAssetLoader.
     self.webview.custom_protocols.push((
       protocol.clone(),
-      Box::new(|_| Ok(Response::builder().body(Vec::new().into())?)),
+      Box::new(|_, api| {
+        api.respond(Response::builder().body(Vec::new().into())?);
+        Ok(())
+      }),
     ));
     self.platform_specific.with_asset_loader = true;
     self.platform_specific.asset_loader_domain = Some(format!("{}.assets", protocol));

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -475,6 +475,23 @@ impl<'a> WebViewBuilder<'a> {
   #[cfg(feature = "protocol")]
   pub fn with_custom_protocol<F>(mut self, name: String, handler: F) -> Self
   where
+    F: Fn(Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>> + 'static,
+  {
+    self.webview.custom_protocols.push((
+      name,
+      Box::new(move |request, api| {
+        let response = handler(request)?;
+        api.respond(response);
+        Ok(())
+      }),
+    ));
+    self
+  }
+
+  /// Same as [`Self::with_custom_protocol`] but with an asynchronous responder.
+  #[cfg(feature = "protocol")]
+  pub fn with_asynchronous_custom_protocol<F>(mut self, name: String, handler: F) -> Self
+  where
     F: Fn(Request<Vec<u8>>, RequestApi) -> Result<()> + 'static,
   {
     self

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -494,7 +494,7 @@ impl<'a> WebViewBuilder<'a> {
 
   /// Same as [`Self::with_custom_protocol`] but with an asynchronous responder.
   ///
-  /// ```
+  /// ```no_run
   /// use wry::{
   ///   application::{
   ///     event_loop::EventLoop,

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -517,18 +517,20 @@ impl<'a> WebViewBuilder<'a> {
   ///         std::thread::sleep(std::time::Duration::from_secs(2));
   ///         response.respond(http::Response::builder().body(Vec::new()).unwrap());
   ///       });
-  ///       Ok(())
   ///     });
   /// ```
   #[cfg(feature = "protocol")]
   pub fn with_asynchronous_custom_protocol<F>(mut self, name: String, handler: F) -> Self
   where
-    F: Fn(Request<Vec<u8>>, Response) -> Result<()> + 'static,
+    F: Fn(Request<Vec<u8>>, Response) + 'static,
   {
-    self
-      .webview
-      .custom_protocols
-      .push((name, Box::new(handler)));
+    self.webview.custom_protocols.push((
+      name,
+      Box::new(move |request, response| {
+        handler(request, response);
+        Ok(())
+      }),
+    ));
     self
   }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -511,7 +511,13 @@ impl<'a> WebViewBuilder<'a> {
   ///   WebViewBuilder::new(window)
   ///     .unwrap()
   ///     .with_asynchronous_custom_protocol("wry".into(), |request, response| {
-  ///       response.respond(http::Response::builder().body(Vec::new())?);
+  ///       // here you can use a tokio task, thread pool or anything
+  ///       // to do heavy computation to resolve your request
+  ///       // e.g. downloading files, opening the camera...
+  ///       std::thread::spawn(move || {
+  ///         std::thread::sleep(std::time::Duration::from_secs(2));
+  ///         response.respond(http::Response::builder().body(Vec::new()).unwrap());
+  ///       });
   ///       Ok(())
   ///     });
   /// }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -503,7 +503,6 @@ impl<'a> WebViewBuilder<'a> {
   ///   webview::WebViewBuilder,
   /// };
   ///
-  /// fn main() {
   /// let event_loop = EventLoop::new();
   /// let window = WindowBuilder::new()
   ///   .build(&event_loop)
@@ -520,7 +519,6 @@ impl<'a> WebViewBuilder<'a> {
   ///       });
   ///       Ok(())
   ///     });
-  /// }
   /// ```
   #[cfg(feature = "protocol")]
   pub fn with_asynchronous_custom_protocol<F>(mut self, name: String, handler: F) -> Self

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -60,6 +60,20 @@ use crate::application::{dpi::PhysicalSize, window::Window};
 
 use http::{Request, Response};
 
+pub struct RequestApi {
+  pub(crate) responder: Box<dyn FnOnce(Response<Cow<'static, [u8]>>)>,
+}
+
+unsafe impl Send for RequestApi {}
+unsafe impl Sync for RequestApi {}
+
+impl RequestApi {
+  /// Resolves the request with the given response.
+  pub fn respond(self, response: Response<Cow<'static, [u8]>>) {
+    (self.responder)(response)
+  }
+}
+
 pub struct WebViewAttributes {
   /// Whether the WebView should have a custom user-agent.
   pub user_agent: Option<String>,
@@ -135,7 +149,7 @@ pub struct WebViewAttributes {
   /// [bug]: https://bugs.webkit.org/show_bug.cgi?id=229034
   pub custom_protocols: Vec<(
     String,
-    Box<dyn Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>>>,
+    Box<dyn Fn(Request<Vec<u8>>, RequestApi) -> Result<()>>,
   )>,
   /// Set the IPC handler to receive the message from Javascript on webview to host Rust code.
   /// The message sent from webview should call `window.ipc.postMessage("insert_message_here");`.
@@ -461,7 +475,7 @@ impl<'a> WebViewBuilder<'a> {
   #[cfg(feature = "protocol")]
   pub fn with_custom_protocol<F>(mut self, name: String, handler: F) -> Self
   where
-    F: Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>> + 'static,
+    F: Fn(Request<Vec<u8>>, RequestApi) -> Result<()> + 'static,
   {
     self
       .webview

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -119,7 +119,7 @@ pub trait WebContextExt {
   /// relying on the platform's implementation to properly handle duplicated scheme handlers.
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
+    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
 
   /// Register a custom protocol to the web context, only if it is not a duplicate scheme.
   ///
@@ -127,7 +127,7 @@ pub trait WebContextExt {
   /// function will return `Err(Error::DuplicateCustomProtocol)`.
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
+    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
 
   /// Add a [`WebView`] to the queue waiting to be opened.
   ///
@@ -164,7 +164,7 @@ impl WebContextExt for super::WebContext {
 
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
+    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
   {
     actually_register_uri_scheme(self, name, handler)?;
     if self.os.registered_protocols.insert(name.to_string()) {
@@ -176,7 +176,7 @@ impl WebContextExt for super::WebContext {
 
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
+    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
   {
     if self.os.registered_protocols.insert(name.to_string()) {
       actually_register_uri_scheme(self, name, handler)
@@ -284,7 +284,7 @@ fn actually_register_uri_scheme<F>(
   handler: F,
 ) -> crate::Result<()>
 where
-  F: Fn(&Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
+  F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
 {
   use webkit2gtk::traits::*;
   let context = &context.os.context;

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -5,11 +5,11 @@
 //! Unix platform extensions for [`WebContext`](super::WebContext).
 
 use crate::{
-  webview::{web_context::WebContextData, RequestApi},
+  webview::{web_context::WebContextData, Response},
   Error,
 };
 use glib::FileError;
-use http::{header::CONTENT_TYPE, Request, Response};
+use http::{header::CONTENT_TYPE, Request, Response as HttpResponse};
 use std::{
   borrow::Cow,
   cell::RefCell,
@@ -122,7 +122,7 @@ pub trait WebContextExt {
   /// relying on the platform's implementation to properly handle duplicated scheme handlers.
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static;
+    F: Fn(Request<Vec<u8>>, Response) -> crate::Result<()> + 'static;
 
   /// Register a custom protocol to the web context, only if it is not a duplicate scheme.
   ///
@@ -130,7 +130,7 @@ pub trait WebContextExt {
   /// function will return `Err(Error::DuplicateCustomProtocol)`.
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static;
+    F: Fn(Request<Vec<u8>>, Response) -> crate::Result<()> + 'static;
 
   /// Add a [`WebView`] to the queue waiting to be opened.
   ///
@@ -167,7 +167,7 @@ impl WebContextExt for super::WebContext {
 
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static,
+    F: Fn(Request<Vec<u8>>, Response) -> crate::Result<()> + 'static,
   {
     actually_register_uri_scheme(self, name, handler)?;
     if self.os.registered_protocols.insert(name.to_string()) {
@@ -179,7 +179,7 @@ impl WebContextExt for super::WebContext {
 
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static,
+    F: Fn(Request<Vec<u8>>, Response) -> crate::Result<()> + 'static,
   {
     if self.os.registered_protocols.insert(name.to_string()) {
       actually_register_uri_scheme(self, name, handler)
@@ -287,7 +287,7 @@ fn actually_register_uri_scheme<F>(
   handler: F,
 ) -> crate::Result<()>
 where
-  F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static,
+  F: Fn(Request<Vec<u8>>, Response) -> crate::Result<()> + 'static,
 {
   use webkit2gtk::traits::*;
   let context = &context.os.context;
@@ -371,7 +371,7 @@ where
       };
 
       let request_ = request.clone();
-      let responder: Box<dyn FnOnce(Response<Cow<'static, [u8]>>)> =
+      let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
         Box::new(move |http_response| {
           let buffer = http_response.body();
           let input = gio::MemoryInputStream::from_bytes(&glib::Bytes::from(buffer));
@@ -397,7 +397,7 @@ where
           request_.finish_with_response(&response);
         });
 
-      if handler(http_request, RequestApi { responder }).is_err() {
+      if handler(http_request, Response { responder }).is_err() {
         request.finish_error(&mut glib::Error::new(
           FileError::Exist,
           "Could not get requested file.",

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -4,7 +4,10 @@
 
 //! Unix platform extensions for [`WebContext`](super::WebContext).
 
-use crate::{webview::web_context::WebContextData, Error};
+use crate::{
+  webview::{web_context::WebContextData, RequestApi},
+  Error,
+};
 use glib::FileError;
 use http::{header::CONTENT_TYPE, Request, Response};
 use std::{
@@ -119,7 +122,7 @@ pub trait WebContextExt {
   /// relying on the platform's implementation to properly handle duplicated scheme handlers.
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
+    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static;
 
   /// Register a custom protocol to the web context, only if it is not a duplicate scheme.
   ///
@@ -127,7 +130,7 @@ pub trait WebContextExt {
   /// function will return `Err(Error::DuplicateCustomProtocol)`.
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static;
+    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static;
 
   /// Add a [`WebView`] to the queue waiting to be opened.
   ///
@@ -164,7 +167,7 @@ impl WebContextExt for super::WebContext {
 
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
+    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static,
   {
     actually_register_uri_scheme(self, name, handler)?;
     if self.os.registered_protocols.insert(name.to_string()) {
@@ -176,7 +179,7 @@ impl WebContextExt for super::WebContext {
 
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
+    F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static,
   {
     if self.os.registered_protocols.insert(name.to_string()) {
       actually_register_uri_scheme(self, name, handler)
@@ -284,7 +287,7 @@ fn actually_register_uri_scheme<F>(
   handler: F,
 ) -> crate::Result<()>
 where
-  F: Fn(Request<Vec<u8>>) -> crate::Result<Response<Cow<'static, [u8]>>> + 'static,
+  F: Fn(Request<Vec<u8>>, RequestApi) -> crate::Result<()> + 'static,
 {
   use webkit2gtk::traits::*;
   let context = &context.os.context;
@@ -367,8 +370,9 @@ where
         }
       };
 
-      match handler(&http_request) {
-        Ok(http_response) => {
+      let request_ = request.clone();
+      let responder: Box<dyn FnOnce(Response<Cow<'static, [u8]>>)> =
+        Box::new(move |http_response| {
           let buffer = http_response.body();
           let input = gio::MemoryInputStream::from_bytes(&glib::Bytes::from(buffer));
           let content_type = http_response
@@ -390,13 +394,14 @@ where
             headers.append(name.as_str(), value.to_str().unwrap_or(""));
           }
           response.set_http_headers(&headers);
+          request_.finish_with_response(&response);
+        });
 
-          request.finish_with_response(&response);
-        }
-        Err(_) => request.finish_error(&mut glib::Error::new(
+      if handler(http_request, RequestApi { responder }).is_err() {
+        request.finish_error(&mut glib::Error::new(
           FileError::Exist,
           "Could not get requested file.",
-        )),
+        ));
       }
     } else {
       request.finish_error(&mut glib::Error::new(

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -122,7 +122,7 @@ pub trait WebContextExt {
   /// relying on the platform's implementation to properly handle duplicated scheme handlers.
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) -> crate::Result<()> + 'static;
+    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) + 'static;
 
   /// Register a custom protocol to the web context, only if it is not a duplicate scheme.
   ///
@@ -130,7 +130,7 @@ pub trait WebContextExt {
   /// function will return `Err(Error::DuplicateCustomProtocol)`.
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) -> crate::Result<()> + 'static;
+    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) + 'static;
 
   /// Add a [`WebView`] to the queue waiting to be opened.
   ///
@@ -167,7 +167,7 @@ impl WebContextExt for super::WebContext {
 
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) -> crate::Result<()> + 'static,
+    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) + 'static,
   {
     actually_register_uri_scheme(self, name, handler)?;
     if self.os.registered_protocols.insert(name.to_string()) {
@@ -179,7 +179,7 @@ impl WebContextExt for super::WebContext {
 
   fn try_register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>
   where
-    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) -> crate::Result<()> + 'static,
+    F: Fn(Request<Vec<u8>>, RequestAsyncResponder) + 'static,
   {
     if self.os.registered_protocols.insert(name.to_string()) {
       actually_register_uri_scheme(self, name, handler)
@@ -287,7 +287,7 @@ fn actually_register_uri_scheme<F>(
   handler: F,
 ) -> crate::Result<()>
 where
-  F: Fn(Request<Vec<u8>>, RequestAsyncResponder) -> crate::Result<()> + 'static,
+  F: Fn(Request<Vec<u8>>, RequestAsyncResponder) + 'static,
 {
   use webkit2gtk::traits::*;
   let context = &context.os.context;
@@ -397,12 +397,7 @@ where
           request_.finish_with_response(&response);
         });
 
-      if handler(http_request, RequestAsyncResponder { responder }).is_err() {
-        request.finish_error(&mut glib::Error::new(
-          FileError::Exist,
-          "Could not get requested file.",
-        ));
-      }
+      handler(http_request, RequestAsyncResponder { responder });
     } else {
       request.finish_error(&mut glib::Error::new(
         FileError::Exist,

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -5,7 +5,9 @@
 mod file_drop;
 
 use crate::{
-  webview::{proxy::ProxyConfig, PageLoadEvent, Response, WebContext, WebViewAttributes, RGBA},
+  webview::{
+    proxy::ProxyConfig, PageLoadEvent, RequestAsyncResponder, WebContext, WebViewAttributes, RGBA,
+  },
   Error, Result,
 };
 
@@ -682,7 +684,10 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
                         }
                       }
                     });
-                  return match (custom_protocol.1)(final_request, Response { responder }) {
+                  return match (custom_protocol.1)(
+                    final_request,
+                    RequestAsyncResponder { responder },
+                  ) {
                     Ok(_) => Ok(()),
                     Err(_) => Err(E_FAIL.into()),
                   };

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -5,7 +5,7 @@
 mod file_drop;
 
 use crate::{
-  webview::{proxy::ProxyConfig, PageLoadEvent, RequestApi, WebContext, WebViewAttributes, RGBA},
+  webview::{proxy::ProxyConfig, PageLoadEvent, Response, WebContext, WebViewAttributes, RGBA},
   Error, Result,
 };
 
@@ -49,7 +49,7 @@ use windows::{
 use webview2_com::{Microsoft::Web::WebView2::Win32::*, *};
 
 use crate::application::{platform::windows::WindowExtWindows, window::Window};
-use http::{Request, Response, StatusCode};
+use http::{Request, Response as HttpResponse, StatusCode};
 
 use super::Theme;
 
@@ -661,7 +661,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
                   };
 
                   let env = env.clone();
-                  let responder: Box<dyn FnOnce(Response<Cow<'static, [u8]>>)> =
+                  let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
                     Box::new(move |sent_response| {
                       match prepare_web_request_response(&env, sent_response) {
                         Ok(response) => {
@@ -682,7 +682,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
                         }
                       }
                     });
-                  return match (custom_protocol.1)(final_request, RequestApi { responder }) {
+                  return match (custom_protocol.1)(final_request, Response { responder }) {
                     Ok(_) => Ok(()),
                     Err(_) => Err(E_FAIL.into()),
                   };
@@ -942,7 +942,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
 
 unsafe fn prepare_web_request_response(
   env: &ICoreWebView2Environment,
-  sent_response: Response<Cow<'static, [u8]>>,
+  sent_response: HttpResponse<Cow<'static, [u8]>>,
 ) -> windows::core::Result<ICoreWebView2WebResourceResponse> {
   let content = sent_response.body();
   let status_code = sent_response.status();

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -684,13 +684,9 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
                         }
                       }
                     });
-                  return match (custom_protocol.1)(
-                    final_request,
-                    RequestAsyncResponder { responder },
-                  ) {
-                    Ok(_) => Ok(()),
-                    Err(_) => Err(E_FAIL.into()),
-                  };
+
+                  (custom_protocol.1)(final_request, RequestAsyncResponder { responder });
+                  return Ok(());
                 }
               }
 

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -66,7 +66,7 @@ use crate::{
       },
       navigation::{add_navigation_mathods, drop_navigation_methods, set_navigation_methods},
     },
-    FileDropEvent, PageLoadEvent, WebContext, WebViewAttributes, RGBA,
+    FileDropEvent, PageLoadEvent, RequestApi, WebContext, WebViewAttributes, RGBA,
   },
   Result,
 };
@@ -77,8 +77,6 @@ use http::{
   version::Version,
   Request, Response,
 };
-
-use super::RequestApi;
 
 const IPC_MESSAGE_HANDLER_NAME: &str = "ipc";
 const ACCEPT_FIRST_MOUSE: &str = "accept_first_mouse";

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -98,7 +98,7 @@ pub(crate) struct InnerWebView {
   #[cfg(target_os = "macos")]
   file_drop_ptr: *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>),
   download_delegate: id,
-  protocol_ptrs: Vec<*mut Box<dyn Fn(Request<Vec<u8>>, RequestAsyncResponder) -> Result<()>>>,
+  protocol_ptrs: Vec<*mut Box<dyn Fn(Request<Vec<u8>>, RequestAsyncResponder)>>,
 }
 
 impl InnerWebView {
@@ -132,8 +132,8 @@ impl InnerWebView {
       unsafe {
         let function = this.get_ivar::<*mut c_void>("function");
         if !function.is_null() {
-          let function = &mut *(*function
-            as *mut Box<dyn Fn(Request<Vec<u8>>, RequestAsyncResponder) -> Result<()>>);
+          let function =
+            &mut *(*function as *mut Box<dyn Fn(Request<Vec<u8>>, RequestAsyncResponder)>);
 
           // Get url request
           let request: id = msg_send![task, request];
@@ -238,9 +238,8 @@ impl InnerWebView {
                   let () = msg_send![task, didFinish];
                 },
               );
-              if function(final_request, RequestAsyncResponder { responder }).is_err() {
-                respond_with_404();
-              }
+
+              function(final_request, RequestAsyncResponder { responder });
             }
             Err(_) => respond_with_404(),
           };

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -78,6 +78,8 @@ use http::{
   Request, Response,
 };
 
+use super::RequestApi;
+
 const IPC_MESSAGE_HANDLER_NAME: &str = "ipc";
 const ACCEPT_FIRST_MOUSE: &str = "accept_first_mouse";
 
@@ -98,7 +100,7 @@ pub(crate) struct InnerWebView {
   #[cfg(target_os = "macos")]
   file_drop_ptr: *mut (Box<dyn Fn(&Window, FileDropEvent) -> bool>, Rc<Window>),
   download_delegate: id,
-  protocol_ptrs: Vec<*mut Box<dyn Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>>>>,
+  protocol_ptrs: Vec<*mut Box<dyn Fn(Request<Vec<u8>>, RequestApi) -> Result<()>>>,
 }
 
 impl InnerWebView {
@@ -132,8 +134,8 @@ impl InnerWebView {
       unsafe {
         let function = this.get_ivar::<*mut c_void>("function");
         if !function.is_null() {
-          let function = &mut *(*function
-            as *mut Box<dyn Fn(&Request<Vec<u8>>) -> Result<Response<Cow<'static, [u8]>>>>);
+          let function =
+            &mut *(*function as *mut Box<dyn Fn(Request<Vec<u8>>, RequestApi) -> Result<()>>);
 
           // Get url request
           let request: id = msg_send![task, request];
@@ -193,53 +195,57 @@ impl InnerWebView {
             let urlresponse: id = msg_send![class!(NSHTTPURLResponse), alloc];
             let response: id = msg_send![urlresponse, initWithURL:url statusCode:StatusCode::NOT_FOUND HTTPVersion:NSString::new(format!("{:#?}", Version::HTTP_11).as_str()) headerFields:null::<c_void>()];
             let () = msg_send![task, didReceiveResponse: response];
+            // Finish
+            let () = msg_send![task, didFinish];
           };
 
           // send response
           match http_request.body(sent_form_body) {
             Ok(final_request) => {
-              if let Ok(sent_response) = function(&final_request) {
-                let content = sent_response.body();
-                // default: application/octet-stream, but should be provided by the client
-                let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
-                // default to 200
-                let wanted_status_code = sent_response.status().as_u16() as i32;
-                // default to HTTP/1.1
-                let wanted_version = format!("{:#?}", sent_response.version());
+              let responder: Box<dyn FnOnce(Response<Cow<'static, [u8]>>)> = Box::new(
+                move |sent_response| {
+                  let content = sent_response.body();
+                  // default: application/octet-stream, but should be provided by the client
+                  let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
+                  // default to 200
+                  let wanted_status_code = sent_response.status().as_u16() as i32;
+                  // default to HTTP/1.1
+                  let wanted_version = format!("{:#?}", sent_response.version());
 
-                let dictionary: id = msg_send![class!(NSMutableDictionary), alloc];
-                let headers: id = msg_send![dictionary, initWithCapacity:1];
-                if let Some(mime) = wanted_mime {
-                  let () = msg_send![headers, setObject:NSString::new(mime.to_str().unwrap()) forKey: NSString::new(CONTENT_TYPE.as_str())];
-                }
-                let () = msg_send![headers, setObject:NSString::new(&content.len().to_string()) forKey: NSString::new(CONTENT_LENGTH.as_str())];
-
-                // add headers
-                for (name, value) in sent_response.headers().iter() {
-                  let header_key = name.as_str();
-                  if let Ok(value) = value.to_str() {
-                    let () = msg_send![headers, setObject:NSString::new(value) forKey: NSString::new(header_key)];
+                  let dictionary: id = msg_send![class!(NSMutableDictionary), alloc];
+                  let headers: id = msg_send![dictionary, initWithCapacity:1];
+                  if let Some(mime) = wanted_mime {
+                    let () = msg_send![headers, setObject:NSString::new(mime.to_str().unwrap()) forKey: NSString::new(CONTENT_TYPE.as_str())];
                   }
-                }
+                  let () = msg_send![headers, setObject:NSString::new(&content.len().to_string()) forKey: NSString::new(CONTENT_LENGTH.as_str())];
 
-                let urlresponse: id = msg_send![class!(NSHTTPURLResponse), alloc];
-                let response: id = msg_send![urlresponse, initWithURL:url statusCode: wanted_status_code HTTPVersion:NSString::new(&wanted_version) headerFields:headers];
-                let () = msg_send![task, didReceiveResponse: response];
+                  // add headers
+                  for (name, value) in sent_response.headers().iter() {
+                    let header_key = name.as_str();
+                    if let Ok(value) = value.to_str() {
+                      let () = msg_send![headers, setObject:NSString::new(value) forKey: NSString::new(header_key)];
+                    }
+                  }
 
-                // Send data
-                let bytes = content.as_ptr() as *mut c_void;
-                let data: id = msg_send![class!(NSData), alloc];
-                let data: id = msg_send![data, initWithBytesNoCopy:bytes length:content.len() freeWhenDone: if content.len() == 0 { NO } else { YES }];
-                let () = msg_send![task, didReceiveData: data];
-              } else {
-                respond_with_404()
+                  let urlresponse: id = msg_send![class!(NSHTTPURLResponse), alloc];
+                  let response: id = msg_send![urlresponse, initWithURL:url statusCode: wanted_status_code HTTPVersion:NSString::new(&wanted_version) headerFields:headers];
+                  let () = msg_send![task, didReceiveResponse: response];
+
+                  // Send data
+                  let bytes = content.as_ptr() as *mut c_void;
+                  let data: id = msg_send![class!(NSData), alloc];
+                  let data: id = msg_send![data, initWithBytesNoCopy:bytes length:content.len() freeWhenDone: if content.len() == 0 { NO } else { YES }];
+                  let () = msg_send![task, didReceiveData: data];
+                  // Finish
+                  let () = msg_send![task, didFinish];
+                },
+              );
+              if function(final_request, RequestApi { responder }).is_err() {
+                respond_with_404();
               }
             }
             Err(_) => respond_with_404(),
           };
-
-          // Finish
-          let () = msg_send![task, didFinish];
         } else {
           log::warn!(
             "Either WebView or WebContext instance is dropped! This handler shouldn't be called."


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

This enhances the custom protocol handler to allow working asynchronously instead of freezing the main thread for longer tasks. I wanted to do this for a long time but now with Tauri using custom protocols for IPC, we actually need this (my biggest issue right now is using the camera on mobile, it was freezing the app).