### PR TITLE
refactor(webview): use the more efficent `SHCreateMemStream`

### DIFF
--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -29,7 +29,7 @@ use std::{
 use once_cell::{sync::Lazy, unsync::OnceCell};
 
 use windows::{
-  core::{ComInterface, IUnknown, PCSTR, PCWSTR, PWSTR},
+  core::{ComInterface, PCSTR, PCWSTR, PWSTR},
   s,
   Win32::{
     Foundation::*,

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -20,7 +20,6 @@ use std::{
   collections::HashSet,
   fmt::Write,
   iter::once,
-  mem::MaybeUninit,
   os::windows::prelude::OsStrExt,
   path::PathBuf,
   rc::Rc,
@@ -30,20 +29,20 @@ use std::{
 use once_cell::{sync::Lazy, unsync::OnceCell};
 
 use windows::{
-  core::{ComInterface, PCSTR, PCWSTR, PWSTR},
+  core::{ComInterface, IUnknown, PCSTR, PCWSTR, PWSTR},
   s,
   Win32::{
     Foundation::*,
     Globalization::{self, MAX_LOCALE_NAME},
     Graphics::Gdi::{RedrawWindow, HRGN, RDW_INTERNALPAINT},
     System::{
-      Com::{IStream, StructuredStorage::CreateStreamOnHGlobal},
+      Com::IStream,
       LibraryLoader::{GetProcAddress, LoadLibraryW},
       SystemInformation::OSVERSIONINFOW,
       WinRT::EventRegistrationToken,
     },
     UI::{
-      Shell::{DefSubclassProc, SetWindowSubclass},
+      Shell::{DefSubclassProc, SHCreateMemStream, SetWindowSubclass},
       WindowsAndMessaging::{self as win32wm, PostMessageW, RegisterWindowMessageA},
     },
   },
@@ -992,28 +991,15 @@ unsafe fn prepare_web_request_response(
     }
   }
 
-  let mut body_sent = None;
+  let mut stream = None;
   if !content.is_empty() {
-    let stream = CreateStreamOnHGlobal(HGLOBAL(0), true)?;
-    stream.SetSize(content.len() as u64)?;
-    let mut cb_write = MaybeUninit::uninit();
-    if stream
-      .Write(
-        content.as_ptr() as *const _,
-        content.len() as u32,
-        Some(cb_write.as_mut_ptr()),
-      )
-      .is_ok()
-      && cb_write.assume_init() as usize == content.len()
-    {
-      body_sent = Some(stream);
-    }
+    stream = SHCreateMemStream(Some(content));
   }
 
   // FIXME: Set http response version
 
   env.CreateWebResourceResponse(
-    body_sent.as_ref(),
+    stream.as_ref(),
     status_code.as_u16() as i32,
     PCWSTR::from_raw(encode_wide(status_code.canonical_reason().unwrap_or("OK")).as_ptr()),
     PCWSTR::from_raw(encode_wide(headers_map).as_ptr()),


### PR DESCRIPTION
ref: https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-createstreamonhglobal?redirectedfrom=MSDN

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
