### PR TITLE
fix(docs): adjust manifest to fix docs.rs build

### DIFF
--- a/.changes/fix-docs-build.md
+++ b/.changes/fix-docs-build.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix docs.rs build.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ categories = [ "gui" ]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = [ "file-drop", "protocol" ]
+features = [ "tao", "file-drop", "protocol", "webkit2gtk/dox" ]
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",
   "x86_64-apple-darwin"
 ]
+rustc-args = [ "--cfg", "docsrs" ]
+rustdoc-args = [ "--cfg", "docsrs" ]
 
 [features]
 default = [ "file-drop", "objc-exception", "protocol", "tao" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_cmp)]
 #![allow(clippy::upper_case_acronyms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

I'm not sure why we removed the `dox` stuff, but we need that for the docs.rs build. Tested it locally with https://github.com/rust-lang/docs.rs/