### PR TITLE
fix(ci): Fix benchmark in CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,7 +9,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0 # This would add unnecessary bloat to the target folder, decreasing cache efficiency.
-  LC_ALL: en_US.UTF-8 # This prevents strace from changing it's number format to use commas.
+  LC_ALL: en_US.UTF-8 # This prevents strace from changing its number format to use commas.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,28 +27,31 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: install ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+
+      - name: install Rust ${{ matrix.rust }}
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rust-src
-          target: ${{ matrix.platform.target }}
+          targets: ${{ matrix.platform.target }}
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: '3.10'
           architecture: x64
 
-      - name: install depedencies
+      - name: install dependencies
         run: |
           python -m pip install --upgrade pip
           sudo apt-get update
-          sudo apt-get install -y webkit2gtk-4.1-dev libayatana-appindicator3-dev xvfb
-          wget https://github.com/sharkdp/hyperfine/releases/download/v1.11.0/hyperfine_1.11.0_amd64.deb
-          sudo dpkg -i hyperfine_1.11.0_amd64.deb
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+            xvfb \
+            at-spi2-core
+          wget https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
+          sudo dpkg -i hyperfine_1.18.0_amd64.deb
           pip install memory_profiler
 
       - uses: Swatinem/rust-cache@v2
@@ -64,7 +67,7 @@ jobs:
 
       - name: clone benchmarks_results
         if: github.repository == 'tauri-apps/wry' && github.ref == 'refs/heads/dev'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BENCH_PAT }}
           path: gh-pages
@@ -82,7 +85,7 @@ jobs:
           git commit --message "Update WRY benchmarks"
           git push origin gh-pages
 
-      - name: worker info
+      - name: Print worker info
         run: |
           cat /proc/cpuinfo
           cat /proc/meminfo

--- a/bench/src/build_benchmark_jsons.rs
+++ b/bench/src/build_benchmark_jsons.rs
@@ -15,14 +15,13 @@ fn main() {
 
   // current data
   let current_data_buffer = BufReader::new(
-    File::open(&utils::target_dir().join("bench.json")).expect("Unable to read current data file"),
+    File::open(utils::target_dir().join("bench.json")).expect("Unable to read current data file"),
   );
   let current_data: utils::BenchResult =
     serde_json::from_reader(current_data_buffer).expect("Unable to read current data buffer");
 
   // all data's
-  let all_data_buffer =
-    BufReader::new(File::open(&wry_data).expect("Unable to read all data file"));
+  let all_data_buffer = BufReader::new(File::open(wry_data).expect("Unable to read all data file"));
   let mut all_data: Vec<utils::BenchResult> =
     serde_json::from_reader(all_data_buffer).expect("Unable to read all data buffer");
 
@@ -30,25 +29,24 @@ fn main() {
   all_data.push(current_data);
 
   // use only latest 20 elements from all data
-  let recent: Vec<utils::BenchResult>;
-  if all_data.len() > 20 {
-    recent = all_data[all_data.len() - 20..].to_vec();
+  let recent: Vec<utils::BenchResult> = if all_data.len() > 20 {
+    all_data[all_data.len() - 20..].to_vec()
   } else {
-    recent = all_data.clone();
-  }
+    all_data.clone()
+  };
 
   // write jsons
   utils::write_json(
     wry_data.to_str().expect("Something wrong with wry_data"),
     &serde_json::to_value(&all_data).expect("Unable to build final json (all)"),
   )
-  .expect(format!("Unable to write {:?}", wry_data).as_str());
+  .unwrap_or_else(|_| panic!("Unable to write {:?}", wry_data));
 
   utils::write_json(
     wry_recent
       .to_str()
       .expect("Something wrong with wry_recent"),
-    &serde_json::to_value(&recent).expect("Unable to build final json (recent)"),
+    &serde_json::to_value(recent).expect("Unable to build final json (recent)"),
   )
-  .expect(format!("Unable to write {:?}", wry_recent).as_str());
+  .unwrap_or_else(|_| panic!("Unable to write {:?}", wry_recent));
 }

--- a/bench/src/run_benchmark.rs
+++ b/bench/src/run_benchmark.rs
@@ -49,7 +49,7 @@ fn run_strace_benchmarks(new_data: &mut utils::BenchResult) -> Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
 
     Command::new("strace")
-      .args(&[
+      .args([
         "-c",
         "-f",
         "-o",
@@ -86,7 +86,7 @@ fn run_max_mem_benchmark() -> Result<HashMap<String, u64>> {
     let benchmark_file = benchmark_file.to_str().unwrap();
 
     let proc = Command::new("mprof")
-      .args(&[
+      .args([
         "run",
         "-C",
         "-o",
@@ -101,7 +101,7 @@ fn run_max_mem_benchmark() -> Result<HashMap<String, u64>> {
     println!("{:?}", proc_result);
     results.insert(
       name.to_string(),
-      utils::parse_max_mem(&benchmark_file).unwrap(),
+      utils::parse_max_mem(benchmark_file).unwrap(),
     );
   }
 
@@ -135,12 +135,12 @@ fn rlib_size(target_dir: &std::path::Path, prefix: &str) -> u64 {
 fn get_binary_sizes(target_dir: &Path) -> Result<HashMap<String, u64>> {
   let mut sizes = HashMap::<String, u64>::new();
 
-  let wry_size = rlib_size(&target_dir, "libwry");
+  let wry_size = rlib_size(target_dir, "libwry");
   println!("wry {} bytes", wry_size);
   sizes.insert("wry_rlib".to_string(), wry_size);
 
   // add up size for everything in target/release/deps/libtao*
-  let tao_size = rlib_size(&target_dir, "libtao");
+  let tao_size = rlib_size(target_dir, "libtao");
   println!("tao {} bytes", tao_size);
   sizes.insert("tao_rlib".to_string(), tao_size);
 
@@ -182,9 +182,9 @@ fn cargo_deps() -> HashMap<String, usize> {
       let mut cmd = Command::new("cargo");
       cmd.arg("tree");
       cmd.arg("--no-dedupe");
-      cmd.args(&["--edges", "normal"]);
-      cmd.args(&["--prefix", "none"]);
-      cmd.args(&["--target", target]);
+      cmd.args(["--edges", "normal"]);
+      cmd.args(["--prefix", "none"]);
+      cmd.args(["--target", target]);
       cmd.current_dir(&utils::wry_root_path());
 
       let full_deps = cmd.output().expect("failed to run cargo tree").stdout;
@@ -258,14 +258,13 @@ fn main() -> Result<()> {
   println!("Starting wry benchmark");
 
   let target_dir = utils::target_dir();
-  env::set_current_dir(&utils::bench_root_path())?;
+  env::set_current_dir(utils::bench_root_path())?;
 
   let format =
     time::format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z").unwrap();
   let now = time::OffsetDateTime::now_utc();
-
   let mut new_data = utils::BenchResult {
-    created_at: format!("{}", now.format(&format).unwrap()),
+    created_at: now.format(&format).unwrap(),
     sha1: utils::run_collect(&["git", "rev-parse", "HEAD"])
       .0
       .trim()

--- a/bench/src/utils.rs
+++ b/bench/src/utils.rs
@@ -11,7 +11,6 @@ use std::{
   io::{BufRead, BufReader},
   path::PathBuf,
   process::{Command, Output, Stdio},
-  u64,
 };
 
 #[derive(Default, Clone, Serialize, Deserialize, Debug)]
@@ -46,12 +45,11 @@ pub fn get_target() -> &'static str {
 }
 
 pub fn target_dir() -> PathBuf {
-  let target_dir = bench_root_path()
+  bench_root_path()
     .join("tests")
     .join("target")
     .join(get_target())
-    .join("release");
-  target_dir.into()
+    .join("release")
 }
 
 pub fn bench_root_path() -> PathBuf {
@@ -93,16 +91,14 @@ pub fn parse_max_mem(file_path: &str) -> Option<u64> {
   let output = BufReader::new(file);
   let mut highest: u64 = 0;
   // MEM 203.437500 1621617192.4123
-  for line in output.lines() {
-    if let Ok(line) = line {
-      // split line by space
-      let split = line.split(" ").collect::<Vec<_>>();
-      if split.len() == 3 {
-        // mprof generate result in MB
-        let current_bytes = str::parse::<f64>(split[1]).unwrap() as u64 * 1024 * 1024;
-        if current_bytes > highest {
-          highest = current_bytes;
-        }
+  for line in output.lines().flatten() {
+    // split line by space
+    let split = line.split(' ').collect::<Vec<_>>();
+    if split.len() == 3 {
+      // mprof generate result in MB
+      let current_bytes = str::parse::<f64>(split[1]).unwrap() as u64 * 1024 * 1024;
+      if current_bytes > highest {
+        highest = current_bytes;
       }
     }
   }


### PR DESCRIPTION
- Add `--no-install-recommends` to `apt-get install` command, which stops installing `xdg-desktop-portal-gtk`, which made the benchmarks to run about 30 times slower.
- Stop using deprecated actions-rs GitHub actions
- Update hyperfine
- Clippy fixes in `bench` code

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

Benchmark results (running in GitHub Actions):

```
{
  "created_at": "2023-10-26T20:54:18Z",
  "sha1": "4513fb073ba5136962d94be24dee26b112fd30d4",
  "exec_time": {
    "wry_custom_protocol": {
      "system": 0.0714027,
      "user": 0.14192854000000002,
      "min": 0.8725552358,
      "stddev": 0.01756320294129718,
      "mean": 0.8883356643999999,
      "max": 0.9214953298
    },
    "wry_cpu_intensive": {
      "mean": 9.1147323695,
      "stddev": 0.3139193863963647,
      "user": 0.18347473999999991,
      "system": 0.0666227,
      "max": 9.3391904678,
      "min": 8.5209664118
    },
    "wry_hello_world": {
      "system": 0.06789239999999999,
      "user": 0.15248433999999994,
      "max": 0.9439270368,
      "stddev": 0.02301975594994049,
      "min": 0.8771616618,
      "mean": 0.9071919307
    }
  },
  "binary_size": {
    "tao_rlib": 4300464,
    "wry_rlib": 933768,
    "wry_custom_protocol": 1541280,
    "wry_cpu_intensive": 1545568,
    "wry_hello_world": 1532168
  },
  "max_memory": {
    "wry_hello_world": 368050176,
    "wry_cpu_intensive": 465567744,
    "wry_custom_protocol": 351272960
  },
  "thread_count": {
    "wry_cpu_intensive": 60,
    "wry_hello_world": 56,
    "wry_custom_protocol": 55
  },
  "syscall_count": {
    "wry_cpu_intensive": 32786,
    "wry_custom_protocol": 21736,
    "wry_hello_world": 21896
  },
  "cargo_deps": {
    "Linux": 161,
    "macOS": 60,
    "Windows": 56
  }
}
```