### PR TITLE
feat(windows): allow setting memory usage target level to reduce memory consumption of inactive application

### DIFF
--- a/.changes/add-api-to-set-memory-usage-for-windows.md
+++ b/.changes/add-api-to-set-memory-usage-for-windows.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-Add `WebviewExtWindows::set_low_memory_usage` API to set [the memory usage target level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel) on Windows. Setting 'Low' memory usage target level when an application is going to inactive can significantly reduce the memory usage by the application. Please read [the guide for WebView2](https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md) for more details.
+Add `WebviewExtWindows::set_memory_usage_level` API to set the [memory usage target level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel) on Windows. Setting 'Low' memory usage target level when an application is going to inactive can significantly reduce the memory consumption. Please read the [guide for WebView2](https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md) for more details.

--- a/.changes/add-api-to-set-memory-usage-for-windows.md
+++ b/.changes/add-api-to-set-memory-usage-for-windows.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Add `WebviewExtWindows::set_low_memory_usage` API to set [the memory usage target level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel) on Windows. Setting 'Low' memory usage target level when an application is going to inactive can significantly reduce the memory usage by the application. Please read [the guide for WebView2](https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md) for more details.

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -1140,8 +1140,24 @@ pub trait WebviewExtWindows {
   /// Returns WebView2 Controller
   fn controller(&self) -> ICoreWebView2Controller;
 
-  // Changes the webview2 theme.
+  /// Changes the webview2 theme.
   fn set_theme(&self, theme: Theme);
+
+  /// Sets [the memory usage target level][1] to 'Low'. There are two levels 'Low' and 'Normal' and
+  /// the default level is 'Normal'. When the application is going inactive, setting the level to
+  /// 'Low' can significantly save the memory used by the application.
+  ///
+  /// Passing `true` to `enabled` argument means the WebView will switch the level to 'Low' and
+  /// passing `false` will switch to 'Normal'.
+  ///
+  /// The logic when application goes to inactive/active is specific to the application.
+  /// [`tao::event::WindowEvent::Focused`] event may be useful.
+  ///
+  /// Please read [the guide for WebView2][2] for more details.
+  ///
+  /// [1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
+  /// [2]: https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md
+  fn set_low_memory_usage(&self, enabled: bool);
 }
 
 #[cfg(target_os = "windows")]
@@ -1152,6 +1168,10 @@ impl WebviewExtWindows for WebView {
 
   fn set_theme(&self, theme: Theme) {
     self.webview.set_theme(theme)
+  }
+
+  fn set_low_memory_usage(&self, enabled: bool) {
+    self.webview.set_low_memory_usage(enabled);
   }
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -1143,23 +1143,20 @@ pub trait WebviewExtWindows {
   /// Changes the webview2 theme.
   fn set_theme(&self, theme: Theme);
 
-  /// Sets [the memory usage target level][1] to 'Low'. There are two levels 'Low' and 'Normal' and
+  /// Sets the [memory usage target level][1] to 'Low'. There are two levels 'Low' and 'Normal' and
   /// the default level is 'Normal'. When the application is going inactive, setting the level to
-  /// 'Low' can significantly save the memory used by the application.
+  /// 'Low' can significantly reduce the application's memory consumption.
   ///
-  /// Passing `true` to `enabled` argument means the WebView will switch the level to 'Low' and
-  /// passing `false` will switch to 'Normal'.
+  /// When to best use this mode depends on the app in question. Most commonly it's called when
+  /// the app's visiblity state changes.
   ///
-  /// The logic when application goes to inactive/active is specific to the application.
-  /// [`tao::event::WindowEvent::Focused`] event may be useful.
+  /// Please read the [guide for WebView2][2] for more details.
   ///
-  /// Please read [the guide for WebView2][2] for more details.
-  ///
-  /// This method internally uses an API added at WebView2 v1.0.1020.30. When it is called with
-  /// WebView2 older than the version, it does nothing.
+  /// This method uses a WebView2 API added in Runtime version 114.0.1823.32. When it is used in
+  /// an older Runtime version, it does nothing.
   ///
   /// [1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
-  /// [2]: https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md
+  /// [2]: https://learn.microsoft.com/de-de/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel?view=webview2-dotnet-1.0.2088.41&preserve-view=true#remarks
   fn set_low_memory_usage(&self, enabled: bool);
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -1171,7 +1171,7 @@ pub trait WebviewExtWindows {
   /// an older Runtime version, it does nothing.
   ///
   /// [1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
-  /// [2]: https://learn.microsoft.com/de-de/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel?view=webview2-dotnet-1.0.2088.41&preserve-view=true#remarks
+  /// [2]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel?view=webview2-dotnet-1.0.2088.41#remarks
   fn set_memory_usage_level(&self, level: MemoryUsageLevel);
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -1134,6 +1134,23 @@ pub fn webview_version() -> Result<String> {
   platform_webview_version()
 }
 
+/// The [memory usage target level][1]. There are two levels 'Low' and 'Normal' and the default
+/// level is 'Normal'. When the application is going inactive, setting the level to 'Low' can
+/// significantly reduce the application's memory consumption.
+///
+/// [1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
+#[cfg(target_os = "windows")]
+#[non_exhaustive]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MemoryUsageLevel {
+  /// The 'Normal' memory usage. Applications should set this level when they are becoming active.
+  #[default]
+  Normal,
+  /// The 'Low' memory usage. Applications can reduce memory comsumption by setting this level when
+  /// they are becoming inactive.
+  Low,
+}
+
 /// Additional methods on `WebView` that are specific to Windows.
 #[cfg(target_os = "windows")]
 pub trait WebviewExtWindows {
@@ -1143,9 +1160,7 @@ pub trait WebviewExtWindows {
   /// Changes the webview2 theme.
   fn set_theme(&self, theme: Theme);
 
-  /// Sets the [memory usage target level][1] to 'Low'. There are two levels 'Low' and 'Normal' and
-  /// the default level is 'Normal'. When the application is going inactive, setting the level to
-  /// 'Low' can significantly reduce the application's memory consumption.
+  /// Sets the [memory usage target level][1].
   ///
   /// When to best use this mode depends on the app in question. Most commonly it's called when
   /// the app's visiblity state changes.
@@ -1157,7 +1172,7 @@ pub trait WebviewExtWindows {
   ///
   /// [1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
   /// [2]: https://learn.microsoft.com/de-de/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel?view=webview2-dotnet-1.0.2088.41&preserve-view=true#remarks
-  fn set_low_memory_usage(&self, enabled: bool);
+  fn set_memory_usage_level(&self, level: MemoryUsageLevel);
 }
 
 #[cfg(target_os = "windows")]
@@ -1170,8 +1185,8 @@ impl WebviewExtWindows for WebView {
     self.webview.set_theme(theme)
   }
 
-  fn set_low_memory_usage(&self, enabled: bool) {
-    self.webview.set_low_memory_usage(enabled);
+  fn set_memory_usage_level(&self, level: MemoryUsageLevel) {
+    self.webview.set_memory_usage_level(level);
   }
 }
 

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -1155,6 +1155,9 @@ pub trait WebviewExtWindows {
   ///
   /// Please read [the guide for WebView2][2] for more details.
   ///
+  /// This method internally uses an API added at WebView2 v1.0.1020.30. When it is called with
+  /// WebView2 older than the version, it does nothing.
+  ///
   /// [1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
   /// [2]: https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md
   fn set_low_memory_usage(&self, enabled: bool);

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -967,6 +967,16 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
   pub fn set_theme(&self, theme: Theme) {
     set_theme(&self.webview, theme);
   }
+
+  pub fn set_low_memory_usage(&self, enabled: bool) {
+    let Ok(webview) = self.webview.cast::<ICoreWebView2_19>() else {
+      return;
+    };
+    // https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
+    let level = if enabled { 1 } else { 0 };
+    let level = COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL(level);
+    let _ = unsafe { webview.SetMemoryUsageTargetLevel(level) };
+  }
 }
 
 unsafe fn prepare_web_request_response(

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -7,7 +7,8 @@ mod resize;
 
 use crate::{
   webview::{
-    proxy::ProxyConfig, PageLoadEvent, RequestAsyncResponder, WebContext, WebViewAttributes, RGBA,
+    proxy::ProxyConfig, MemoryUsageLevel, PageLoadEvent, RequestAsyncResponder, WebContext,
+    WebViewAttributes, RGBA,
   },
   Error, Result,
 };
@@ -968,12 +969,15 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
     set_theme(&self.webview, theme);
   }
 
-  pub fn set_low_memory_usage(&self, enabled: bool) {
+  pub fn set_memory_usage_level(&self, level: MemoryUsageLevel) {
     let Ok(webview) = self.webview.cast::<ICoreWebView2_19>() else {
       return;
     };
     // https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel
-    let level = if enabled { 1 } else { 0 };
+    let level = match level {
+      MemoryUsageLevel::Normal => 0,
+      MemoryUsageLevel::Low => 1,
+    };
     let level = COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL(level);
     let _ = unsafe { webview.SetMemoryUsageTargetLevel(level) };
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

This PR adds an API to control [the memory usage target level](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2memoryusagetargetlevel) for WebView2.

I noticed my application consumed much memory (more than 100MB) and looked for how to reduce the memory usage, and I found the following guide.

https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/MemoryUsageTargetLevel.md

To try this best practice, I implemented the API and had some experiment. I modified `hello_world` example to switch to 'Low' level when the window lost its focus. Then I ran it with monitoring its memory usage with Task Manager. As the result, I could see 94.8% improvement in memory usage on inactive state.

| | In 'Normal' | Just after switch to 'Low' | 30 secs after switch to 'Low' |
|-|-|-|-|
| Mem | 149.8MB | 82.3MB | 7.8MB |
| Rate | 100% | 54.9% | 5.2% |

```diff
diff --git a/examples/hello_world.rs b/examples/hello_world.rs
index f74d276..8509023 100644
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -12,11 +12,14 @@ fn main() -> wry::Result<()> {
     webview::WebViewBuilder,
   };

+  #[cfg(target_os = "windows")]
+  use wry::webview::WebviewExtWindows as _;
+
   let event_loop = EventLoop::new();
   let window = WindowBuilder::new()
     .with_title("Hello World")
     .build(&event_loop)?;
-  let _webview = WebViewBuilder::new(window)?
+  let webview = WebViewBuilder::new(window)?
     .with_url("https://www.netflix.com/browse")?
     // .with_incognito(true)
     .build()?;
@@ -30,6 +33,14 @@ fn main() -> wry::Result<()> {
         event: WindowEvent::CloseRequested,
         ..
       } => *control_flow = ControlFlow::Exit,
+      #[cfg(target_os = "windows")]
+      Event::WindowEvent {
+        event: WindowEvent::Focused(gained),
+        ..
+      } => {
+        println!("Focus event: {}", gained);
+        webview.set_low_memory_usage(!gained);
+      }
       _ => (),
     }
   });
```


### In 'Normal' level

![normal](https://user-images.githubusercontent.com/823277/278582562-c74fd1d3-c955-4dbf-be24-72b353263555.png)

### Just after going to 'Low'

![just after](https://user-images.githubusercontent.com/823277/278582953-1d52db7e-7c63-4e6a-a0fb-11c748c99b83.png)

### 30 seconds passed after going to 'Low'

![tmp3](https://user-images.githubusercontent.com/823277/278583293-ac62ebe4-0d30-4efc-bd4d-8e7577f93234.png)