### PR TITLE
fix(unix): fix feature gate on `WebviewExtUnix`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1454,14 +1454,26 @@ impl WebviewExtWindows for WebView {
   }
 }
 
-/// Additional methods on `WebView` that are specific to Linux.
-#[cfg(target_os = "linux")]
+/// Additional methods on `WebView` that are specific to Unix.
+#[cfg(any(
+  target_os = "linux",
+  target_os = "dragonfly",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+))]
 pub trait WebviewExtUnix {
   /// Returns Webkit2gtk Webview handle
   fn webview(&self) -> webkit2gtk::WebView;
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(
+  target_os = "linux",
+  target_os = "dragonfly",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+))]
 impl WebviewExtUnix for WebView {
   fn webview(&self) -> webkit2gtk::WebView {
     self.webview.webview.clone()


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

`WebviewExtUnix` trait is only enabled when `target_os` is `"linux"`. However, as its name says, it should be enabled on all *nix platforms. `webkit2gtk` crate is also imported with the same feature gate.

I didn't make a change file for this since `WebviewExtUnix` is not published yet. This change can be amended to changes of #1041.