### PR TITLE
fix(android): properly use $wry on android_binding macro

### DIFF
--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -27,8 +27,10 @@ macro_rules! android_binding {
   ($domain:ident, $package:ident) => {
     ::wry::android_binding!($domain, $package, ::wry)
   };
-  ($domain:ident, $package:ident, $wry:path) => {{
-    use $wry::prelude::*;
+  // use import `android_setup` just to force the import path to use `wry::{}`
+  // as the macro breaks without braces
+  ($domain:ident, $package:ident, $wry:path) => {
+    use $wry::{android_setup as _, prelude::*};
 
     android_fn!(
       $domain,
@@ -92,7 +94,7 @@ macro_rules! android_binding {
       handleReceivedTitle,
       [JObject, JString],
     );
-  }};
+  };
 }
 
 fn handle_request(env: &mut JNIEnv, request: JObject) -> JniResult<jobject> {

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -29,7 +29,7 @@ macro_rules! android_binding {
   };
   // use import `android_setup` just to force the import path to use `wry::{}`
   // as the macro breaks without braces
-  ($domain:ident, $package:ident, $wry:path) => {
+  ($domain:ident, $package:ident, $wry:path) => {{
     use $wry::{android_setup as _, prelude::*};
 
     android_fn!(
@@ -94,7 +94,7 @@ macro_rules! android_binding {
       handleReceivedTitle,
       [JObject, JString],
     );
-  };
+  }};
 }
 
 fn handle_request(env: &mut JNIEnv, request: JObject) -> JniResult<jobject> {


### PR DESCRIPTION


<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

The android_binding macro fails to compile due to the `use $wry::prelude::*;` with `expected { or *` error.

Regression from #1041 which was not released yet so I didn't add a change file.