### PR TITLE
fix: fix wkwebview crashed when received invalid UTF8 string from IPC (#1084)

### DIFF
--- a/.changes/fix-expect.md
+++ b/.changes/fix-expect.md
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+Fix wkwebview crashed when received invalid UTF8 string from IPC. 
+

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -99,9 +99,11 @@ impl InnerWebView {
             &mut *(*function as *mut (Box<dyn for<'r> Fn(&'r Window, String)>, Rc<Window>));
           let body: id = msg_send![msg, body];
           let utf8: *const c_char = msg_send![body, UTF8String];
-          let js = CStr::from_ptr(utf8).to_str().expect("Invalid UTF8 string");
-
-          (function.0)(&function.1, js.to_string());
+          if let Ok(js) = CStr::from_ptr(utf8).to_str() {
+            (function.0)(&function.1, js.to_string());
+          } else {
+            log::warn!("WebView received invalid UTF8 string from IPC.");
+          }
         } else {
           log::warn!("WebView instance is dropped! This handler shouldn't be called.");
         }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
