### PR TITLE
fix(doc): fix the API documentation cannot be built on docs.rs

### DIFF
--- a/.changes/fix-doc-build.md
+++ b/.changes/fix-doc-build.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix the API documentation cannot be built on docs.rs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = [ "gui" ]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = [ "file-drop", "protocol" ]
+features = [ "file-drop", "protocol", "os-webview" ]
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#![cfg_attr(docsrs, feature(doc_cfg))]
-
 //! Wry is a Cross-platform WebView rendering library.
 //!
 //! The webview requires a running event loop and a window type that implements [`HasRawWindowHandle`],


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #1096
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

This commit was made based on confirmation by [this comment](https://github.com/tauri-apps/wry/issues/1096#issuecomment-1827665906). I also confirmed the doc build successfully done with the same features config (including `--cfg docsrs`) on Ubuntu.