### PR TITLE
ci: add build tests for `cargo doc` reading metadata from Cargo.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,13 @@ jobs:
           export RUSTFLAGS="$(echo "$md" | jq -r '.["rustc-args"] | join(" ")')"
 
           features="$(echo "$md" | jq -r '.features | join(",")')"
+          no_default_features=
+          if [ "$(echo "$md" | jq '.["no-default-features"]')" = true ]; then
+            no_default_features="--no-default-features"
+          fi
 
           for target in $(echo "$md" | jq -r '.targets | join(" ")')
           do
             rustup target add "$target"
-            cargo doc -p wry --no-default-features "--features=$features" "--target=$target"
+            cargo doc -p wry "$no_default_features" "--features=$features" "--target=$target"
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
 
 jobs:
   test:
@@ -17,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -59,3 +63,23 @@ jobs:
       - name: Run tests with miri
         if: (!contains(matrix.platform.target, 'android') && !contains(matrix.platform.target, 'ios'))
         run: cargo +nightly miri test --verbose --target ${{ matrix.platform.target }} --features linux-body
+
+  doc:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '--cfg docsrs'
+      RUSTDOCFLAGS: '--cfg docsrs'
+    steps:
+      - uses: actions/checkout@v4
+      - name: install nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-unknown-linux-gnu,x86_64-pc-windows-msvc,x86_64-apple-darwin
+      - name: install webkit2gtk
+        run: |
+          sudo apt-get update -y -q
+          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev
+      # When updating arguments to `cargo doc`, consider to update `[package.metadata.docs.rs]` section in Cargo.toml
+      - run: cargo doc -p wry --no-default-features --features=file-drop,protocol,os-webview --target=x86_64-unknown-linux-gnu
+      - run: cargo doc -p wry --no-default-features --features=file-drop,protocol,os-webview --target=x86_64-pc-windows-msvc
+      - run: cargo doc -p wry --no-default-features --features=file-drop,protocol,os-webview --target=x86_64-apple-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,20 +66,29 @@ jobs:
 
   doc:
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: '--cfg docsrs'
-      RUSTDOCFLAGS: '--cfg docsrs'
     steps:
       - uses: actions/checkout@v4
       - name: install nightly
         uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: x86_64-unknown-linux-gnu,x86_64-pc-windows-msvc,x86_64-apple-darwin
       - name: install webkit2gtk
         run: |
           sudo apt-get update -y -q
           sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev
-      # When updating arguments to `cargo doc`, consider to update `[package.metadata.docs.rs]` section in Cargo.toml
-      - run: cargo doc -p wry --no-default-features --features=file-drop,protocol,os-webview --target=x86_64-unknown-linux-gnu
-      - run: cargo doc -p wry --no-default-features --features=file-drop,protocol,os-webview --target=x86_64-pc-windows-msvc
-      - run: cargo doc -p wry --no-default-features --features=file-drop,protocol,os-webview --target=x86_64-apple-darwin
+      - name: Install dasel
+        run: |
+          curl -LO 'https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_amd64.gz'
+          gunzip dasel_linux_amd64.gz
+          chmod +x dasel_linux_amd64
+          mv dasel_linux_amd64 dasel
+          ./dasel --version
+      - name: Run cargo doc with each targets
+        run: |
+          set -ex
+          export RUSTFLAGS="$(./dasel -r toml -w - 'package.metadata.docs.rs.rustc-args.all().join( )' < Cargo.toml)"
+          export RUSTDOCFLAGS="$(./dasel -r toml -w - 'package.metadata.docs.rs.rustdoc-args.all().join( )' < Cargo.toml)"
+          features="$(./dasel -r toml -w - 'package.metadata.docs.rs.features.all().join(\,)' < Cargo.toml)"
+
+          for target in $(./dasel -r toml -w - 'package.metadata.docs.rs.targets.all().join( )' < Cargo.toml); do
+            rustup target add "$target"
+            cargo doc -p wry --no-default-features "--features=$features" "--target=$target"
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,21 +74,19 @@ jobs:
         run: |
           sudo apt-get update -y -q
           sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev
-      - name: Install dasel
-        run: |
-          curl -LO 'https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_amd64.gz'
-          gunzip dasel_linux_amd64.gz
-          chmod +x dasel_linux_amd64
-          mv dasel_linux_amd64 dasel
-          ./dasel --version
       - name: Run cargo doc with each targets
         run: |
           set -ex
-          export RUSTFLAGS="$(./dasel -r toml -w - 'package.metadata.docs.rs.rustc-args.all().join( )' < Cargo.toml)"
-          export RUSTDOCFLAGS="$(./dasel -r toml -w - 'package.metadata.docs.rs.rustdoc-args.all().join( )' < Cargo.toml)"
-          features="$(./dasel -r toml -w - 'package.metadata.docs.rs.features.all().join(\,)' < Cargo.toml)"
 
-          for target in $(./dasel -r toml -w - 'package.metadata.docs.rs.targets.all().join( )' < Cargo.toml); do
+          md="$(cargo metadata --format-version=1 | jq '.packages[] | select(.name=="wry") | .metadata.docs.rs')"
+
+          export RUSTDOCFLAGS="$(echo "$md" | jq -r '.["rustdoc-args"] | join(" ")')"
+          export RUSTFLAGS="$(echo "$md" | jq -r '.["rustc-args"] | join(" ")')"
+
+          features="$(echo "$md" | jq -r '.features | join(",")')"
+
+          for target in $(echo "$md" | jq -r '.targets | join(" ")')
+          do
             rustup target add "$target"
             cargo doc -p wry --no-default-features "--features=$features" "--target=$target"
           done


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: CI update

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

This PR adds a new `doc` CI job to `build` workflow to prevent mistakes like #1032 and #1096. The job runs `cargo doc` with the same argument as docs.rs builder. Though the environment to build the doc is not completely the same as docs.rs, this job can catch various mistakes (e.g. lack of feature to be enabled).

I confirmed this job ran successfully in my forked repository:

https://github.com/rhysd/wry/actions/runs/7006709364/job/19059155359