### PR TITLE
fix: #1101 screen share permissions dialog

### DIFF
--- a/.changes/fix-screenshare-media-dialog.md
+++ b/.changes/fix-screenshare-media-dialog.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix screen share permissions dialog not showing up on macOS 14.0+


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #1101
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
I had to close https://github.com/tauri-apps/wry/pull/1107 because of the signing should be fine now