### PR TITLE
fix: exclude change files, github assets, and audits from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 repository = "https://github.com/tauri-apps/wry"
 documentation = "https://docs.rs/wry"
 categories = [ "gui" ]
+exclude = ["/.changes", "/.github", "/audits", "/wry-logo.svg"]
 
 [package.metadata.docs.rs]
 no-default-features = true


### PR DESCRIPTION
The wry package is now 2.1MB because the audit is included (~2MB). This excludes the audit directory, along with other directories that aren't related to a packaged crate, such as the changelog files and github specific files.