### PR TITLE
servo-wry-demo: fix build on Windows and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ In this branch, we showcase how to integrate and customize it to become a modern
 
 ## Usage
 
-The current demo only works on macOS at the moment since it tries to customize its traffic light buttons to be seamless in the window. 
+The current demo works best on macOS at the moment, since it tries to customize its traffic light buttons to be seamless in the window.
+
+It should also work on Windows, as well as Linux with X11. You may encounter problems running the demo on Linux with Wayland or Xwayland.
 
 ### Build Servo
 
-- Clone Servo repository (rev@ 7305c59): We are still working on making it to be a cargo git dependency. But it's more stable to make a local build for now.
+- Clone Servo repository (rev@ 90f70e3): We are still working on making it to be a cargo git dependency. But it's more stable to make a local build for now.
 
   ```sh
   git clone https://github.com/servo/servo.git
   cd servo
-  git checkout 7305c59
+  git checkout 90f70e3408e1d4b3f378e50f9f051cb00c77c446
   ```
 
   - Please follow the instructions in [Servo - Build Setup (macOS)](https://github.com/servo/servo#macos) to build a successful copy first.
@@ -46,16 +48,31 @@ The current demo only works on macOS at the moment since it tries to customize i
 
   - Copy required files from Servo repository
 
-  ```sh
-  cp -a ../servo/resources .
-  cp -f ../servo/Cargo.lock .
+    - macOS, Linux:
+
+    ```sh
+    cp -a ../servo/resources .
+    cp -f ../servo/Cargo.lock .
+    ```
+
+    - Windows:
+
+    ```
+    xcopy /i ..\servo\resources resources
+    copy ..\servo\Cargo.lock .
+    ```
+
+  - **Windows only:** set environment variables
+
+  ```
+  set PYTHON3=python
+  set LIBCLANG_PATH=C:\Program Files\LLVM\lib
+  set MOZTOOLS_PATH=%CD%\..\servo\target\dependencies\moztools\4.0
+  set CC=clang-cl.exe
+  set CXX=clang-cl.exe
   ```
 
-  - Build wry
-
-  ```sh
-  cargo build
-  ```
+  - **NixOS only:** add `wayland` and `libGL` to `LD_LIBRARY_PATH` in `../servo/etc/shell.nix`
 
   - Run servo example
 
@@ -63,8 +80,14 @@ The current demo only works on macOS at the moment since it tries to customize i
   cargo run --example servo
   ```
 
+    - Or if you are using Nix or NixOS:
+
+    ```
+    nix-shell ../servo/etc/shell.nix --run 'cargo run --example servo'
+    ```
+
 ## Future Work
 
-- Add more window and servo features to make it feel more like a general webivew library.
+- Add more window and servo features to make it feel more like a general webview library.
 - Improve Servo's development experience.
 - Multi webviews and multi browsing contexts in the same window.

--- a/build.rs
+++ b/build.rs
@@ -112,6 +112,6 @@ fn main() {
       // Backends
       gtk: { all(feature = "native", linux) },
       gtk: { all(feature = "os-webview", linux) },
-      servo: { all(feature = "servo", any(linux, macos)) },
+      servo: { all(feature = "servo", any(linux, macos, windows)) },
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,11 +215,11 @@ pub(crate) mod wkwebview;
 #[cfg(all(not(servo), apple))]
 use wkwebview::*;
 
-#[cfg(target_os = "windows")]
+#[cfg(all(not(servo), target_os = "windows"))]
 pub(crate) mod webview2;
-#[cfg(target_os = "windows")]
+#[cfg(all(not(servo), target_os = "windows"))]
 use self::webview2::*;
-#[cfg(target_os = "windows")]
+#[cfg(all(not(servo), target_os = "windows"))]
 use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 
 use std::{borrow::Cow, path::PathBuf, rc::Rc};
@@ -1397,7 +1397,7 @@ pub enum MemoryUsageLevel {
 }
 
 /// Additional methods on `WebView` that are specific to Windows.
-#[cfg(target_os = "windows")]
+#[cfg(all(not(servo), target_os = "windows"))]
 pub trait WebViewExtWindows {
   /// Returns WebView2 Controller
   fn controller(&self) -> ICoreWebView2Controller;
@@ -1420,7 +1420,7 @@ pub trait WebViewExtWindows {
   fn set_memory_usage_level(&self, level: MemoryUsageLevel);
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(not(servo), target_os = "windows"))]
 impl WebViewExtWindows for WebView {
   fn controller(&self) -> ICoreWebView2Controller {
     self.webview.controller.clone()

--- a/src/servo/window.rs
+++ b/src/servo/window.rs
@@ -88,7 +88,7 @@ impl WindowMethods for WebView {
     let native_context = self.webrender_surfman.native_context();
 
     #[cfg(target_os = "windows")]
-    return PlayerGLContext::Egl(native_context.egl_context as usize);
+    return GlContext::Egl(native_context.egl_context as usize);
 
     #[cfg(target_os = "linux")]
     return {


### PR DESCRIPTION
I managed to get the Servo demo working on Linux and even Windows, at least without the seamless window decorations. This patch updates the README accordingly, and fixes some small compile errors on Windows.

![Untitled5106](https://github.com/tauri-apps/wry/assets/465303/1166e00d-8c90-4cce-b474-535335d94dc9)

![Untitled5107](https://github.com/tauri-apps/wry/assets/465303/ba393911-76ea-4b14-b54e-d5e792438fea)