### PR TITLE
docs(windows): Recommend users to use different data dirs for different envs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //!
 //! event_loop.run(|_e, _evl|{
 //!   // process winit events
-//!    
+//!
 //!   // then advance gtk event loop  <----- IMPORTANT
 //!   #[cfg(target_os = "linux")]
 //!   while gtk::events_pending() {
@@ -1037,7 +1037,8 @@ pub trait WebViewBuilderExtWindows {
   ///
   /// ## Warning
   ///
-  /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
+  /// - Webview instances with different browser arguments must also have different [data directories](struct.WebContext.html#method.new).
+  /// - By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// `--autoplay-policy=no-user-gesture-required` if autoplay is enabled
   /// and `--proxy-server=<scheme>://<host>:<port>` if a proxy is set.
   /// so if you use this method, you have to add these arguments yourself if you want to keep the same behavior.


### PR DESCRIPTION
Source: https://github.com/MicrosoftEdge/WebView2Feedback/issues/2323#issuecomment-1088248488 - iirc it was also part of the actual docs somewhere but couldn't find it on first try. I'm not sure how strict it actually is about it so maybe we can change "must" to "should have" or "must, if..." idk