### PR TITLE
fix(macos): fix SEGV when calling `WebView::evaluate_script` on release build

### DIFF
--- a/.changes/fix-eval-crash.md
+++ b/.changes/fix-eval-crash.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-On macOS, fix a release build crashes with SEGV when calling `WebView::evaluate_javascript`.
+On macOS, fix a release build crashes with SEGV when calling `WebView::evaluate_script`. This crash bug was introduced at v0.35.2.

--- a/.changes/fix-eval-crash.md
+++ b/.changes/fix-eval-crash.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, fix a release build crashes with SEGV when calling `WebView::evaluate_javascript`.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1023,7 +1023,7 @@ r#"Object.defineProperty(window, 'ipc', {
       let store: id = msg_send![config, websiteDataStore];
       let all_data_types: id = msg_send![class!(WKWebsiteDataStore), allWebsiteDataTypes];
       let date: id = msg_send![class!(NSDate), dateWithTimeIntervalSince1970: 0.0];
-      let handler = block::ConcreteBlock::new(|| {});
+      let handler = null::<*const c_void>();
       let _: () = msg_send![store, removeDataOfTypes:all_data_types modifiedSince:date completionHandler:handler];
     }
     Ok(())


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Fix #1151
Fix tauri-apps/tauri#8663

I confirmed the issue was fixed as follows:

<img width="584" alt="image" src="https://github.com/tauri-apps/wry/assets/823277/327cf92d-368b-4430-bf39-89f2f43fc6ac">

This PR fixes the misusage of `block` crate. The `ConcreteBlock` instance (bound to `handler` variable) needs to be copied to the heap before it is passed to Obj-C.

https://crates.io/crates/block

> It is important to copy your block to the heap (with the `copy` method) before passing it to Objective-C; this is because our ConcreteBlock is only meant to be copied once, and we can enforce this in Rust, but if Objective-C code were to copy it twice we could have a double free.