### PR TITLE
docs: mention that 'transparent' feature is required in transparent example

### DIFF
--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -53,6 +53,7 @@ fn main() -> wry::Result<()> {
 
   let _webview = builder
     // The second is on webview...
+    // Feature `transparent` is required for transparency to work.
     .with_transparent(true)
     // And the last is in html.
     .with_html(


### PR DESCRIPTION
Hello!

I was playing with wry and bevy and was struggling with transparency issues due to missing `transparent` feature.
I added a mention about this feature in the `examples/transparent.rs` file.
