### PR TITLE
fix(macos): global keys shortcuts

### DIFF
--- a/.changes/wkwebview.md
+++ b/.changes/wkwebview.md
@@ -1,0 +1,5 @@
+---
+"wry": fix
+---
+
+On `macOS`, fix menu keyboard shortcuts. This issue bug was introduced in `v2` when added `webview` as `child`.

--- a/.changes/wkwebview.md
+++ b/.changes/wkwebview.md
@@ -1,5 +1,5 @@
 ---
-"wry": fix
+"wry": patch
 ---
 
 On `macOS`, fix menu keyboard shortcuts. This issue bug was introduced in `v2` when added `webview` as `child`.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -342,6 +342,10 @@ impl InnerWebView {
               sel!(acceptsFirstMouse:),
               accept_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
             );
+            decl.add_method(
+              sel!(performKeyEquivalent:),
+              key_equivalent as extern "C" fn(&mut Object, Sel, id) -> BOOL,
+            );
 
             extern "C" fn accept_first_mouse(this: &Object, _sel: Sel, _event: id) -> BOOL {
               unsafe {
@@ -353,7 +357,17 @@ impl InnerWebView {
                 }
               }
             }
+
+            extern "C" fn key_equivalent(_this: &mut Object, _sel: Sel, event: id) -> BOOL {
+              unsafe {
+                let app = cocoa::appkit::NSApp();
+                let menu: id = msg_send![app, mainMenu];
+                let () = msg_send![menu, performKeyEquivalent: event];
+              }
+              YES
+            }
           }
+
           decl.register()
         }
         _ => class!(WryWebView),


### PR DESCRIPTION
Since `WkWebview` implementation used `webview::new_as_child`, global keyboard shortcuts didn't worked in `MacOS` even when there's a menu with global shortcuts.
for instnace, `command + h` (for hiding the window) didn't worked, and any other menu shortcut in `MacOS`

Resolve
https://github.com/tauri-apps/tauri/issues/8676

Context
https://discord.com/channels/616186924390023171/1199750637240459327