### PR TITLE
fix(servo): fix type error on building `servo` example

### DIFF
--- a/examples/servo.rs
+++ b/examples/servo.rs
@@ -12,9 +12,12 @@ use wry::{WebViewBuilder, WebViewBuilderExtServo, WebViewExtServo};
 
 /* window decoration */
 #[cfg(target_os = "macos")]
-use cocoa::appkit::{NSView, NSWindow};
-#[cfg(target_os = "macos")]
 use cocoa::appkit::{NSWindowStyleMask, NSWindowTitleVisibility};
+#[cfg(target_os = "macos")]
+use cocoa::{
+  appkit::{NSView, NSWindow},
+  base::YES,
+};
 #[cfg(target_os = "macos")]
 use objc::{msg_send, runtime::Object, sel, sel_impl};
 #[cfg(target_os = "macos")]
@@ -63,7 +66,7 @@ fn main() -> wry::Result<()> {
 
 #[cfg(target_os = "macos")]
 pub unsafe fn decorate_window(window: *mut Object, position: LogicalPosition<f64>) {
-  NSWindow::setTitlebarAppearsTransparent_(window, true);
+  NSWindow::setTitlebarAppearsTransparent_(window, YES);
   NSWindow::setTitleVisibility_(window, NSWindowTitleVisibility::NSWindowTitleHidden);
   NSWindow::setStyleMask_(
     window,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

When I tried `servo-wry-demo` branch,

```sh
cargo run --example servo
```

The build failed with the following error:

```
error[E0308]: mismatched types
    --> examples/servo.rs:66:52
     |
66   |   NSWindow::setTitlebarAppearsTransparent_(window, true);
     |   ----------------------------------------         ^^^^ expected `i8`, found `bool`
     |   |
     |   arguments to this function are incorrect
     |
note: method defined here
    --> /Users/rhysd/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cocoa-0.25.0/src/appkit.rs:1248:15
     |
1248 |     unsafe fn setTitlebarAppearsTransparent_(self, transparent: BOOL);
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
warning: `wry` (example "servo") generated 4 warnings
error: could not compile `wry` (example "servo") due to previous error; 4 warnings emitted
```

The issue was that the `BOOL` type of `cocoa` crate was actually `i8`, not `bool`.

https://docs.rs/cocoa/0.25.0/cocoa/base/type.BOOL.html

This PR fixed the build failure and now I can confirm Servo launches correctly.

CC: @wusyong
