### PR TITLE
fix(android): add `void evalScript(...);` to `proguard-wry`

### DIFF
--- a/.changes/fix-android-eval.md
+++ b/.changes/fix-android-eval.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On android, fix `no non-static method ".evalScript(ILjava/lang/String;)"` when calling `Window::eval`.

--- a/src/android/kotlin/proguard-wry.pro
+++ b/src/android/kotlin/proguard-wry.pro
@@ -27,6 +27,7 @@
   void loadHTMLMainThread(...);
   void setAutoPlay(...);
   void setUserAgent(...);
+  void evalScript(...);
 }
 
 -keep class {{package}}.RustWebChromeClient,{{package}}.RustWebViewClient {


### PR DESCRIPTION
Hi!

Android app crashes when calling `Window::eval` in **release** mode.
Seems, `proguard-wry` is missing necessary method `evalScript`

<details>
<summary>Stacktrace</summary>
02-02 14:34:32.721  1901  2707 D OplusAppStartupMonitor: notifyUnstableAppInfo: Bundle[{unstableTime=1706873672720, reason=crash, userId=0, exceptionMsg=no non-static method "Ltauri/react/app/RustWebView;.evalScript(ILjava/lang/String;)V", exceptionClass=java.lang.NoSuchMethodError, app_channel_type=unstable, packageName=tauri.react.app, unstable_restrict_switch=true}]
</details>

This PR fixes it by adding `void evalScript(...)` to proguard file