### PR TITLE
Revert "fix(macos): global keys shortcuts"

### DIFF
--- a/.changes/revert-global-command.md
+++ b/.changes/revert-global-command.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Revert global keys shortcuts (wry#1156)

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -342,10 +342,6 @@ impl InnerWebView {
               sel!(acceptsFirstMouse:),
               accept_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
             );
-            decl.add_method(
-              sel!(performKeyEquivalent:),
-              key_equivalent as extern "C" fn(&mut Object, Sel, id) -> BOOL,
-            );
 
             extern "C" fn accept_first_mouse(this: &Object, _sel: Sel, _event: id) -> BOOL {
               unsafe {
@@ -357,17 +353,7 @@ impl InnerWebView {
                 }
               }
             }
-
-            extern "C" fn key_equivalent(_this: &mut Object, _sel: Sel, event: id) -> BOOL {
-              unsafe {
-                let app = cocoa::appkit::NSApp();
-                let menu: id = msg_send![app, mainMenu];
-                let () = msg_send![menu, performKeyEquivalent: event];
-              }
-              YES
-            }
           }
-
           decl.register()
         }
         _ => class!(WryWebView),


### PR DESCRIPTION
Reverts tauri-apps/wry#1156

**Reason:** It will stop propagating the event to other responders and cause other shortcut handlers not work as expected. If we make it pass to other responders, it will also call the perform_key_equivalent multiple times and have weird behavior in the multi-webview scenario. See links below for more information:
- https://github.com/tauri-apps/wry/pull/1156#issuecomment-1933242734
- https://github.com/tauri-apps/wry/pull/1156#issuecomment-1933354336
