### PR TITLE
fix(mac): suppress duplicated media permission prompt

### DIFF
--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -804,16 +804,10 @@ impl InnerWebView {
             run_file_upload_panel as extern "C" fn(&Object, Sel, id, id, id, id),
           );
 
-          // Only disable media dialogs on macOS < 14.0
-          // https://tauri.app/v1/references/webview-versions/
-          let webview_system_version = platform_webview_system_version()?.parse::<i32>();
-          if webview_system_version.is_err() || webview_system_version.unwrap() < 19 {
-            // Disable media dialogs
-            ctl.add_method(
-              sel!(webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:),
-              request_media_capture_permission as extern "C" fn(&Object, Sel, id, id, id, id, id),
-            );
-          }
+          ctl.add_method(
+            sel!(webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:),
+            request_media_capture_permission as extern "C" fn(&Object, Sel, id, id, id, id, id),
+          );
 
           ctl.register()
         }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Issue: https://github.com/tauri-apps/tauri/issues/8979
Original fix: #1101 


- #1101 fixed the issue that the prompt does not show up on macOS 14.0 hence the request always being denied.
- In https://github.com/tauri-apps/tauri/issues/8979, the behavior seems to have changed back on macOS 14.2; we should also revert the fix.

I've tested it on my macOS 14.2.1. It would be better to have a second check.

A minimal testing repo: https://github.com/pewsheen/tauri-media-permission/


