### PR TITLE
fix(linux): Disable deprecated applicationCache web api.

### DIFF
--- a/.changes/deprecated-application-cache.md
+++ b/.changes/deprecated-application-cache.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Disable deprecated applicationCache web api. This api was completely removed upstream in webkitgtk 2.44.

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -378,7 +378,6 @@ impl InnerWebView {
       }
 
       // Enable App cache
-      settings.set_enable_offline_web_application_cache(true);
       settings.set_enable_page_cache(true);
 
       // Set user agent


### PR DESCRIPTION
fixes https://github.com/tauri-apps/tauri/issues/9300
ref https://github.com/WebKit/WebKit/pull/23382

Seems like this was dropped in other engines/browsers a long time ago. Even MDN didn't document it for years now.