### PR TITLE
fix(wkwebview): menu shortcuts

### DIFF
--- a/.changes/wkwebview.md
+++ b/.changes/wkwebview.md
@@ -1,0 +1,6 @@
+---
+"wry": patch
+---
+
+On `macOS`, fix menu keyboard shortcuts. This issue bug was introduced in `v2` when added `webview` as `child`.
+Improve version of PR #1156.

--- a/.changes/wkwebview.md
+++ b/.changes/wkwebview.md
@@ -2,5 +2,4 @@
 "wry": patch
 ---
 
-On `macOS`, fix menu keyboard shortcuts. This issue bug was introduced in `v2` when added `webview` as `child`.
-Improve version of PR #1156.
+On `macOS`, fix menu keyboard shortcuts when added `webview` as `child`.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -352,6 +352,14 @@ impl InnerWebView {
               sel!(acceptsFirstMouse:),
               accept_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
             );
+            decl.add_method(
+              sel!(performKeyEquivalent:),
+              key_equivalent as extern "C" fn(&mut Object, Sel, id) -> BOOL,
+            );
+
+            extern "C" fn key_equivalent(_this: &mut Object, _sel: Sel, _event: id) -> BOOL {
+              NO
+            }
 
             extern "C" fn accept_first_mouse(this: &Object, _sel: Sel, _event: id) -> BOOL {
               unsafe {


### PR DESCRIPTION
Fix global menu shortcuts on macOS with multiwebview window, when adding webview as child.
Improved version of https://github.com/tauri-apps/wry/pull/1156#issuecomment-2029180822