### PR TITLE
fix (macos) APP crash when a web custom protocol request is aborted before or during response

### DIFF
--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -250,9 +250,9 @@ impl InnerWebView {
                   let stoppedtaskslock:id = * (* _this).get_ivar("stoppedtaskslock");
                   let _: () = msg_send![stoppedtaskslock, lock];
                   let stoppedtasks:id = *(* _this).get_ivar("stoppedtasks");
-                  let ctns:bool = msg_send![stoppedtasks, containsObject: task];
+                  let hash:id = msg_send![task, hash];
+                  let ctns:bool = msg_send![stoppedtasks, containsObject: hash];
                   if !ctns {
-                    let _: () = msg_send![stoppedtaskslock, unlock];
                     let content = sent_response.body();
                     // default: application/octet-stream, but should be provided by the client
                     let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
@@ -289,9 +289,9 @@ impl InnerWebView {
                     let () = msg_send![task, didFinish];
                   } else {
                     // Remove stopped task
-                    let _: () = msg_send![stoppedtasks, removeObject: task];
-                    let _: () = msg_send![stoppedtaskslock, unlock];
-                  }  
+                    let _: () = msg_send![stoppedtasks, removeObject: hash];
+                  }
+                  let _: () = msg_send![stoppedtaskslock, unlock];
                 },
               );
 
@@ -315,7 +315,8 @@ impl InnerWebView {
         let stoppedtaskslock:id = * (* this).get_ivar("stoppedtaskslock");
         let _: () = msg_send![stoppedtaskslock, lock];
         let stoppedtasks:id = * (* this).get_ivar("stoppedtasks");
-        let _: () = msg_send![stoppedtasks, addObject: task];
+        let hash:id = msg_send![task, hash];
+        let _: () = msg_send![stoppedtasks, addObject: hash];
         let _: () = msg_send![stoppedtaskslock, unlock];
       }
     }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -240,16 +240,15 @@ impl InnerWebView {
             // Finish
             let () = msg_send![task, didFinish];
           };
-          let _this:*const Object = &(* this) as *const Object;
+          let stoppedtaskslock:id = * (* this).get_ivar("stoppedtaskslock");
+          let stoppedtasks:id = *(* this).get_ivar("stoppedtasks");
           // send response
           match http_request.body(sent_form_body) {
             Ok(final_request) => {
               let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> = Box::new(
                 move |sent_response| {
                   // Check if task was stopped
-                  let stoppedtaskslock:id = * (* _this).get_ivar("stoppedtaskslock");
                   let _: () = msg_send![stoppedtaskslock, lock];
-                  let stoppedtasks:id = *(* _this).get_ivar("stoppedtasks");
                   let hash:id = msg_send![task, hash];
                   let ctns:bool = msg_send![stoppedtasks, containsObject: hash];
                   if !ctns {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

closes 1189

I am new to rust and object-c, so not sure if everything is alright with the memory management, but it works well for my tests so far. 
Testfile attached - every third request is aborted. 
[main.rs.zip](https://github.com/tauri-apps/wry/files/14887689/main.rs.zip)

