### PR TITLE
fix: use TARGET env var instead of cfg_aliases so cross compiling works

### DIFF
--- a/.changes/fix-cross-compile.md
+++ b/.changes/fix-cross-compile.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix target detection on build script to enhance cross compiling capabilities.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,40 +1,40 @@
-workspace = { }
+workspace = {}
 
 [package]
 name = "wry"
 version = "0.39.0"
-authors = [ "Tauri Programme within The Commons Conservancy" ]
+authors = ["Tauri Programme within The Commons Conservancy"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Cross-platform WebView rendering library"
 readme = "README.md"
 repository = "https://github.com/tauri-apps/wry"
 documentation = "https://docs.rs/wry"
-categories = [ "gui" ]
-exclude = [ "/.changes", "/.github", "/audits", "/wry-logo.svg" ]
+categories = ["gui"]
+exclude = ["/.changes", "/.github", "/audits", "/wry-logo.svg"]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = [ "drag-drop", "protocol", "os-webview" ]
+features = ["drag-drop", "protocol", "os-webview"]
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",
-  "x86_64-apple-darwin"
+  "x86_64-apple-darwin",
 ]
-rustc-args = [ "--cfg", "docsrs" ]
-rustdoc-args = [ "--cfg", "docsrs" ]
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = [ "drag-drop", "objc-exception", "protocol", "os-webview" ]
-serde = [ "dpi/serde" ]
-objc-exception = [ "objc/exception" ]
-drag-drop = [ ]
-protocol = [ ]
-devtools = [ ]
-transparent = [ ]
-fullscreen = [ ]
-linux-body = [ "webkit2gtk/v2_40", "os-webview" ]
-mac-proxy = [ ]
+default = ["drag-drop", "objc-exception", "protocol", "os-webview"]
+serde = ["dpi/serde"]
+objc-exception = ["objc/exception"]
+drag-drop = []
+protocol = []
+devtools = []
+transparent = []
+fullscreen = []
+linux-body = ["webkit2gtk/v2_40", "os-webview"]
+mac-proxy = []
 os-webview = [
   "javascriptcore-rs",
   "webkit2gtk",
@@ -42,24 +42,21 @@ os-webview = [
   "dep:gtk",
   "soup3",
   "x11-dl",
-  "gdkx11"
+  "gdkx11",
 ]
-tracing = [ "dep:tracing" ]
-
-[build-dependencies]
-cfg_aliases = "0.1"
+tracing = ["dep:tracing"]
 
 [dependencies]
 tracing = { version = "0.1", optional = true }
 once_cell = "1"
 thiserror = "1.0"
 http = "1.1"
-raw-window-handle = { version = "0.6", features = [ "std" ] }
+raw-window-handle = { version = "0.6", features = ["std"] }
 dpi = "0.1"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-javascriptcore-rs = { version = "=1.1", features = [ "v2_28" ], optional = true }
-webkit2gtk = { version = "=2.0", features = [ "v2_38" ], optional = true }
+javascriptcore-rs = { version = "=1.1", features = ["v2_28"], optional = true }
+webkit2gtk = { version = "=2.0", features = ["v2_38"], optional = true }
 webkit2gtk-sys = { version = "=2.0", optional = true }
 gtk = { version = "0.18", optional = true }
 soup3 = { version = "0.5", optional = true }
@@ -72,9 +69,9 @@ webview2-com = "0.29"
 windows-version = "0.1"
 dunce = "1"
 
-  [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.54"
-  features = [
+[target."cfg(target_os = \"windows\")".dependencies.windows]
+version = "0.54"
+features = [
   "implement",
   "Win32_Foundation",
   "Win32_Graphics_Gdi",
@@ -89,7 +86,7 @@ dunce = "1"
   "Win32_Globalization",
   "Win32_UI_HiDpi",
   "Win32_UI_Input",
-  "Win32_UI_Input_KeyboardAndMouse"
+  "Win32_UI_Input_KeyboardAndMouse",
 ]
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,40 +1,40 @@
-workspace = {}
+workspace = { }
 
 [package]
 name = "wry"
 version = "0.39.0"
-authors = ["Tauri Programme within The Commons Conservancy"]
+authors = [ "Tauri Programme within The Commons Conservancy" ]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Cross-platform WebView rendering library"
 readme = "README.md"
 repository = "https://github.com/tauri-apps/wry"
 documentation = "https://docs.rs/wry"
-categories = ["gui"]
-exclude = ["/.changes", "/.github", "/audits", "/wry-logo.svg"]
+categories = [ "gui" ]
+exclude = [ "/.changes", "/.github", "/audits", "/wry-logo.svg" ]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["drag-drop", "protocol", "os-webview"]
+features = [ "drag-drop", "protocol", "os-webview" ]
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",
-  "x86_64-apple-darwin",
+  "x86_64-apple-darwin"
 ]
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = [ "--cfg", "docsrs" ]
+rustdoc-args = [ "--cfg", "docsrs" ]
 
 [features]
-default = ["drag-drop", "objc-exception", "protocol", "os-webview"]
-serde = ["dpi/serde"]
-objc-exception = ["objc/exception"]
-drag-drop = []
-protocol = []
-devtools = []
-transparent = []
-fullscreen = []
-linux-body = ["webkit2gtk/v2_40", "os-webview"]
-mac-proxy = []
+default = [ "drag-drop", "objc-exception", "protocol", "os-webview" ]
+serde = [ "dpi/serde" ]
+objc-exception = [ "objc/exception" ]
+drag-drop = [ ]
+protocol = [ ]
+devtools = [ ]
+transparent = [ ]
+fullscreen = [ ]
+linux-body = [ "webkit2gtk/v2_40", "os-webview" ]
+mac-proxy = [ ]
 os-webview = [
   "javascriptcore-rs",
   "webkit2gtk",
@@ -42,21 +42,24 @@ os-webview = [
   "dep:gtk",
   "soup3",
   "x11-dl",
-  "gdkx11",
+  "gdkx11"
 ]
-tracing = ["dep:tracing"]
+tracing = [ "dep:tracing" ]
+
+[build-dependencies]
+cfg_aliases = "0.1"
 
 [dependencies]
 tracing = { version = "0.1", optional = true }
 once_cell = "1"
 thiserror = "1.0"
 http = "1.1"
-raw-window-handle = { version = "0.6", features = ["std"] }
+raw-window-handle = { version = "0.6", features = [ "std" ] }
 dpi = "0.1"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-javascriptcore-rs = { version = "=1.1", features = ["v2_28"], optional = true }
-webkit2gtk = { version = "=2.0", features = ["v2_38"], optional = true }
+javascriptcore-rs = { version = "=1.1", features = [ "v2_28" ], optional = true }
+webkit2gtk = { version = "=2.0", features = [ "v2_38" ], optional = true }
 webkit2gtk-sys = { version = "=2.0", optional = true }
 gtk = { version = "0.18", optional = true }
 soup3 = { version = "0.5", optional = true }
@@ -69,9 +72,9 @@ webview2-com = "0.29"
 windows-version = "0.1"
 dunce = "1"
 
-[target."cfg(target_os = \"windows\")".dependencies.windows]
-version = "0.54"
-features = [
+  [target."cfg(target_os = \"windows\")".dependencies.windows]
+  version = "0.54"
+  features = [
   "implement",
   "Win32_Foundation",
   "Win32_Graphics_Gdi",
@@ -86,7 +89,7 @@ features = [
   "Win32_Globalization",
   "Win32_UI_HiDpi",
   "Win32_UI_Input",
-  "Win32_UI_Input_KeyboardAndMouse",
+  "Win32_UI_Input_KeyboardAndMouse"
 ]
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ os-webview = [
 ]
 tracing = [ "dep:tracing" ]
 
-[build-dependencies]
-cfg_aliases = "0.1"
-
 [dependencies]
 tracing = { version = "0.1", optional = true }
 once_cell = "1"

--- a/build.rs
+++ b/build.rs
@@ -110,6 +110,6 @@ fn main() {
       apple: { any(target_os = "ios", target_os = "macos") },
       linux: { all(unix, not(apple), not(android)) },
       // Backends
-      gtk: { all(feature = "os-webview", linux) },
+      gtk: { all(feature = "os-webview", unix, not(apple), not(android)) },
   }
 }

--- a/build.rs
+++ b/build.rs
@@ -107,11 +107,11 @@ fn main() {
   alias("ios", target.contains("ios"));
   alias("windows", target.contains("windows"));
   alias("apple", target.contains("apple"));
-  alias("linux", target.contains("linux"));
+  alias("linux", target.contains("unknown-linux"));
 
   alias(
     "gtk",
-    cfg!(feature = "os-webview") && target.contains("linux"),
+    cfg!(feature = "os-webview") && target.contains("unknown-linux"),
   );
 }
 

--- a/build.rs
+++ b/build.rs
@@ -102,12 +102,13 @@ fn main() {
   }
 
   let target = std::env::var("TARGET").unwrap();
-  alias("android", target.contains("android"));
+  let android = target.contains("android");
+  alias("android", android);
   alias("macos", target.contains("darwin"));
   alias("ios", target.contains("ios"));
   alias("windows", target.contains("windows"));
   alias("apple", target.contains("apple"));
-  alias("linux", target.contains("unknown-linux"));
+  alias("linux", !android && target.contains("linux"));
 
   alias(
     "gtk",

--- a/build.rs
+++ b/build.rs
@@ -101,15 +101,22 @@ fn main() {
     }
   }
 
-  cfg_aliases::cfg_aliases! {
-      // Platforms
-      android: { target_os = "android" },
-      macos: { target_os = "macos" },
-      ios: { target_os = "ios" },
-      windows: { target_os = "windows" },
-      apple: { any(target_os = "ios", target_os = "macos") },
-      linux: { all(unix, not(apple), not(android)) },
-      // Backends
-      gtk: { all(feature = "os-webview", unix, not(apple), not(android)) },
+  let target = std::env::var("TARGET").unwrap();
+  alias("android", target.contains("android"));
+  alias("macos", target.contains("darwin"));
+  alias("ios", target.contains("ios"));
+  alias("windows", target.contains("windows"));
+  alias("apple", target.contains("apple"));
+  alias("linux", target.contains("linux"));
+
+  alias(
+    "gtk",
+    cfg!(feature = "os-webview") && target.contains("linux"),
+  );
+}
+
+fn alias(alias: &str, condition: bool) {
+  if condition {
+    println!("cargo:rustc-cfg={alias}");
   }
 }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -112,7 +112,6 @@ impl InnerWebView {
     pl_attrs: super::PlatformSpecificWebViewAttributes,
     _web_context: Option<&mut WebContext>,
   ) -> Result<Self> {
-    println!("N");
     let ns_view = match window.window_handle()?.as_raw() {
       #[cfg(target_os = "macos")]
       RawWindowHandle::AppKit(w) => w.ns_view.as_ptr(),
@@ -1204,11 +1203,8 @@ r#"Object.defineProperty(window, 'ipc', {
   #[cfg(target_os = "macos")]
   pub(crate) fn reparent(&self, window: id) -> crate::Result<()> {
     unsafe {
-      println!("A");
       let content_view: id = msg_send![window, contentView];
-      println!("AB");
       let _: () = msg_send![content_view, addSubview: self.webview];
-      println!("ABC");
     }
 
     Ok(())

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -112,6 +112,7 @@ impl InnerWebView {
     pl_attrs: super::PlatformSpecificWebViewAttributes,
     _web_context: Option<&mut WebContext>,
   ) -> Result<Self> {
+    println!("N");
     let ns_view = match window.window_handle()?.as_raw() {
       #[cfg(target_os = "macos")]
       RawWindowHandle::AppKit(w) => w.ns_view.as_ptr(),
@@ -1203,8 +1204,11 @@ r#"Object.defineProperty(window, 'ipc', {
   #[cfg(target_os = "macos")]
   pub(crate) fn reparent(&self, window: id) -> crate::Result<()> {
     unsafe {
+      println!("A");
       let content_view: id = msg_send![window, contentView];
+      println!("AB");
       let _: () = msg_send![content_view, addSubview: self.webview];
+      println!("ABC");
     }
 
     Ok(())


### PR DESCRIPTION
I've been facing random issues when cross compiling wry. When running `cargo xwin build --target x86_64-pc-windows-msvc`, sometimes the build script enables the gtk alias. So I thought its better to detect the target platform manually with the TARGET env var.