### PR TITLE
fix(windows): clone `HSTRING` so it is not dropped eagerly

### DIFF
--- a/.changes/webview-data-dir.md
+++ b/.changes/webview-data-dir.md
@@ -2,4 +2,4 @@
 "wry": "patch"
 ---
 
-On Windows, fix data directory created next to the executable even if it was provided in `WebConext::new`
+On Windows, fix data directory created next to the executable with a gibberish name even if it was explicitly provided in `WebConext::new`

--- a/.changes/webview-data-dir.md
+++ b/.changes/webview-data-dir.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Windows, fix data directory created next to the executable even if it was provided in `WebConext::new`

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -250,6 +250,9 @@ impl InnerWebView {
       .and_then(|path| path.to_str())
       .map(HSTRING::from);
 
+    // clone here so HSTRING is not dropped eagerly
+    let data_directory_param = data_directory.clone().map(|d| PCWSTR::from_raw(d.as_ptr()));
+
     // additional browser args
     let additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
       // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
@@ -280,10 +283,10 @@ impl InnerWebView {
 
       arguments
     });
-    let additional_browser_args = HSTRING::from(additional_browser_args);
-    let additional_browser_args = PCWSTR::from_raw(additional_browser_args.as_ptr());
 
-    let data_directory_param = data_directory.clone().map(|d| PCWSTR::from_raw(d.as_ptr()));
+    let additional_browser_args = HSTRING::from(additional_browser_args);
+    let additional_browser_args = additional_browser_args.clone();
+    let additional_browser_args = PCWSTR::from_raw(additional_browser_args.as_ptr());
 
     let (tx, rx) = mpsc::channel();
     CreateCoreWebView2EnvironmentCompletedHandler::wait_for_async_operation(

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -283,9 +283,6 @@ impl InnerWebView {
     let additional_browser_args = HSTRING::from(additional_browser_args);
     let additional_browser_args = PCWSTR::from_raw(additional_browser_args.as_ptr());
 
-    let data_directory = data_directory.map(HSTRING::from);
-    let data_directory = data_directory.map(|d| PCWSTR::from_raw(d.as_ptr()));
-
     let (tx, rx) = mpsc::channel();
     CreateCoreWebView2EnvironmentCompletedHandler::wait_for_async_operation(
       Box::new(move |environmentcreatedhandler| unsafe {
@@ -304,9 +301,14 @@ impl InnerWebView {
         );
         options.SetLanguage(PCWSTR::from_raw(lang.as_ptr()))?;
 
+        let data_directory = data_directory.map(HSTRING::from);
+        let data_directory = data_directory
+          .map(|d| PCWSTR::from_raw(d.as_ptr()))
+          .unwrap_or_else(PCWSTR::null);
+
         CreateCoreWebView2EnvironmentWithOptions(
           PCWSTR::null(),
-          data_directory.unwrap_or_else(PCWSTR::null),
+          data_directory,
           &options,
           &environmentcreatedhandler,
         )

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -302,8 +302,9 @@ impl InnerWebView {
         );
         options.SetLanguage(PCWSTR::from_raw(lang.as_ptr()))?;
 
-        let data_directory_param = data_directory.as_ref().map(|d| PCWSTR::from_raw(d.as_ptr()));
-
+        let data_directory_param = data_directory
+          .as_ref()
+          .map(|d| PCWSTR::from_raw(d.as_ptr()));
         CreateCoreWebView2EnvironmentWithOptions(
           PCWSTR::null(),
           data_directory_param.unwrap_or_else(PCWSTR::null),


### PR DESCRIPTION
ref: https://discord.com/channels/616186924390023171/1229300159607996437/1229300159607996437

closes tauri-apps/tauri#9501

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
