### PR TITLE
feat(macos): add option to set a DataStoreIdentifier for WKWebView

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1032,6 +1032,36 @@ impl<'a> WebViewBuilder<'a> {
   }
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+pub(crate) struct PlatformSpecificWebViewAttributes {
+  data_store_identifier: Option<[u8; 16]>,
+}
+
+#[cfg(target_os = "macos")]
+impl Default for PlatformSpecificWebViewAttributes {
+  fn default() -> Self {
+    Self {
+      data_store_identifier: None,
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+pub trait WebViewBuilderExtMacOS {
+  /// Initialize the WebView with a custom data store identifier. This can be used as a replacement for
+  /// data_directory not being available in WKWebView.
+  fn with_data_store_identifier(self, identifier: [u8; 16]) -> Self;
+}
+
+#[cfg(target_os = "macos")]
+impl WebViewBuilderExtMacOS for WebViewBuilder<'_> {
+  fn with_data_store_identifier(mut self, identifier: [u8; 16]) -> Self {
+    self.platform_specific.data_store_identifier = Some(identifier);
+    self
+  }
+}
+
 #[cfg(windows)]
 #[derive(Clone)]
 pub(crate) struct PlatformSpecificWebViewAttributes {
@@ -1654,7 +1684,6 @@ pub enum PageLoadEvent {
   target_os = "netbsd",
   target_os = "openbsd",
   target_os = "ios",
-  target_os = "macos",
 ))]
 #[derive(Default)]
 pub(crate) struct PlatformSpecificWebViewAttributes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1049,8 +1049,10 @@ impl Default for PlatformSpecificWebViewAttributes {
 
 #[cfg(any(target_os = "macos", target_os = "ios",))]
 pub trait WebViewBuilderExtDarwin {
-  /// Initialize the WebView with a custom data store identifier. This can be used as a replacement for
-  /// data_directory not being available in WKWebView on macOS and iOS.
+  /// Initialize the WebView with a custom data store identifier.
+  /// Can be used as a replacement for data_directory not being available in WKWebView.
+  ///
+  /// Only available on macOS >= 14 and iOS >= 17
   fn with_data_store_identifier(self, identifier: [u8; 16]) -> Self;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1032,13 +1032,13 @@ impl<'a> WebViewBuilder<'a> {
   }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios",))]
 #[derive(Clone)]
 pub(crate) struct PlatformSpecificWebViewAttributes {
   data_store_identifier: Option<[u8; 16]>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios",))]
 impl Default for PlatformSpecificWebViewAttributes {
   fn default() -> Self {
     Self {
@@ -1047,15 +1047,15 @@ impl Default for PlatformSpecificWebViewAttributes {
   }
 }
 
-#[cfg(target_os = "macos")]
-pub trait WebViewBuilderExtMacOS {
+#[cfg(any(target_os = "macos", target_os = "ios",))]
+pub trait WebViewBuilderExtDarwin {
   /// Initialize the WebView with a custom data store identifier. This can be used as a replacement for
-  /// data_directory not being available in WKWebView.
+  /// data_directory not being available in WKWebView on macOS and iOS.
   fn with_data_store_identifier(self, identifier: [u8; 16]) -> Self;
 }
 
-#[cfg(target_os = "macos")]
-impl WebViewBuilderExtMacOS for WebViewBuilder<'_> {
+#[cfg(any(target_os = "macos", target_os = "ios",))]
+impl WebViewBuilderExtDarwin for WebViewBuilder<'_> {
   fn with_data_store_identifier(mut self, identifier: [u8; 16]) -> Self {
     self.platform_specific.data_store_identifier = Some(identifier);
     self
@@ -1683,7 +1683,6 @@ pub enum PageLoadEvent {
   target_os = "freebsd",
   target_os = "netbsd",
   target_os = "openbsd",
-  target_os = "ios",
 ))]
 #[derive(Default)]
 pub(crate) struct PlatformSpecificWebViewAttributes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1052,7 +1052,7 @@ pub trait WebViewBuilderExtDarwin {
   /// Initialize the WebView with a custom data store identifier.
   /// Can be used as a replacement for data_directory not being available in WKWebView.
   ///
-  /// Only available on macOS >= 14 and iOS >= 17
+  /// - **macOS / iOS**: Available on macOS >= 14 and iOS >= 17
   fn with_data_store_identifier(self, identifier: [u8; 16]) -> Self;
 }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -135,7 +135,7 @@ impl InnerWebView {
   fn new_ns_view(
     ns_view: id,
     attributes: WebViewAttributes,
-    _pl_attrs: super::PlatformSpecificWebViewAttributes,
+    pl_attrs: super::PlatformSpecificWebViewAttributes,
     _web_context: Option<&mut WebContext>,
     is_child: bool,
   ) -> Result<Self> {
@@ -332,9 +332,15 @@ impl InnerWebView {
       let config: id = msg_send![class!(WKWebViewConfiguration), new];
       let mut protocol_ptrs = Vec::new();
 
-      // Incognito mode
+      // data store is either default, non-persistent if incognito is set, or custom
       let data_store: id = if attributes.incognito {
+        // incognito
         msg_send![class!(WKWebsiteDataStore), nonPersistentDataStore]
+      // Custom data store identifier
+      } else if let Some(data_store) = pl_attrs.data_store_identifier {
+        let ns_uuid = NSUUID::new(&data_store);
+        msg_send![class!(WKWebsiteDataStore), dataStoreForIdentifier:ns_uuid.0]
+      // Default data store
       } else {
         msg_send![class!(WKWebsiteDataStore), defaultDataStore]
       };
@@ -1320,6 +1326,21 @@ impl Drop for InnerWebView {
 }
 
 const UTF8_ENCODING: usize = 4;
+
+struct NSUUID(id);
+
+impl NSUUID {
+  fn new(data: &[u8; 16]) -> Self {
+    NSUUID(unsafe {
+      let ns_uuid: id = msg_send![class!(NSUUID), alloc];
+      let ns_uuid: id = msg_send![ns_uuid, initWithUUIDBytes:data.as_ptr()];
+
+      let _: () = msg_send![ns_uuid, autorelease];
+
+      ns_uuid
+    })
+  }
+}
 
 struct NSString(id);
 

--- a/src/wkwebview/util.rs
+++ b/src/wkwebview/util.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use cocoa::{base::id, foundation::NSOperatingSystemVersion};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 pub struct Counter(AtomicU32);
@@ -14,5 +15,18 @@ impl Counter {
 
   pub fn next(&self) -> u32 {
     self.0.fetch_add(1, Ordering::Relaxed)
+  }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn operating_system_version() -> (u64, u64, u64) {
+  unsafe {
+    let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
+    let version: NSOperatingSystemVersion = msg_send![process_info, operatingSystemVersion];
+    (
+      version.majorVersion,
+      version.minorVersion,
+      version.patchVersion,
+    )
   }
 }

--- a/src/wkwebview/util.rs
+++ b/src/wkwebview/util.rs
@@ -18,7 +18,6 @@ impl Counter {
   }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn operating_system_version() -> (u64, u64, u64) {
   unsafe {
     let process_info: id = msg_send![class!(NSProcessInfo), processInfo];


### PR DESCRIPTION
Both WebView2 for Windows and WebkitGTK support setting a custom data directory path to store cookies, IndexedDB and other data (set in ```src/web_context.rs -> WebContextData```). On macOS, WKWebView does not support this so setting data_directory in wry or tauri has no effect.

This PR adds the ability to specify a UUID that is used to call [dataStoreForIdentifier](https://developer.apple.com/documentation/webkit/wkwebsitedatastore/4183560-datastoreforidentifier?language=objc), which creates a data directory in ~/Library/WebKit/[application]/WebsiteDataStore/[UUID] instead of using the default ~/Library/WebKit/[application]/WebsiteData .

Discussion: #1198 

tauri-apps/tauri#8637
