### PR TITLE
fix: incorrect linux target name

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,15 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-  let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+  let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
   if target_os == "macos" || target_os == "ios" {
     println!("cargo:rustc-link-lib=framework=WebKit");
   }
 
-  let is_android = std::env::var("CARGO_CFG_TARGET_OS")
-    .map(|t| t == "android")
-    .unwrap_or_default();
-  if is_android {
+  if target_os == "android" {
     use std::{fs, path::PathBuf};
 
     fn env_var(var: &str) -> String {
@@ -101,20 +98,15 @@ fn main() {
     }
   }
 
-  let target = std::env::var("TARGET").unwrap();
+  let target = std::env::var("TARGET").unwrap_or_default();
   let android = target.contains("android");
-  let linux = target.contains("linux");
-  alias("android", android);
-  alias("macos", target.contains("darwin"));
-  alias("ios", target.contains("ios"));
-  alias("windows", target.contains("windows"));
-  alias("apple", target.contains("apple"));
-  alias("linux", !android && linux);
-
-  alias(
-    "gtk",
-    cfg!(feature = "os-webview") && linux,
-  );
+  let linux = !android && target.contains("linux")
+    || target.contains("freebsd")
+    || target.contains("dragonfly")
+    || target.contains("netbsd")
+    || target.contains("openbsd");
+  alias("linux", linux);
+  alias("gtk", cfg!(feature = "os-webview") && linux);
 }
 
 fn alias(alias: &str, condition: bool) {

--- a/build.rs
+++ b/build.rs
@@ -103,16 +103,17 @@ fn main() {
 
   let target = std::env::var("TARGET").unwrap();
   let android = target.contains("android");
+  let linux = target.contains("linux");
   alias("android", android);
   alias("macos", target.contains("darwin"));
   alias("ios", target.contains("ios"));
   alias("windows", target.contains("windows"));
   alias("apple", target.contains("apple"));
-  alias("linux", !android && target.contains("linux"));
+  alias("linux", !android && linux);
 
   alias(
     "gtk",
-    cfg!(feature = "os-webview") && target.contains("unknown-linux"),
+    cfg!(feature = "os-webview") && linux,
   );
 }
 

--- a/build.rs
+++ b/build.rs
@@ -100,11 +100,12 @@ fn main() {
 
   let target = std::env::var("TARGET").unwrap_or_default();
   let android = target.contains("android");
-  let linux = !android && target.contains("linux")
-    || target.contains("freebsd")
-    || target.contains("dragonfly")
-    || target.contains("netbsd")
-    || target.contains("openbsd");
+  let linux = !android
+    && (target.contains("linux")
+      || target.contains("freebsd")
+      || target.contains("dragonfly")
+      || target.contains("netbsd")
+      || target.contains("openbsd"));
   alias("linux", linux);
   alias("gtk", cfg!(feature = "os-webview") && linux);
 }


### PR DESCRIPTION
Just testing the cross-compiling using Yocto when coming across this thing. Sorry for no issue, but I figure it's faster to contribute, rather than do extra writing, no? I'm presuming a lot below, so please correct me or abandon this PR if needed.

The target configuration leaves it possible for gtk to not be found. It is my understanding, that the "unknown-linux" is supposed to be "linux".

Fix it by changing the checked target name to "linux".


