### PR TITLE
feat(tracing): IPC and custom protocol spans should not have a parent

### DIFF
--- a/.changes/force-ipc-span-parent-none.md
+++ b/.changes/force-ipc-span-parent-none.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Force the IPC and custom protocol tracing spans to have no parent.

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -106,7 +106,7 @@ fn handle_request(
   if let Some(handler) = REQUEST_HANDLER.get() {
     #[cfg(feature = "tracing")]
     let span =
-      tracing::info_span!("wry::custom_protocol::handle", uri = tracing::field::Empty).entered();
+      tracing::info_span!(parent: None, "wry::custom_protocol::handle", uri = tracing::field::Empty).entered();
 
     let mut request_builder = Request::builder();
 
@@ -309,7 +309,7 @@ pub unsafe fn ipc(mut env: JNIEnv, _: JClass, url: JString, body: JString) {
   match (env.get_string(&url), env.get_string(&body)) {
     (Ok(url), Ok(body)) => {
       #[cfg(feature = "tracing")]
-      let _span = tracing::info_span!("wry::ipc::handle").entered();
+      let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
 
       let url = url.to_string_lossy().to_string();
       let body = body.to_string_lossy().to_string();

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -520,7 +520,7 @@ impl InnerWebView {
     // Connect before registering as recommended by the docs
     manager.connect_script_message_received(None, move |_m, msg| {
       #[cfg(feature = "tracing")]
-      let _span = tracing::info_span!("wry::ipc::handle").entered();
+      let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
 
       if let Some(js) = msg.js_value() {
         if let Some(ipc_handler) = &ipc_handler {

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -289,8 +289,7 @@ where
 
   context.register_uri_scheme(name, move |request| {
     #[cfg(feature = "tracing")]
-    let span =
-      tracing::info_span!("wry::custom_protocol::handle", uri = tracing::field::Empty).entered();
+    let span = tracing::info_span!(parent: None, "wry::custom_protocol::handle", uri = tracing::field::Empty).entered();
 
     if let Some(uri) = request.uri() {
       let uri = uri.as_str();

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -744,7 +744,7 @@ impl InnerWebView {
         };
 
         #[cfg(feature = "tracing")]
-        let _span = tracing::info_span!("wry::ipc::handle").entered();
+        let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
         ipc_handler(Request::builder().uri(url).body(js).unwrap());
 
         Ok(())
@@ -785,7 +785,7 @@ impl InnerWebView {
         };
 
         #[cfg(feature = "tracing")]
-        let span = tracing::info_span!("wry::custom_protocol::handle", uri = tracing::field::Empty)
+        let span = tracing::info_span!(parent: None, "wry::custom_protocol::handle", uri = tracing::field::Empty)
           .entered();
 
         // Request uri

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -144,7 +144,7 @@ impl InnerWebView {
       // Safety: objc runtime calls are unsafe
       unsafe {
         #[cfg(feature = "tracing")]
-        let _span = tracing::info_span!("wry::ipc::handle").entered();
+        let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
 
         let function = this.get_ivar::<*mut c_void>("function");
         if !function.is_null() {
@@ -179,7 +179,7 @@ impl InnerWebView {
     extern "C" fn start_task(this: &Object, _: Sel, _webview: id, task: id) {
       unsafe {
         #[cfg(feature = "tracing")]
-        let span = tracing::info_span!("wry::custom_protocol::handle", uri = tracing::field::Empty)
+        let span = tracing::info_span!(parent: None, "wry::custom_protocol::handle", uri = tracing::field::Empty)
           .entered();
         let webview_id = *this.get_ivar::<u32>("webview_id");
 


### PR DESCRIPTION
IPC and custom protocol tracing spans are treated as root for these operations, so they should not have a parent.

When an IPC is being executed on the main thread, and another IPC message is received, the second IPC span might be added as a child of the first IPC call, which can be misleading.