### PR TITLE
disable initialization script injection into subframes on macOS

### DIFF
--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -423,9 +423,7 @@ impl InnerWebView {
     if let Some(manager) = self.webview.user_content_manager() {
       let script = UserScript::new(
         js,
-        // FIXME: We allow subframe injection because webview2 does and cannot be disabled (currently).
-        // once webview2 allows disabling all-frame script injection, TopFrame should be set
-        // if it does not break anything. (originally added for isolation pattern).
+        // TODO: feature to allow injecting into subframes
         UserContentInjectedFrames::TopFrame,
         UserScriptInjectionTime::Start,
         &[],

--- a/src/webview/webview2/mod.rs
+++ b/src/webview/webview2/mod.rs
@@ -798,6 +798,7 @@ window.addEventListener('mousemove', (e) => window.chrome.webview.postMessage('_
     Ok(webview)
   }
 
+  // TODO: feature to allow injecting into (specific) subframes
   fn add_script_to_execute_on_document_created(
     webview: &ICoreWebView2,
     js: String,

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -898,8 +898,8 @@ r#"Object.defineProperty(window, 'ipc', {
     // [manager addUserScript:[[WKUserScript alloc] initWithSource:[NSString stringWithUTF8String:js.c_str()] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]]
     unsafe {
       let userscript: id = msg_send![class!(WKUserScript), alloc];
-      let script: id =
       // TODO: feature to allow injecting into subframes
+      let script: id =
         msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:1];
       let _: () = msg_send![self.manager, addUserScript: script];
     }

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -899,7 +899,7 @@ r#"Object.defineProperty(window, 'ipc', {
     unsafe {
       let userscript: id = msg_send![class!(WKUserScript), alloc];
       let script: id =
-        // TODO: feature to allow injecting into subframes
+      // TODO: feature to allow injecting into subframes
         msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:1];
       let _: () = msg_send![self.manager, addUserScript: script];
     }

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -899,8 +899,8 @@ r#"Object.defineProperty(window, 'ipc', {
     unsafe {
       let userscript: id = msg_send![class!(WKUserScript), alloc];
       let script: id =
-          // TODO: feature to allow injecting into subframes
-          msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:1];
+        // TODO: feature to allow injecting into subframes
+        msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:1];
       let _: () = msg_send![self.manager, addUserScript: script];
     }
   }

--- a/src/webview/wkwebview/mod.rs
+++ b/src/webview/wkwebview/mod.rs
@@ -899,10 +899,8 @@ r#"Object.defineProperty(window, 'ipc', {
     unsafe {
       let userscript: id = msg_send![class!(WKUserScript), alloc];
       let script: id =
-      // FIXME: We allow subframe injection because webview2 does and cannot be disabled (currently).
-      // once webview2 allows disabling all-frame script injection, forMainFrameOnly should be enabled
-      // if it does not break anything. (originally added for isolation pattern).
-        msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:0];
+          // TODO: feature to allow injecting into subframes
+          msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:1];
       let _: () = msg_send![self.manager, addUserScript: script];
     }
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

This matches the current behavior of Linux and (mostly) Windows. Windows differs slightly since it still injects subscripts to subframes on the same origin as the main frame.