### PR TITLE
fix(windows): use physical size when resizing to parent

### DIFF
--- a/.changes/windows-resize-to-parent-logical.md
+++ b/.changes/windows-resize-to-parent-logical.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Windows, fix webview having a bigger size than the actual window size after creation and until the window is resized.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1268,10 +1268,7 @@ impl InnerWebView {
     let width = rect.right - rect.left;
     let height = rect.bottom - rect.top;
 
-    self.set_bounds(Rect {
-      size: dpi::Size::Logical((width, height).into()),
-      ..Default::default()
-    })
+    self.set_bounds_inner((width, height).into(), (0, 0).into())
   }
 
   pub fn set_visible(&self, visible: bool) -> Result<()> {


### PR DESCRIPTION
closes tauri-apps/tauri#9716