### PR TITLE
feat: Add screenshot functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ os-webview = [
   "dep:gtk",
   "soup3",
   "x11-dl",
-  "gdkx11"
+  "gdkx11",
+  "cairo-rs"
 ]
 tracing = [ "dep:tracing" ]
 
@@ -59,6 +60,7 @@ javascriptcore-rs = { version = "=1.1.2", features = [ "v2_28" ], optional = tru
 webkit2gtk = { version = "=2.0.1", features = [ "v2_38" ], optional = true }
 webkit2gtk-sys = { version = "=2.0.1", optional = true }
 gtk = { version = "0.18", optional = true }
+cairo-rs = { version = "0.18", features = ["png"], optional = true }
 soup3 = { version = "0.5", optional = true }
 x11-dl = { version = "2.21", optional = true }
 gdkx11 = { version = "0.18", optional = true }

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -20,7 +20,14 @@ fn main() -> wry::Result<()> {
     .build(&event_loop)
     .unwrap();
   // Build the webview
-  let webview = WebViewBuilder::new(&window)
+  let webview = WebViewBuilder::new_as_child(&window)
+    .with_bounds(wry::Rect {
+      position: dpi::Position::Logical(dpi::LogicalPosition { x: 50.0, y: 50.0 }),
+      size: dpi::Size::Logical(dpi::LogicalSize {
+        width: 600.0,
+        height: 400.0,
+      }),
+    })
     .with_url("https://html5test.com")
     .with_on_page_load_handler(move |_, _| event_proxy.send_event(()).unwrap())
     .build()?;

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,0 +1,51 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+use std::{fs::File, io::Write};
+
+use tao::{
+  event::{Event, StartCause, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  window::WindowBuilder,
+};
+use wry::WebViewBuilder;
+
+fn main() -> wry::Result<()> {
+  // Build our event loop
+  let event_loop = EventLoop::new();
+  let event_proxy = event_loop.create_proxy();
+  // Build the window
+  let window = WindowBuilder::new()
+    .with_title("Hello World")
+    .build(&event_loop)
+    .unwrap();
+  // Build the webview
+  let webview = WebViewBuilder::new(&window)
+    .with_url("https://html5test.com")
+    .with_on_page_load_handler(move |_, _| event_proxy.send_event(()).unwrap())
+    .build()?;
+
+  // launch WRY process
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::NewEvents(StartCause::Init) => println!("Wry has started!"),
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        ..
+      } => *control_flow = ControlFlow::Exit,
+      Event::UserEvent(()) => {
+        let on_screenshot = |image: wry::Result<Vec<u8>>| {
+          let image = image.expect("No image?");
+          let mut file = File::create("baaaaar.png").expect("Couldn't create the dang file");
+          file
+            .write(image.as_slice())
+            .expect("Couldn't write the dang file");
+        };
+        webview.screenshot(on_screenshot).expect("Take screenshot")
+      }
+      _ => (),
+    }
+  });
+}

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -122,7 +122,7 @@ fn stream_protocol(
     .decode_utf8_lossy()
     .to_string();
 
-  let mut file = std::fs::File::open(&path)?;
+  let mut file = std::fs::File::open(path)?;
 
   // get file length
   let len = {

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -371,6 +371,14 @@ impl InnerWebView {
     // Unsupported
     Ok(())
   }
+
+  pub fn screenshot<F>(&self, region: ScreenshotRegion, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
+  {
+    // Unsupported
+    Ok(())
+  }
 }
 
 #[derive(Clone, Copy)]

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -372,7 +372,7 @@ impl InnerWebView {
     Ok(())
   }
 
-  pub fn screenshot<F>(&self, region: ScreenshotRegion, handler: F) -> Result<()>
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
   where
     F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
   {

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,8 +60,8 @@ pub enum Error {
   
   #[cfg(target_os = "linux")]
   #[error(transparent)]
-  CairoError(#[from] cairo::Error),
+  CairoError(#[from] gtk::cairo::Error),
   #[cfg(target_os = "linux")]
   #[error(transparent)]
-  CairoIoError(#[from] cairo::IoError),
+  CairoIoError(#[from] gtk::cairo::IoError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,8 +60,8 @@ pub enum Error {
   
   #[cfg(target_os = "linux")]
   #[error(transparent)]
-  CairoError(#[from] gtk::cairo::Error),
+  CairoError(#[from] cairo::Error),
   #[cfg(target_os = "linux")]
   #[error(transparent)]
-  CairoIoError(#[from] gtk::cairo::IoError),
+  CairoIoError(#[from] cairo::IoError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,4 +57,11 @@ pub enum Error {
   #[cfg(target_os = "android")]
   #[error(transparent)]
   CrossBeamRecvError(#[from] crossbeam_channel::RecvError),
+  
+  #[cfg(target_os = "linux")]
+  #[error(transparent)]
+  CairoError(#[from] cairo::Error),
+  #[cfg(target_os = "linux")]
+  #[error(transparent)]
+  CairoIoError(#[from] cairo::IoError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,4 +64,8 @@ pub enum Error {
   #[cfg(target_os = "linux")]
   #[error(transparent)]
   CairoIoError(#[from] cairo::IoError),
+
+  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  #[error("Could not obtain screenshot from webview")]
+  NilScreenshot()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1443,6 +1443,13 @@ impl WebView {
   pub fn focus(&self) -> Result<()> {
     self.webview.focus()
   }
+
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
+  {
+    self.webview.screenshot(handler)
+  }
 }
 
 /// An event describing drag and drop operations on the webview.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1446,7 +1446,7 @@ impl WebView {
 
   pub fn screenshot<F>(&self, handler: F) -> Result<()>
   where
-    F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
   {
     self.webview.screenshot(handler)
   }

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use cairo::ImageSurface;
 use dpi::{LogicalPosition, LogicalSize};
 use gdkx11::{
   ffi::{gdk_x11_window_foreign_new_for_display, GdkX11Display},
   X11Display,
 };
 use gtk::{
-  cairo::ImageSurface,
   gdk::{self},
   gio::Cancellable,
   glib::{self, translate::FromGlibPtrFull},
@@ -816,7 +816,7 @@ impl InnerWebView {
     F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
   {
     let cancellable: Option<&Cancellable> = None;
-    let cb = move |result: std::result::Result<gtk::cairo::Surface, glib::Error>| match result {
+    let cb = move |result: std::result::Result<cairo::Surface, glib::Error>| match result {
       Ok(surface) => match ImageSurface::try_from(surface) {
         Ok(image) => {
           let mut bytes = Vec::new();
@@ -826,7 +826,7 @@ impl InnerWebView {
           }
         }
         Err(_) => handler(Err(Error::CairoError(
-          gtk::cairo::Error::SurfaceTypeMismatch,
+          cairo::Error::SurfaceTypeMismatch,
         ))),
       },
       Err(err) => handler(Err(Error::GlibError(err))),

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -833,7 +833,7 @@ impl InnerWebView {
     };
 
     self.webview.snapshot(
-      SnapshotRegion::FullDocument,
+      SnapshotRegion::Visible,
       SnapshotOptions::NONE,
       cancellable,
       cb,

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use cairo::ImageSurface;
 use dpi::{LogicalPosition, LogicalSize};
 use gdkx11::{
   ffi::{gdk_x11_window_foreign_new_for_display, GdkX11Display},
   X11Display,
 };
 use gtk::{
+  cairo::ImageSurface,
   gdk::{self},
   gio::Cancellable,
   glib::{self, translate::FromGlibPtrFull},
@@ -30,9 +30,9 @@ use webkit2gtk::{
   AutoplayPolicy, InputMethodContextExt, LoadEvent, NavigationPolicyDecision,
   NavigationPolicyDecisionExt, NetworkProxyMode, NetworkProxySettings, PolicyDecisionType,
   PrintOperationExt, SettingsExt, SnapshotOptions, SnapshotRegion, URIRequest, URIRequestExt,
-  URISchemeRequestExt, UserContentInjectedFrames, UserContentManagerExt, UserScript,
-  UserScriptInjectionTime, WebContextExt as Webkit2gtkWeContextExt, WebView, WebViewExt,
-  WebsiteDataManagerExt, WebsiteDataManagerExtManual, WebsitePolicies,
+  UserContentInjectedFrames, UserContentManagerExt, UserScript, UserScriptInjectionTime,
+  WebContextExt as Webkit2gtkWeContextExt, WebView, WebViewExt, WebsiteDataManagerExt,
+  WebsiteDataManagerExtManual, WebsitePolicies,
 };
 use webkit2gtk_sys::{
   webkit_get_major_version, webkit_get_micro_version, webkit_get_minor_version,
@@ -816,7 +816,7 @@ impl InnerWebView {
     F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
   {
     let cancellable: Option<&Cancellable> = None;
-    let cb = move |result: std::result::Result<cairo::Surface, glib::Error>| match result {
+    let cb = move |result: std::result::Result<gtk::cairo::Surface, glib::Error>| match result {
       Ok(surface) => match ImageSurface::try_from(surface) {
         Ok(image) => {
           let mut bytes = Vec::new();
@@ -825,12 +825,14 @@ impl InnerWebView {
             Err(err) => handler(Err(Error::CairoIoError(err))),
           }
         }
-        Err(_) => handler(Err(Error::CairoError(cairo::Error::SurfaceTypeMismatch))),
+        Err(_) => handler(Err(Error::CairoError(
+          gtk::cairo::Error::SurfaceTypeMismatch,
+        ))),
       },
       Err(err) => handler(Err(Error::GlibError(err))),
     };
 
-    self.webview.get_snapshot(
+    self.webview.snapshot(
       SnapshotRegion::FullDocument,
       SnapshotOptions::NONE,
       cancellable,

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1376,7 +1376,7 @@ impl InnerWebView {
 
   pub fn screenshot<F>(&self, handler: F) -> Result<()>
   where
-    F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
   {
     unsafe {
       let stream = SHCreateMemStream(None);

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -21,7 +21,7 @@ use windows::{
     Globalization::{self, MAX_LOCALE_NAME},
     Graphics::Gdi::{MapWindowPoints, RedrawWindow, HBRUSH, HRGN, RDW_INTERNALPAINT},
     System::{
-      Com::{CoInitializeEx, IStream, COINIT_APARTMENTTHREADED},
+      Com::{CoInitializeEx, IStream, COINIT_APARTMENTTHREADED, STREAM_SEEK_SET},
       LibraryLoader::GetModuleHandleW,
       WinRT::EventRegistrationToken,
     },
@@ -1372,6 +1372,49 @@ impl InnerWebView {
   #[cfg(any(debug_assertions, feature = "devtools"))]
   pub fn is_devtools_open(&self) -> bool {
     false
+  }
+
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
+  {
+    unsafe {
+      let stream = SHCreateMemStream(None);
+      let _ = self.webview.CapturePreview(
+        COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG,
+        stream.clone().as_ref(),
+        &CapturePreviewCompletedHandler::create(Box::new(move |res| {
+          res?;
+
+          let mut bytes = Vec::new();
+          if let Some(stream) = stream {
+            stream.Seek(0, STREAM_SEEK_SET, None)?;
+            let mut buffer: [u8; 1024] = [0; 1024];
+            loop {
+              let mut cb_read = 0;
+
+              stream
+                .Read(
+                  buffer.as_mut_ptr() as *mut _,
+                  buffer.len() as u32,
+                  Some(&mut cb_read),
+                )
+                .ok()?;
+
+              if cb_read == 0 {
+                break;
+              }
+
+              bytes.extend_from_slice(&buffer[..(cb_read as usize)]);
+            }
+          }
+          handler(Ok(bytes));
+
+          Ok(())
+        })),
+      );
+    }
+    Ok(())
   }
 }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1256,6 +1256,33 @@ r#"Object.defineProperty(window, 'ipc', {
 
     Ok(())
   }
+
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) -> () + 'static + Send,
+  {
+    unsafe {
+      let config: id = msg_send![class!(WKSnapshotConfiguration), new];
+      let handler = block::ConcreteBlock::new(move |image: id, _error: id| {
+        let cgref: id =
+          msg_send![image, CGImageForProposedRect:null::<*const c_void>() context:nil hints:nil];
+        let bitmap_image_ref: id = msg_send![class!(NSBitmapImageRep), alloc];
+        let newrep: id = msg_send![bitmap_image_ref, initWithCGImage: cgref];
+        let size: id = msg_send![image, size];
+        let () = msg_send![newrep, setSize: size];
+        let nsdata: id = msg_send![newrep, representationUsingType:4 properties:nil];
+        let bytes: *const u8 = msg_send![nsdata, bytes];
+        let len: usize = msg_send![nsdata, length];
+        let vector = slice::from_raw_parts(bytes, len).to_vec();
+        handler(Ok(vector));
+      });
+      let handler = handler.copy();
+      let handler: &block::Block<(id, id), ()> = &handler;
+      let () =
+        msg_send![self.webview, takeSnapshotWithConfiguration:config completionHandler:handler];
+    }
+    Ok(())
+  }
 }
 
 pub fn url_from_webview(webview: id) -> Result<String> {


### PR DESCRIPTION
Based on work in PR #226 - adds screenshot functionality to macOS, linux and Windows. Android is unsupported.

Compared to 226, this PR does not include the region selection functionality. [This comment in the Webview2 repo](https://github.com/MicrosoftEdge/WebView2Feedback/issues/529#issuecomment-1021262814) indicates that it may now be possible to have parity across all three platforms in selecting regions, and so make it worthwhile to re-add.

This PR does not (yet) improve on the API presented in 226.
