### PR TITLE
fix(macos): override performKeyEquivalent only when creating child WebView

### DIFF
--- a/.changes/fix-macos-key-equivalent.md
+++ b/.changes/fix-macos-key-equivalent.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, fixed an issue of not being able to listen to the cmd+key event in javascript in single WebView.


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
Related: https://github.com/tauri-apps/tauri/issues/9426

If we override the method, it cannot listen to the `CMD+Key` event in JavaScript.

We still need the overriding since the method always returns `YES` when the webview is a child webview (multi-webview), the event won't be passed the window, and the menu shortcut (like cmd+z to undo) won't be triggered. However, we should remove this when we find a solution for multi-webview.