### PR TITLE
fix(macos): check IPC message body is null before dereference it, close tauri#9787

### DIFF
--- a/.changes/fix-macos-ipc-empty-body-crash.md
+++ b/.changes/fix-macos-ipc-empty-body-crash.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, fixed a crash when sending empty body by IPC.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -232,7 +232,9 @@ impl InnerWebView {
           if !body.is_null() {
             let length = msg_send![body, length];
             let data_bytes: id = msg_send![body, bytes];
-            sent_form_body = slice::from_raw_parts(data_bytes as *const u8, length).to_vec();
+            if !data_bytes.is_null() {
+              sent_form_body = slice::from_raw_parts(data_bytes as *const u8, length).to_vec();
+            }
           } else if !body_stream.is_null() {
             let _: () = msg_send![body_stream, open];
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Close https://github.com/tauri-apps/tauri/issues/9787
When the message body is empty, the `data_bytes` is `null`. We should check it before dereference it.