### PR TITLE
fix: Disable Initialization Script Injection into Subframes on MacOS

### DIFF
--- a/.changes/disable-script-inject-subframe.md
+++ b/.changes/disable-script-inject-subframe.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, disable initialization script injection into subframes.

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -601,6 +601,7 @@ impl InnerWebView {
     if let Some(manager) = self.webview.user_content_manager() {
       let script = UserScript::new(
         js,
+        // TODO: feature to allow injecting into subframes
         UserContentInjectedFrames::TopFrame,
         UserScriptInjectionTime::Start,
         &[],

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1101,6 +1101,7 @@ impl InnerWebView {
     );
   }
 
+  // TODO: feature to allow injecting into (specific) subframes
   #[inline]
   fn add_script_to_execute_on_document_created(webview: &ICoreWebView2, js: String) -> Result<()> {
     let webview = webview.clone();

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1085,10 +1085,8 @@ r#"Object.defineProperty(window, 'ipc', {
     unsafe {
       let userscript: id = msg_send![class!(WKUserScript), alloc];
       let script: id =
-      // FIXME: We allow subframe injection because webview2 does and cannot be disabled (currently).
-      // once webview2 allows disabling all-frame script injection, forMainFrameOnly should be enabled
-      // if it does not break anything. (originally added for isolation pattern).
-        msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:0];
+      // TODO: feature to allow injecting into subframes
+        msg_send![userscript, initWithSource:NSString::new(js) injectionTime:0 forMainFrameOnly:1];
       let _: () = msg_send![self.manager, addUserScript: script];
     }
   }


### PR DESCRIPTION
This is the same work done by @chippers in #1251 targeting the latest wry version.