### PR TITLE
fix(windows): create child webviews on top of the z-order

### DIFF
--- a/.changes/child-webview.md
+++ b/.changes/child-webview.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Windows, create child webview at the top of z-order to align with other platforms.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -31,8 +31,9 @@ use windows::{
         self as win32wm, CreateWindowExW, DefWindowProcW, DestroyWindow, GetClientRect,
         PostMessageW, RegisterClassExW, RegisterWindowMessageA, SendMessageW, SetParent,
         SetWindowPos, ShowWindow, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, HCURSOR, HICON, HMENU,
-        SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOZORDER, SW_HIDE, SW_SHOW,
-        WINDOW_EX_STYLE, WM_USER, WNDCLASSEXW, WS_CHILD, WS_CLIPCHILDREN, WS_VISIBLE,
+        HWND_TOP, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOOWNERZORDER, SWP_NOSIZE,
+        SWP_NOZORDER, SW_HIDE, SW_SHOW, WINDOW_EX_STYLE, WM_USER, WNDCLASSEXW, WS_CHILD,
+        WS_CLIPCHILDREN, WS_VISIBLE,
       },
     },
   },
@@ -239,6 +240,18 @@ impl InnerWebView {
         None,
       )
     };
+
+    unsafe {
+      SetWindowPos(
+        hwnd,
+        HWND_TOP,
+        0,
+        0,
+        0,
+        0,
+        SWP_ASYNCWINDOWPOS | SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOSIZE,
+      )
+    }?;
 
     Ok(hwnd)
   }


### PR DESCRIPTION
closes tauri-apps/tauri#9798

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
