### PR TITLE
fix(android): moved `currentUrl` assignment to onPageStarted

### DIFF
--- a/.changes/currentUrl.md
+++ b/.changes/currentUrl.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On Android, set `RustWebViewClient.currentUrl` field early in `onPageStarted` method instead of `onPageFinished`

--- a/src/android/kotlin/RustWebViewClient.kt
+++ b/src/android/kotlin/RustWebViewClient.kt
@@ -39,6 +39,7 @@ class RustWebViewClient(context: Context): WebViewClient() {
     }
 
     override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
+        currentUrl = url
         if (interceptedState[url] == false) {
             val webView = view as RustWebView
             for (script in webView.initScripts) {
@@ -49,7 +50,6 @@ class RustWebViewClient(context: Context): WebViewClient() {
     }
 
     override fun onPageFinished(view: WebView, url: String) {
-        currentUrl = url
         return onPageLoaded(url)
     }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

On Android, when Tauri opens a page with multiple scripts, some IPC calls gets invoked before `onPageFinished` callback, causing `Ipc.postMessage` not retrieving correct `currentUrl`.

This patch moved `currentUrl` assignment to `onPageStarted`, so when frontend codes make any IPC calls, the `currentUrl` will be up-to-date.

Fixes https://github.com/tauri-apps/tauri/issues/9502.