### PR TITLE
fix(linux): async custom protocol crashing sending response

### DIFF
--- a/.changes/fix-custom-protocol-async-linux.md
+++ b/.changes/fix-custom-protocol-async-linux.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes `with_asynchronous_custom_protocol` crashing when sending the response on Linux.

--- a/examples/async_custom_protocol.rs
+++ b/examples/async_custom_protocol.rs
@@ -9,9 +9,8 @@ use tao::{
   event_loop::{ControlFlow, EventLoop},
   window::WindowBuilder,
 };
-use wry::http::Request;
 use wry::{
-  http::{header::CONTENT_TYPE, Response},
+  http::{header::CONTENT_TYPE, Request, Response},
   WebViewBuilder,
 };
 

--- a/examples/custom_protocol.rs
+++ b/examples/custom_protocol.rs
@@ -9,9 +9,8 @@ use tao::{
   event_loop::{ControlFlow, EventLoop},
   window::WindowBuilder,
 };
-use wry::http::Request;
 use wry::{
-  http::{header::CONTENT_TYPE, Response},
+  http::{header::CONTENT_TYPE, Request, Response},
   WebViewBuilder,
 };
 

--- a/examples/custom_titlebar.rs
+++ b/examples/custom_titlebar.rs
@@ -8,8 +8,7 @@ use tao::{
   event_loop::{ControlFlow, EventLoopBuilder},
   window::{CursorIcon, ResizeDirection, Window, WindowBuilder},
 };
-use wry::http::Request;
-use wry::WebViewBuilder;
+use wry::{http::Request, WebViewBuilder};
 
 #[derive(Debug)]
 enum HitTestResult {

--- a/examples/gtk_multiwebview.rs
+++ b/examples/gtk_multiwebview.rs
@@ -7,8 +7,10 @@ use tao::{
   event_loop::{ControlFlow, EventLoop},
   window::WindowBuilder,
 };
-use wry::dpi::{LogicalPosition, LogicalSize};
-use wry::{Rect, WebViewBuilder};
+use wry::{
+  dpi::{LogicalPosition, LogicalSize},
+  Rect, WebViewBuilder,
+};
 
 fn main() -> wry::Result<()> {
   let event_loop = EventLoop::new();

--- a/examples/multiwebview.rs
+++ b/examples/multiwebview.rs
@@ -7,8 +7,10 @@ use winit::{
   event_loop::{ControlFlow, EventLoop},
   window::WindowBuilder,
 };
-use wry::dpi::{LogicalPosition, LogicalSize};
-use wry::{Rect, WebViewBuilder};
+use wry::{
+  dpi::{LogicalPosition, LogicalSize},
+  Rect, WebViewBuilder,
+};
 
 fn main() -> wry::Result<()> {
   #[cfg(any(

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -8,8 +8,7 @@ use tao::{
   event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy, EventLoopWindowTarget},
   window::{Window, WindowBuilder, WindowId},
 };
-use wry::http::Request;
-use wry::{WebView, WebViewBuilder};
+use wry::{http::Request, WebView, WebViewBuilder};
 
 enum UserEvent {
   CloseWindow(WindowId),

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -14,9 +14,8 @@ use tao::{
   event_loop::{ControlFlow, EventLoop},
   window::WindowBuilder,
 };
-use wry::http::Request;
 use wry::{
-  http::{header::*, Response},
+  http::{header::*, Request, Response},
   WebViewBuilder,
 };
 

--- a/examples/wgpu.rs
+++ b/examples/wgpu.rs
@@ -4,8 +4,10 @@ use winit::{
   event_loop::{ControlFlow, EventLoop},
   window::Window,
 };
-use wry::dpi::{LogicalPosition, LogicalSize};
-use wry::{Rect, WebViewBuilder};
+use wry::{
+  dpi::{LogicalPosition, LogicalSize},
+  Rect, WebViewBuilder,
+};
 
 async fn run(event_loop: EventLoop<()>, window: Window) {
   let size = window.inner_size();

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use webkit2gtk::{
   ApplicationInfo, AutomationSessionExt, CookiePersistentStorage, DownloadExt, LoadEvent,
-  SecurityManagerExt, URIRequest, URIRequestExt, URISchemeRequestExt, URISchemeResponse,
+  SecurityManagerExt, URIRequest, URIRequestExt, URISchemeRequestExt, URISchemeResponse, URISchemeRequest,
   URISchemeResponseExt, UserContentManager, WebContext, WebContextExt as Webkit2gtkContextExt,
   WebView, WebViewExt,
 };
@@ -361,28 +361,33 @@ where
         }
       };
 
-      let request_ = request.clone();
+      let request_ = MainThreadRequest(request.clone());
       let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
         Box::new(move |http_response| {
-          let buffer = http_response.body();
-          let input = gtk::gio::MemoryInputStream::from_bytes(&gtk::glib::Bytes::from(buffer));
-          let content_type = http_response
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|h| h.to_str().ok());
+          gtk::glib::idle_add(move || {
+            let buffer = http_response.body();
+            let input = gtk::gio::MemoryInputStream::from_bytes(&gtk::glib::Bytes::from(buffer));
+            let content_type = http_response
+              .headers()
+              .get(CONTENT_TYPE)
+              .and_then(|h| h.to_str().ok());
 
-          let response = URISchemeResponse::new(&input, buffer.len() as i64);
-          response.set_status(http_response.status().as_u16() as u32, None);
-          if let Some(content_type) = content_type {
-            response.set_content_type(content_type);
-          }
+            let response = URISchemeResponse::new(&input, buffer.len() as i64);
+            response.set_status(http_response.status().as_u16() as u32, None);
+            if let Some(content_type) = content_type {
+              response.set_content_type(content_type);
+            }
 
-          let headers = MessageHeaders::new(MessageHeadersType::Response);
-          for (name, value) in http_response.headers().into_iter() {
-            headers.append(name.as_str(), value.to_str().unwrap_or(""));
-          }
-          response.set_http_headers(headers);
-          request_.finish_with_response(&response);
+            let headers = MessageHeaders::new(MessageHeadersType::Response);
+            for (name, value) in http_response.headers().into_iter() {
+              headers.append(name.as_str(), value.to_str().unwrap_or(""));
+            }
+            response.set_http_headers(headers);
+            request_.finish_with_response(&response);
+
+            gtk::glib::ControlFlow::Break
+          });
+          
         });
 
       #[cfg(feature = "tracing")]
@@ -398,6 +403,17 @@ where
 
   Ok(())
 }
+
+struct MainThreadRequest(URISchemeRequest);
+
+impl MainThreadRequest {
+  fn finish_with_response(&self, response: &URISchemeResponse) {
+    self.0.finish_with_response(response);
+  }
+}
+
+unsafe impl Send for MainThreadRequest {}
+unsafe impl Sync for MainThreadRequest {}
 
 #[derive(Debug)]
 struct WebviewUriRequest {

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -21,9 +21,9 @@ use std::{
 };
 use webkit2gtk::{
   ApplicationInfo, AutomationSessionExt, CookiePersistentStorage, DownloadExt, LoadEvent,
-  SecurityManagerExt, URIRequest, URIRequestExt, URISchemeRequestExt, URISchemeResponse, URISchemeRequest,
-  URISchemeResponseExt, UserContentManager, WebContext, WebContextExt as Webkit2gtkContextExt,
-  WebView, WebViewExt,
+  SecurityManagerExt, URIRequest, URIRequestExt, URISchemeRequest, URISchemeRequestExt,
+  URISchemeResponse, URISchemeResponseExt, UserContentManager, WebContext,
+  WebContextExt as Webkit2gtkContextExt, WebView, WebViewExt,
 };
 
 #[derive(Debug)]
@@ -387,7 +387,7 @@ where
 
             gtk::glib::ControlFlow::Break
           });
-          
+
         });
 
       #[cfg(feature = "tracing")]

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -32,8 +32,10 @@ use std::{
   sync::{Arc, Mutex},
 };
 
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use core_graphics::{
+  base::CGFloat,
+  geometry::{CGPoint, CGRect, CGSize},
+};
 
 use objc::{
   declare::ClassDecl,


### PR DESCRIPTION
Fixes `GTK may only be used from the main thread. thread 'tokio-runtime-worker' panicked at .cargo/registry/src/index.crates.io-6f17d22bba15001f/webkit2gtk-2.0.1/src/auto/uri_scheme_response.rs:26`

Ref https://github.com/tauri-apps/tauri/issues/9794