### PR TITLE
fix(macos): suppress incorrect `dead_code` warning from rustc 1.78

### DIFF
--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1438,6 +1438,7 @@ impl From<NSData> for NSString {
   }
 }
 
+#[allow(dead_code)] // rustc complains `id` is unused, but it is actually used from Objective-C
 struct NSData(id);
 
 /// Converts from wry screen-coordinates to macOS screen-coordinates.


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

This PR suppresses the following warning reported by `cargo check`. From 1.78, rustc enhanced the dead code check and it wrongly detected the unused field. The field is actually used from Objective-C world.

```
warning: field `0` is never read
    --> src/wkwebview/mod.rs:1441:15
     |
1441 | struct NSData(id);
     |        ------ ^^
     |        |
     |        field in this struct
     |
     = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
     |
1441 | struct NSData(());
     |               ~~
```
