### PR TITLE
fix(linux): fix warnings from `unexpected_cfgs` lint on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,10 @@ winit = "0.29"
 getrandom = "0.2"
 http-range = "0.1"
 percent-encoding = "2.3"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  "cfg(linux)",
+  "cfg(gtk)",
+]


### PR DESCRIPTION
Recently nightly `rustc` enabled `unexpected_cfgs` lint by default. Since this project uses non-standard cfg names, they started to cause warnings like below on Linux:

```
warning: unexpected `cfg` condition name: `gtk`
    --> src/lib.rs:1029:17
     |
1029 |       #[cfg(not(gtk))]
     |                 ^^^
     |
     = help: consider using a Cargo feature instead
     = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
              [lints.rust]
              unexpected_cfgs = { level = "warn", check-cfg = ['cfg(gtk)'] }
     = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(gtk)");` to the top of the `build.rs`
     = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

I didn't add a change file since this happens only on nightly yet. I confirmed those warnings were fixed on `cargo +nightly check` and also confirmed `cargo check` passed same as before.

Ref: https://github.com/rust-lang/rust/issues/82450

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
