### PR TITLE
fix(ci): fix running benchmarks

### DIFF
--- a/bench/tests/src/hello_world.rs
+++ b/bench/tests/src/hello_world.rs
@@ -22,12 +22,15 @@ fn main() -> wry::Result<()> {
   let event_loop = EventLoop::new();
   let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-  let url = r#"data:text/html,
+  let html = r#"
+    <!DOCTYPE html>
+    <body>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
       ipc.postMessage('dom-loaded')
     })
     </script>
+    </body>
   "#;
 
   let handler = |req: Request<String>| {
@@ -56,7 +59,7 @@ fn main() -> wry::Result<()> {
     let vbox = window.default_vbox().unwrap();
     WebViewBuilder::new_gtk(vbox)
   };
-  let _webview = builder.with_url(url).with_ipc_handler(handler).build()?;
+  let _webview = builder.with_html(html).with_ipc_handler(handler).build()?;
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

This PR fixes benchmarks [continue to fail on dev branch](https://github.com/tauri-apps/wry/actions/workflows/bench.yml?query=branch%3Adev).

The root cause was that GtkWebKit no longer accepted `data:` URL which was passed on `WebViewBuilder::with_url`. By changing it to using `WebViewBuilder::with_html` this issue was solved.

Here is an example of the benchmark workflow run in my fork: https://github.com/rhysd/wry/actions/runs/9319528245/job/25654295202
