### PR TITLE
fix(macos): check WKURLSchemeTask is valid before using

### DIFF
--- a/.changes/fix-macos-mitigate-async-command-panic.md
+++ b/.changes/fix-macos-mitigate-async-command-panic.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, mitigate an issue that could cause a panic when running an async command.

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,4 +57,6 @@ pub enum Error {
   #[cfg(target_os = "android")]
   #[error(transparent)]
   CrossBeamRecvError(#[from] crossbeam_channel::RecvError),
+  #[error("Custom protocol task is invalid.")]
+  CustomProtocolTaskInvalid,
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Ref: https://github.com/tauri-apps/tauri/issues/9933 #1142 #1189

`task` in async mode may become invalid at any moment when webview decides to stop the task.
It could happen in any section of the responder, so we need to record which task is valid and check before we use it in the response callback.

One of my concerns is there might be a small chance that the task becomes invalid after we check it and before using it.
