### PR TITLE
fix(macos): prevent task object been released while executing async command

### DIFF
--- a/.changes/fix-macos-async-command-panic.md
+++ b/.changes/fix-macos-async-command-panic.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, fix an issue that could cause a panic when running an async command.

--- a/.changes/fix-macos-mitigate-async-command-panic.md
+++ b/.changes/fix-macos-mitigate-async-command-panic.md
@@ -1,5 +1,0 @@
----
-"wry": patch
----
-
-On macOS, mitigate an issue that could cause a panic when running an async command.

--- a/.changes/fix-macos-mitigate-async-command-panic.md
+++ b/.changes/fix-macos-mitigate-async-command-panic.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, mitigate an issue that could cause a panic when running an async command.

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,4 +57,6 @@ pub enum Error {
   #[cfg(target_os = "android")]
   #[error(transparent)]
   CrossBeamRecvError(#[from] crossbeam_channel::RecvError),
+  #[error("Custom protocol task is invalid.")]
+  CustomProtocolTaskInvalid,
 }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -276,8 +276,9 @@ impl InnerWebView {
           // send response
           match http_request.body(sent_form_body) {
             Ok(final_request) => {
-              // Place here to prevent task is dropped when responder is called
+              let () = msg_send![task, retain];
               let task_id: NSUInteger = msg_send![task, hash];
+
               let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> = Box::new(
                 move |sent_response| {
                   // Best-effort. OS may release task at any moment.
@@ -353,6 +354,7 @@ impl InnerWebView {
                     let _ = response(task, task_id, webview_id, url, sent_response);
                   }
                   TASK_IDS.lock().unwrap().remove(&task_id);
+                  let () = msg_send![task, release];
                 },
               );
 


### PR DESCRIPTION
Ref: https://github.com/tauri-apps/tauri/issues/9933 https://github.com/tauri-apps/wry/issues/1142 https://github.com/tauri-apps/wry/issues/1189 #1214 

- Retain the `task` until the response closure ends, and catch exceptions from the task function call.

In async mode, `task` object may become invalid and be dropped at any moment while executing the responder. By retaining the `task`, we can be sure the pointer will not point to a released object. If the `task` is marked as invalid, it will throw an exception, and we'll catch it, return the closure, and release the `task` object.

Tested with #1214, https://github.com/tauri-apps/tauri/issues/9933