### PR TITLE
chore(ci): run tests on Intel Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-apple-darwin, os: macos-latest }
           - { target: aarch64-apple-ios, os: macos-latest }
-          - { target: aarch64-apple-darwin, os: macos-14 }
+          - { target: x86_64-apple-darwin, os: macos-12 }
           - { target: aarch64-linux-android, os: ubuntu-latest }
 
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

`macos-latest` runner is now run on arm64 macOS. (`macos-latest` and `macos-14` now mean the same runner.)

https://github.com/actions/runner-images?tab=readme-ov-file#available-images

So the build workflow of this repository is now running only arm64 macOS and no tests are run on x86_64 macOS (Intel Mac).

This PR modifies the build workflow to run tests on both arm64 and x86_64 macOS as follows:

target v.s. host arch

| | aarch64-apple-darwin | x86_64-apple-darwin |
|-|-|-|
| aarch64 | ✅ | ✅ |
| x86_64 | :x: | ✅ |
