### PR TITLE
ci: Re-enable macos-aarch64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         platform:
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
-          - { target: x86_64-apple-darwin, os: macos-latest }
+          - { target: aarch64-apple-darwin, os: macos-latest }
           - { target: aarch64-apple-ios, os: macos-latest }
           - { target: x86_64-apple-darwin, os: macos-12 }
           - { target: aarch64-linux-android, os: ubuntu-latest }


### PR DESCRIPTION
Small mistake in https://github.com/tauri-apps/wry/pull/1291. With 1291 we now only build for x64, but on 2 different hosts. With this PR we do build for x64 and arm64 on their native host.