### PR TITLE
ci: test x86_64 cross compilation on aarch64 macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: aarch64-apple-darwin, os: macos-latest }
           - { target: aarch64-apple-ios, os: macos-latest }
+          - { target: x86_64-apple-darwin, os: macos-latest }
           - { target: x86_64-apple-darwin, os: macos-12 }
           - { target: aarch64-linux-android, os: ubuntu-latest }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

I saw the change at 9a607944d92eb4c3b2f8d701e3dfd865e630601f and noticed the cross compilation on aarch64 macOS is not tested on CI.

I agree that the cross compilation rarely causes an issue, but I believe it is better to check it because we link external Objective-C library. The object file for x86_64 is different from the object file for aarch64 so it may cause platform-specific problem at a boundary between Rust and Objective-C.

This PR adds the combination for the cross compilation to the matrix.

I confirmed tests passed on my fork: https://github.com/rhysd/wry/actions/runs/9483585090