### PR TITLE
chore(deps): Upgrade to `ndk 0.9` and delete unused `ndk-sys`/`ndk-context` dependencies

### DIFF
--- a/.changes/ndk-0.9.md
+++ b/.changes/ndk-0.9.md
@@ -1,0 +1,6 @@
+---
+"wry": minor
+---
+
+**Breaking change**: Upgrade `ndk` crate to `0.9` and delete unused `ndk-sys` and `ndk-context` dependencies.  Types from the `ndk` crate are used in public API surface.
+**Breaking change**: The public `android_setup()` function now takes `&ThreadLooper` instead of `&ForeignLooper`, signifying that the setup function must be called on the thread where the looper is attached (and the `JNIEnv` argument is already thread-local as well).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,7 @@ kuchiki = { package = "kuchikiki", version = "0.8" }
 sha2 = "0.10"
 base64 = "0.22"
 jni = "0.21"
-ndk = "0.7"
-ndk-sys = "0.4"
-ndk-context = "0.1"
+ndk = "0.9"
 tao-macros = "0.1"
 libc = "0.2"
 

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -27,7 +27,7 @@ macro_rules! android_binding {
   ($domain:ident, $package:ident) => {
     ::wry::android_binding!($domain, $package, ::wry)
   };
-  // use import `android_setup` just to force the import path to use `wry::{}`
+  // use imported `android_setup` just to force the import path to use `wry::{}`
   // as the macro breaks without braces
   ($domain:ident, $package:ident, $wry:path) => {{
     use $wry::{android_setup as _, prelude::*};


### PR DESCRIPTION
Closes #1060
Closes #1061

The `ndk` crate received some marginal API upgrades, besides fixing soundness issues.  Specifcally, `ForeignLooper::add_fd_with_callback()` now signifies that the incoming file descriptor is a `BorrowedFd` and the callback is executed on a different thread (where the looper is polled on the `ThreadLooper`) and must hence be `Send.`.

It appears the `ndk-sys` and `ndk-context` crates are not used directly, hence they are removed from `Cargo.toml` here.
