### PR TITLE
chore: add error when failed to register url scheme on macOS, close #1295

### DIFF
--- a/.changes/chore-mac-add-url-scheme-register-error.md
+++ b/.changes/chore-mac-add-url-scheme-register-error.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, emit an error when the URL scheme registration fails.

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,4 +59,6 @@ pub enum Error {
   CrossBeamRecvError(#[from] crossbeam_channel::RecvError),
   #[error("Custom protocol task is invalid.")]
   CustomProtocolTaskInvalid,
+  #[error("Failed to register URL scheme: {0}, could be due to invalid URL scheme or the scheme is already registered.")]
+  UrlSchemeRegisterError(String),
 }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -423,7 +423,13 @@ impl InnerWebView {
 
         (*handler).set_ivar("function", function as *mut _ as *mut c_void);
         (*handler).set_ivar("webview_id", webview_id);
-        let () = msg_send![config, setURLSchemeHandler:handler forURLScheme:NSString::new(&name)];
+
+        (*config)
+          .send_message::<(id, NSString), ()>(
+            sel!(setURLSchemeHandler:forURLScheme:),
+            (handler, NSString::new(&name)),
+          )
+          .map_err(|_| crate::Error::UrlSchemeRegisterError(name))?;
       }
 
       // WebView and manager


### PR DESCRIPTION
Fixed #1295 

I'm not sure what the guidelines are for adding `Error`; this one might be too specific?