### PR TITLE
Enable Change Comments On Fork-based PRs

### DIFF
--- a/.github/workflows/covector-comment-on-fork.yml
+++ b/.github/workflows/covector-comment-on-fork.yml
@@ -1,0 +1,28 @@
+name: covector comment
+on:
+  workflow_run:
+    workflows: [covector status] # the `name` of the workflow run on `pull_request` running `status` with `comment: true`
+    types:
+      - completed
+
+# note all other permissions are set to none if not specified
+#  and these set the permissions for `secrets.GITHUB_TOKEN`
+permissions:
+  # to read the action artifacts on `covector status` workflows
+  actions: read
+  # to write the comment
+  pull-requests: write
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_repository.full_name != github.repository || github.actor == 'dependabot[bot]')
+    steps:
+      - name: covector status
+        # note we are using the release branch temporarily awaiting a publish of these versions: https://github.com/jbolda/covector/pull/317
+        #  those changes include updates to support commenting from forks
+        uses: jbolda/covector/packages/action@release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          command: "status"

--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -7,10 +7,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: covector status
-        uses: jbolda/covector/packages/action@covector-v0
-        id: covector
         with:
-          command: 'status'
+          fetch-depth: 0
+      - name: covector status
+        # note we are using the release branch temporarily awaiting a publish of these versions: https://github.com/jbolda/covector/pull/317
+        #  those changes include updates to support commenting from forks
+        uses: jbolda/covector/packages/action@release
+        with:
+          command: "status"
           token: ${{ secrets.GITHUB_TOKEN }}
           comment: true


### PR DESCRIPTION
## Motivation

PRs from forks were failing as they don't have the permissions to comment to the PR. With changes upstream in covector and adding a workflow_run, we can enable these comments to be securely created.
