### PR TITLE
handle webkit2gtk close signal

### DIFF
--- a/.changes/handle-webkit2gtk-close-signal.md
+++ b/.changes/handle-webkit2gtk-close-signal.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Handle `webkit2gtk` close signal (when `window.close` is called from js)

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -395,6 +395,9 @@ impl InnerWebView {
     web_context: &mut WebContext,
     attributes: &mut WebViewAttributes,
   ) {
+    // window.close()
+    webview.connect_close(move |webview| unsafe { webview.destroy() });
+
     // Synthetic mouse events
     synthetic_mouse_events::setup(webview);
 


### PR DESCRIPTION
While working with selenium and tauri i wasn't able to close the window with `WebKitWebDriver` - now calling `driver.close` works.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
