### PR TITLE
enhance: Add API to allow print options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [ "/.changes", "/.github", "/audits", "/wry-logo.svg" ]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = [ "drag-drop", "protocol", "os-webview" ]
+features = [ "drag-drop", "protocol", "os-webview", "serde" ]
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",
@@ -26,7 +26,7 @@ rustdoc-args = [ "--cfg", "docsrs" ]
 
 [features]
 default = [ "drag-drop", "objc-exception", "protocol", "os-webview" ]
-serde = [ "dpi/serde" ]
+serde = [ "dep:serde", "dpi/serde" ]
 objc-exception = [ "objc/exception" ]
 drag-drop = [ ]
 protocol = [ ]
@@ -53,6 +53,7 @@ thiserror = "1.0"
 http = "1.1"
 raw-window-handle = { version = "0.6", features = [ "std" ] }
 dpi = "0.1"
+serde = { version = "1", features = ["serde_derive"], optional = true }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 javascriptcore-rs = { version = "=1.1.2", features = [ "v2_28" ], optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 /// Convenient type alias of Result type for wry.
 pub type Result<T> = std::result::Result<T, Error>;
 
+use crate::PrintOption;
+
 /// Errors returned by wry.
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
@@ -61,4 +63,6 @@ pub enum Error {
   CustomProtocolTaskInvalid,
   #[error("Failed to register URL scheme: {0}, could be due to invalid URL scheme or the scheme is already registered.")]
   UrlSchemeRegisterError(String),
+  #[error("Invalid print option {0}")]
+  PrintOptionError(PrintOption),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,6 +1271,42 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
   }
 }
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Print margins in millimeters
+#[derive(Debug, Default, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PrintMargin {
+  pub top: f32,
+  pub right: f32,
+  pub bottom: f32,
+  pub left: f32,
+}
+
+/// The print options
+///
+/// When printing, multiple options can be passed to the print function causing it to alter the
+/// printing behavior. If a backend does not support a print option, it can return the option as an
+/// error using: `return Err(Error::PrintOptionError(opt.clone()))`
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PrintOption {
+  Silent(bool),
+  Margins(PrintMargin),
+  GeneratePDF {
+    filename: String
+  }
+}
+
+impl std::fmt::Display for PrintOption {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{:?}", self)
+  }
+}
+
+impl std::error::Error for PrintOption {}
+
 /// The fundamental type to present a [`WebView`].
 ///
 /// [`WebViewBuilder`] / [`WebView`] are the basic building blocks to construct WebView contents and
@@ -1358,7 +1394,11 @@ impl WebView {
 
   /// Launch print modal for the webview content.
   pub fn print(&self) -> Result<()> {
-    self.webview.print()
+    self.webview.print_with_options(&[])
+  }
+
+  pub fn print_with_options(&self, options: &[PrintOption]) -> Result<()> {
+    self.webview.print_with_options(options)
   }
 
   /// Open the web inspector which is usually called dev tool.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1314,7 +1314,11 @@ impl InnerWebView {
     Ok(())
   }
 
-  pub fn print(&self) -> Result<()> {
+  pub fn print_with_options(&self, options: &[PrintOption]) -> Result<()> {
+    for opt in options.iter() {
+      return Err(Error::PrintOptionError(opt.clone()))
+    }
+
     self.eval(
       "window.print()",
       None::<Box<dyn FnOnce(String) + Send + 'static>>,


### PR DESCRIPTION
Implement global print options with WebKitGtk2 support and reuse MacOS support from #1259

Previous failed attempt for Windows was #1167

This could allow a print API in Tauri: https://github.com/tauri-apps/tauri/issues/4917

The specific goal I have is to generate PDF files from WebViews in Tauri.

I took the approach of specifying options in an array as it allows to only pass some options of interest and not the full list, and it also allows some platform to support some options and not others. this would be easier to have the feature developped and some options might not be relevant everywhere.