### PR TITLE
fix(example): workaround to prevent winit crash when unfocused

### DIFF
--- a/.changes/example-winit-unfocus-crash.md
+++ b/.changes/example-winit-unfocus-crash.md
@@ -1,5 +1,0 @@
----
-"wry": patch
----
-
-Use a workaround for winit example to prevent crash when unfocus the window.

--- a/.changes/example-winit-unfocus-crash.md
+++ b/.changes/example-winit-unfocus-crash.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Use a workaround for winit example to prevent crash when unfocus the window.

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -72,26 +72,6 @@ fn main() -> wry::Result<()> {
             })
             .unwrap();
         }
-        #[cfg(any(
-          target_os = "linux",
-          target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "netbsd",
-          target_os = "openbsd",
-        ))]
-        Event::WindowEvent {
-          event: WindowEvent::Resized(size),
-          ..
-        } => {
-          use wry::dpi::{PhysicalPosition, PhysicalSize};
-
-          _webview
-            .set_bounds(wry::Rect {
-              position: PhysicalPosition::new(0, 0).into(),
-              size: PhysicalSize::new(size.width, size.height).into(),
-            })
-            .unwrap();
-        }
         Event::WindowEvent {
           event: WindowEvent::CloseRequested,
           ..

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use dpi::{LogicalPosition, LogicalSize};
 use winit::{
   event::{Event, WindowEvent},
   event_loop::{ControlFlow, EventLoop},
   window::WindowBuilder,
 };
-use wry::WebViewBuilder;
+use wry::{Rect, WebViewBuilder};
 
 fn main() -> wry::Result<()> {
   #[cfg(any(
@@ -39,9 +40,9 @@ fn main() -> wry::Result<()> {
     .build(&event_loop)
     .unwrap();
 
-  #[allow(unused_mut)]
-  let mut builder = WebViewBuilder::new(&window);
-  let _webview = builder.with_url("https://tauri.app").build()?;
+  let webview = WebViewBuilder::new_as_child(&window)
+    .with_url("https://tauri.app")
+    .build()?;
 
   event_loop
     .run(move |event, evl| {
@@ -59,6 +60,18 @@ fn main() -> wry::Result<()> {
       }
 
       match event {
+        Event::WindowEvent {
+          event: WindowEvent::Resized(size),
+          ..
+        } => {
+          let size = size.to_logical::<u32>(window.scale_factor());
+          webview
+            .set_bounds(Rect {
+              position: LogicalPosition::new(0, 0).into(),
+              size: LogicalSize::new(size.width, size.height).into(),
+            })
+            .unwrap();
+        }
         #[cfg(any(
           target_os = "linux",
           target_os = "dragonfly",


### PR DESCRIPTION
It's a workaround for issue https://github.com/tauri-apps/wry/issues/1318

### Root cause
In Wry, we replace the content view with `WryWebViewParent` to pass key events to the application menu. When the window is unfocused, winit will call `WindowDelegate::window_did_resign_key` and get the `contentView`. It assumes the `contentView` is `WinitView` and gets its ivar `_state`. The ivar does not exist in our `WryWebViewParent`, so the exception is thrown.

### Workaround
`WebViewBuilder::new_as_child` will not create `WryWebViewParent` to replace the `contentView`, so it will be safe to use in winit.