### PR TITLE
fix(linux): don't share UserContentManager between webviews (v0.24)

### DIFF
--- a/.changes/linux-shared-webcontext-ipc.md
+++ b/.changes/linux-shared-webcontext-ipc.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix Linux IPC handler and initialization scripts when sharing a WebContext between multiple WebViews.

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -335,7 +335,11 @@ impl InnerWebView {
     };
 
     // Initialize message handler
-    w.init("Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: function(x) { window.webkit.messageHandlers['ipc'].postMessage(x) } }) })")?;
+    let mut init = String::with_capacity(115 + 20 + 22);
+    init.push_str("Object.defineProperty(window, 'ipc', {value: Object.freeze({postMessage:function(x){window.webkit.messageHandlers[\"");
+    init.push_str(&window_hash);
+    init.push_str("\"].postMessage(x)}})})");
+    w.init(&init)?;
 
     // Initialize scripts
     for js in attributes.initialization_scripts {

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -9,6 +9,8 @@ use gtk::prelude::*;
 #[cfg(any(debug_assertions, feature = "devtools"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
+  collections::hash_map::DefaultHasher,
+  hash::{Hash, Hasher},
   rc::Rc,
   sync::{Arc, Mutex},
 };

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -343,10 +343,11 @@ impl InnerWebView {
     }
 
     for (name, handler) in attributes.custom_protocols {
-      match web_context.register_uri_scheme(&name, handler) {
+      match web_context.try_register_uri_scheme(&name, handler) {
         // Swallow duplicate scheme errors to preserve current behavior.
-        // FIXME: we should log this error in the future
-        Err(Error::DuplicateCustomProtocol(_)) => (),
+        Err(Error::DuplicateCustomProtocol(_)) => {
+          log::warn!("Ignoring already registered custom protocol {name}");
+        }
         Err(e) => return Err(e),
         Ok(_) => (),
       }

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -85,6 +85,7 @@ impl InnerWebView {
       w.id().hash(&mut hasher);
       hasher.finish().to_string()
     };
+
     // Connect before registering as recommended by the docs
     manager.connect_script_message_received(None, move |_m, msg| {
       #[cfg(feature = "tracing")]

--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -78,7 +78,13 @@ impl InnerWebView {
     let webview = Rc::new(webview);
     let w = window_rc.clone();
     let ipc_handler = attributes.ipc_handler.take();
-
+    // Use the window hash as the script handler name to prevent from conflict when sharing same
+    // web context.
+    let window_hash = {
+      let mut hasher = DefaultHasher::new();
+      w.id().hash(&mut hasher);
+      hasher.finish().to_string()
+    };
     // Connect before registering as recommended by the docs
     manager.connect_script_message_received(None, move |_m, msg| {
       #[cfg(feature = "tracing")]

--- a/src/webview/webkitgtk/web_context.rs
+++ b/src/webview/webkitgtk/web_context.rs
@@ -21,14 +21,13 @@ use std::{
 };
 use url::Url;
 use webkit2gtk::{
-  traits::*, ApplicationInfo, CookiePersistentStorage, LoadEvent, URIRequest, UserContentManager,
-  WebContext, WebContextBuilder, WebView, WebsiteDataManagerBuilder,
+  traits::*, ApplicationInfo, CookiePersistentStorage, LoadEvent, URIRequest, WebContext,
+  WebContextBuilder, WebView, WebsiteDataManagerBuilder,
 };
 
 #[derive(Debug)]
 pub struct WebContextImpl {
   context: WebContext,
-  manager: UserContentManager,
   webview_uri_loader: Rc<WebviewUriLoader>,
   registered_protocols: HashSet<String>,
   automation: bool,
@@ -82,7 +81,6 @@ impl WebContextImpl {
     Self {
       context,
       automation,
-      manager: UserContentManager::new(),
       registered_protocols: Default::default(),
       webview_uri_loader: Rc::default(),
       app_info: Some(app_info),
@@ -100,9 +98,6 @@ impl WebContextImpl {
 pub trait WebContextExt {
   /// The GTK [`WebContext`] of all webviews in the context.
   fn context(&self) -> &WebContext;
-
-  /// The GTK [`UserContentManager`] of all webviews in the context.
-  fn manager(&self) -> &UserContentManager;
 
   /// Register a custom protocol to the web context.
   ///
@@ -148,10 +143,6 @@ pub trait WebContextExt {
 impl WebContextExt for super::WebContext {
   fn context(&self) -> &WebContext {
     &self.os.context
-  }
-
-  fn manager(&self) -> &UserContentManager {
-    &self.os.manager
   }
 
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>


### PR DESCRIPTION
Fixes #1308

Init scripts are registered to the `UserContentManager`, so if it is shared between `WebView`s, the init scripts conflict. Use a unique `UserContentManager` for each `WebView` instead of sharing it across the `WebContext`.

The IPC message handler is also registered to `UserContentManager`. `window_hash` is no longer needed as a key to `register_script_message_handler` since the manager is unique. (`window_hash` is already removed on the dev branch.)

Also changed from `register_uri_scheme` to `try_register_uri_scheme`, which doesn't attempt to register a URI scheme if we already know that one with the same name was registered to the `WebContext` before. Without this change, I get this error from WebKitGTK:
```
** (tauri-app:[...]): CRITICAL **: 14:03:50.040: Cannot register URI scheme tauri more than once
```
It doesn't seem to affect functionality, but better to issue a more appropriate warning on our side. (On dev, this is propagated as an error)

Corresponding PR on the dev branch: #1326