### PR TITLE
fix(linux): don't share UserContentManager between webviews (dev)

### DIFF
--- a/.changes/linux-shared-webcontext-ipc.md
+++ b/.changes/linux-shared-webcontext-ipc.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix Linux IPC handler and initialization scripts when sharing a WebContext between multiple WebViews.

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -22,14 +22,13 @@ use std::{
 use webkit2gtk::{
   ApplicationInfo, AutomationSessionExt, CookiePersistentStorage, DownloadExt, LoadEvent,
   SecurityManagerExt, URIRequest, URIRequestExt, URISchemeRequest, URISchemeRequestExt,
-  URISchemeResponse, URISchemeResponseExt, UserContentManager, WebContext,
-  WebContextExt as Webkit2gtkContextExt, WebView, WebViewExt,
+  URISchemeResponse, URISchemeResponseExt, WebContext, WebContextExt as Webkit2gtkContextExt,
+  WebView, WebViewExt,
 };
 
 #[derive(Debug)]
 pub struct WebContextImpl {
   context: WebContext,
-  manager: UserContentManager,
   webview_uri_loader: Rc<WebViewUriLoader>,
   registered_protocols: HashSet<String>,
   automation: bool,
@@ -90,7 +89,6 @@ impl WebContextImpl {
     Self {
       context,
       automation,
-      manager: UserContentManager::new(),
       registered_protocols: Default::default(),
       webview_uri_loader: Rc::default(),
       app_info: Some(app_info),
@@ -107,9 +105,6 @@ impl WebContextImpl {
 pub trait WebContextExt {
   /// The GTK [`WebContext`] of all webviews in the context.
   fn context(&self) -> &WebContext;
-
-  /// The GTK [`UserContentManager`] of all webviews in the context.
-  fn manager(&self) -> &UserContentManager;
 
   /// Register a custom protocol to the web context.
   ///
@@ -155,10 +150,6 @@ pub trait WebContextExt {
 impl WebContextExt for super::WebContext {
   fn context(&self) -> &WebContext {
     &self.os.context
-  }
-
-  fn manager(&self) -> &UserContentManager {
-    &self.os.manager
   }
 
   fn register_uri_scheme<F>(&mut self, name: &str, handler: F) -> crate::Result<()>


### PR DESCRIPTION
Fixes #1308

Init scripts are registered to the `UserContentManager`, so if it is shared between `WebView`s, the init scripts conflict. IPC handlers are also tied to the `UserContentManager`. Use a unique `UserContentManager` for each `WebView` instead of sharing it across the `WebContext`.

Corresponding PR on the v0.24 branch: #1325