### PR TITLE
fix(android): avoid rebuilds if nothing changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -93,10 +93,7 @@ fn main() {
 
         let out_path = kotlin_out_dir.join(file.file_name());
         // Overwrite only if changed to not trigger rebuilds
-        if fs::read_to_string(&out_path)
-          .map(|o| o != out)
-          .unwrap_or(false)
-        {
+        if fs::read_to_string(&out_path).map_or(true, |o| o != out) {
           fs::write(&out_path, out).expect("Failed to write kotlin file");
         }
         println!("cargo:rerun-if-changed={}", out_path.display());

--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,13 @@ fn main() {
         out.push_str(&content);
 
         let out_path = kotlin_out_dir.join(file.file_name());
-        fs::write(&out_path, out).expect("Failed to write kotlin file");
+        // Overwrite only if changed to not trigger rebuilds
+        if fs::read_to_string(&out_path)
+          .map(|o| o != out)
+          .unwrap_or(false)
+        {
+          fs::write(&out_path, out).expect("Failed to write kotlin file");
+        }
         println!("cargo:rerun-if-changed={}", out_path.display());
       }
     }


### PR DESCRIPTION
Unconditionally overwriting files where the build reruns if they changed leads to rebuilds every time.
Only overwrite a file if its content is different to not rebuild in such a case.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
