### PR TITLE
feat(windows): add `WebViewBuilderExtWindows::with_scroll_bar_style`

### DIFF
--- a/.changes/1344-with_scroll_bar_style.md
+++ b/.changes/1344-with_scroll_bar_style.md
@@ -1,5 +1,5 @@
 ---
-"wry": patch
+"wry": minor
 ---
 
 Windows: Implement `WebViewBuilderExtWindows::with_scroll_bar_style` to allow opting into Fluent Overlay style scrollbars.

--- a/.changes/1344-with_scroll_bar_style.md
+++ b/.changes/1344-with_scroll_bar_style.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Windows: Implement `WebViewBuilderExtWindows::with_scroll_bar_style` to allow opting into Fluent Overlay style scrollbars.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,8 @@ pub(crate) mod webview2;
 #[cfg(target_os = "windows")]
 use self::webview2::*;
 #[cfg(target_os = "windows")]
+pub use self::webview2::ScrollBarStyle;
+#[cfg(target_os = "windows")]
 use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 
 use std::{borrow::Cow, path::PathBuf, rc::Rc};
@@ -1088,6 +1090,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   browser_accelerator_keys: bool,
   theme: Option<Theme>,
   use_https: bool,
+  scroll_bar_style: ScrollBarStyle,
 }
 
 #[cfg(windows)]
@@ -1098,6 +1101,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       browser_accelerator_keys: true, // This is WebView2's default behavior
       theme: None,
       use_https: false, // To match macOS & Linux behavior in the context of mixed content.
+      scroll_bar_style: ScrollBarStyle::default(),
     }
   }
 }
@@ -1140,6 +1144,15 @@ pub trait WebViewBuilderExtWindows {
   ///
   /// The default value is `false`.
   fn with_https_scheme(self, enabled: bool) -> Self;
+
+  /// Specifies the native scrollbar style to use with webview2.
+  /// CSS styles that modify the scrollbar are applied on top of the native appearance configured here.
+  /// 
+  /// Defaults to [`ScrollbarStyle::Default`] which is the browser default used by Microsoft Edge.
+  /// 
+  /// Requires WebView2 Runtime version 125.0.2535.41 or higher, does nothing on older versions,
+  /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/?tabs=dotnetcsharp#10253541
+  fn with_scroll_bar_style(self, style: ScrollBarStyle) -> Self;
 }
 
 #[cfg(windows)]
@@ -1161,6 +1174,11 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 
   fn with_https_scheme(mut self, enabled: bool) -> Self {
     self.platform_specific.use_https = enabled;
+    self
+  }
+
+  fn with_scroll_bar_style(mut self, style: ScrollBarStyle) -> Self {
+    self.platform_specific.scroll_bar_style = style;
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,9 +238,9 @@ pub use wkwebview::{PrintMargin, PrintOptions};
 #[cfg(target_os = "windows")]
 pub(crate) mod webview2;
 #[cfg(target_os = "windows")]
-use self::webview2::*;
-#[cfg(target_os = "windows")]
 pub use self::webview2::ScrollBarStyle;
+#[cfg(target_os = "windows")]
+use self::webview2::*;
 #[cfg(target_os = "windows")]
 use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 
@@ -1147,9 +1147,9 @@ pub trait WebViewBuilderExtWindows {
 
   /// Specifies the native scrollbar style to use with webview2.
   /// CSS styles that modify the scrollbar are applied on top of the native appearance configured here.
-  /// 
+  ///
   /// Defaults to [`ScrollbarStyle::Default`] which is the browser default used by Microsoft Edge.
-  /// 
+  ///
   /// Requires WebView2 Runtime version 125.0.2535.41 or higher, does nothing on older versions,
   /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/?tabs=dotnetcsharp#10253541
   fn with_scroll_bar_style(self, style: ScrollBarStyle) -> Self;

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -300,6 +300,13 @@ impl InnerWebView {
         LCIDToLocaleName(lcid as u32, Some(&mut lang), LOCALE_ALLOW_NEUTRAL_NAMES);
         options.set_language(String::from_utf16_lossy(&lang));
 
+        let scroll_bar_style = match pl_attrs.scroll_bar_style {
+          ScrollBarStyle::Default => COREWEBVIEW2_SCROLLBAR_STYLE_DEFAULT,
+          ScrollBarStyle::FluentOverlay => COREWEBVIEW2_SCROLLBAR_STYLE_FLUENT_OVERLAY,
+        };
+
+        options.set_scroll_bar_style(scroll_bar_style);
+
         CreateCoreWebView2EnvironmentWithOptions(
           PCWSTR::null(),
           &data_directory.unwrap_or_default(),
@@ -1366,6 +1373,17 @@ impl InnerWebView {
   pub fn is_devtools_open(&self) -> bool {
     false
   }
+}
+
+/// The scrollbar style to use in the webview.
+#[derive(Clone, Copy, Default)]
+pub enum ScrollBarStyle {
+  #[default]
+  /// The browser default scrollbar style.
+  Default,
+
+  /// Fluent UI style overlay scrollbars.
+  FluentOverlay,
 }
 
 #[inline]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Resolves #1339.

Adds a `with_scroll_bar_style` option to the webview builder on Windows, that can be used to opt into Fluent Overlay style scrollbars in the WebView2 environment. Also, `wry::webview2::InnerWebView::create_environment` was modified to directly make use of the COM wrapper API on `CoreWebView2EnvironmentOptions` instead of using the COM API interface; the implementations of those interfaces deferred to this wrapper anyway, and the wrapper exposes a more Rust-friendly API than the interfaces do.