### PR TITLE
fix(linux): correct IPC handler name (v0.24)

### DIFF
--- a/src/webview/webkitgtk/mod.rs
+++ b/src/webview/webkitgtk/mod.rs
@@ -101,7 +101,7 @@ impl InnerWebView {
     });
 
     // Register handler on JS side
-    manager.register_script_message_handler("ipc");
+    manager.register_script_message_handler(&window_hash);
 
     // Allow the webview to close it's own window
     let close_window = window_rc.clone();


### PR DESCRIPTION
Forgotten change after reverting back to the window_hash setup in #1325

cc @amrbashir 