### PR TITLE
fix(android): file picker result processing

### DIFF
--- a/.changes/fix-android-file-picker-result.md
+++ b/.changes/fix-android-file-picker-result.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes Android file picker result processing.

--- a/src/android/kotlin/RustWebChromeClient.kt
+++ b/src/android/kotlin/RustWebChromeClient.kt
@@ -391,8 +391,7 @@ class RustWebChromeClient(appActivity: WryActivity) : WebChromeClient() {
         override fun onActivityResult(result: ActivityResult?) {
           val res: Array<Uri?>?
           val resultIntent = result?.data
-          if (result?.resultCode == Activity.RESULT_OK && resultIntent!!.clipData != null && resultIntent.clipData!!.itemCount > 1
-          ) {
+          if (result?.resultCode == Activity.RESULT_OK && resultIntent!!.clipData != null) {
             val numFiles = resultIntent.clipData!!.itemCount
             res = arrayOfNulls(numFiles)
             for (i in 0 until numFiles) {


### PR DESCRIPTION
The Android file picker result callback implementation is incorrectly checking the expected minimum result length. This only impacts usage on SDK 34+ because on older releases the `FileChooserParams.parseResult` properly resolves the response.
