### PR TITLE
fix(android): error loading resource redirects webview to resource url

### DIFF
--- a/.changes/fix-android-error-handling-page-visible.md
+++ b/.changes/fix-android-error-handling-page-visible.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes Android webview error page flashing when a redirect to the app is performed.

--- a/.changes/fix-request-error-handling-android.md
+++ b/.changes/fix-request-error-handling-android.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix navigation error handling to trigger custom protocol on Android.

--- a/src/android/kotlin/RustWebViewClient.kt
+++ b/src/android/kotlin/RustWebViewClient.kt
@@ -8,12 +8,15 @@ import android.net.Uri
 import android.webkit.*
 import android.content.Context
 import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
 import androidx.webkit.WebViewAssetLoader
 
 class RustWebViewClient(context: Context): WebViewClient() {
     private val interceptedState = mutableMapOf<String, Boolean>()
     var currentUrl: String = "about:blank"
-    var lastInterceptedUrl: Uri? = null
+    private var lastInterceptedUrl: Uri? = null
+    private var pendingUrlRedirect: String? = null
 
     private val assetLoader = WebViewAssetLoader.Builder()
         .setDomain(assetLoaderDomain())
@@ -24,6 +27,14 @@ class RustWebViewClient(context: Context): WebViewClient() {
         view: WebView,
         request: WebResourceRequest
     ): WebResourceResponse? {
+        pendingUrlRedirect?.let {
+            Handler(Looper.getMainLooper()).post {
+              view.loadUrl(it)
+            }
+            pendingUrlRedirect = null
+            return null
+        }
+
         lastInterceptedUrl = request.url
         return if (withAssetLoader()) {
             assetLoader.shouldInterceptRequest(request.url)
@@ -53,7 +64,7 @@ class RustWebViewClient(context: Context): WebViewClient() {
     }
 
     override fun onPageFinished(view: WebView, url: String) {
-        return onPageLoaded(url)
+        onPageLoaded(url)
     }
 
     override fun onReceivedError(
@@ -61,14 +72,19 @@ class RustWebViewClient(context: Context): WebViewClient() {
         request: WebResourceRequest,
         error: WebResourceError
     ) {
-       // we get a net::ERR_CONNECTION_REFUSED when an external URL redirects to a custom protocol
-       // e.g. oauth flow, because shouldInterceptRequest is not called on redirects
-       // so we must force retry here with loadUrl() to get a chance of the custom protocol to kick in
-       if (error.errorCode == ERROR_CONNECT && request.isForMainFrame() && request.url != lastInterceptedUrl) {
-         view.loadUrl(request.url.toString())
-       } else {
-         super.onReceivedError(view, request, error)
-       }
+        // we get a net::ERR_CONNECTION_REFUSED when an external URL redirects to a custom protocol
+        // e.g. oauth flow, because shouldInterceptRequest is not called on redirects
+        // so we must force retry here with loadUrl() to get a chance of the custom protocol to kick in
+        if (error.errorCode == ERROR_CONNECT && request.isForMainFrame && request.url != lastInterceptedUrl) {
+            // prevent the default error page from showing
+            view.stopLoading()
+            // without this initial loadUrl the app is stuck
+            view.loadUrl(request.url.toString())
+            // ensure the URL is actually loaded - for some reason there's a race condition and we need to call loadUrl() again later
+            pendingUrlRedirect = request.url.toString()
+        } else {
+            super.onReceivedError(view, request, error)
+        }
     }
 
     companion object {

--- a/src/android/kotlin/RustWebViewClient.kt
+++ b/src/android/kotlin/RustWebViewClient.kt
@@ -64,7 +64,7 @@ class RustWebViewClient(context: Context): WebViewClient() {
        // we get a net::ERR_CONNECTION_REFUSED when an external URL redirects to a custom protocol
        // e.g. oauth flow, because shouldInterceptRequest is not called on redirects
        // so we must force retry here with loadUrl() to get a chance of the custom protocol to kick in
-       if (error.errorCode == ERROR_CONNECT && request.url != lastInterceptedUrl) {
+       if (error.errorCode == ERROR_CONNECT && request.isForMainFrame() && request.url != lastInterceptedUrl) {
          view.loadUrl(request.url.toString())
        } else {
          super.onReceivedError(view, request, error)


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Currently, the `onReceivedError` override is checking for `net::ERR_CONNECTION_REFUSED` errors and retrying them using `view.loadUrl()`. However, based on [the documentation](https://developer.android.com/reference/android/webkit/WebViewClient#onReceivedError(android.webkit.WebView,%20android.webkit.WebResourceRequest,%20android.webkit.WebResourceError)), `onReceivedError` will be called if there is an error when loading an image, iframe, or other resource, not just the main page. In these cases, the request should not be retried this way.

Therefore, this PR adds a check for `request.isForMainFrame()`.

To give an example of the issue, we experienced a case where a custom DNS server blocked loading of a certain external stylesheet, which caused the webview to be redirected to the url of that stylesheet, resulting in an unexpected user-visible error 

```
Web page not available.
The web page at example.com/styles.css could not be loaded because:
new::ERR_CONNECTION_REFUSED"
```