### PR TITLE
feat: Expose ability to enable browser extensions in WebView2

### DIFF
--- a/.changes/change-pr-1356.md
+++ b/.changes/change-pr-1356.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Expose ability to enable browser extensions in WebView2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1091,6 +1091,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   theme: Option<Theme>,
   use_https: bool,
   scroll_bar_style: ScrollBarStyle,
+  browser_extensions_enabled: bool,
 }
 
 #[cfg(windows)]
@@ -1102,6 +1103,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       theme: None,
       use_https: false, // To match macOS & Linux behavior in the context of mixed content.
       scroll_bar_style: ScrollBarStyle::default(),
+      browser_extensions_enabled: false,
     }
   }
 }
@@ -1153,6 +1155,14 @@ pub trait WebViewBuilderExtWindows {
   /// Requires WebView2 Runtime version 125.0.2535.41 or higher, does nothing on older versions,
   /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/?tabs=dotnetcsharp#10253541
   fn with_scroll_bar_style(self, style: ScrollBarStyle) -> Self;
+
+  /// Determines whether the ability to install and enable extensions is enabled.
+  ///
+  /// By default, extensions are disabled.
+  ///
+  /// Requires WebView2 Runtime version 1.0.2210.55 or higher, does nothing on older versions,,
+  /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10221055
+  fn with_browser_extensions_enabled(self, enabled: bool) -> Self;
 }
 
 #[cfg(windows)]
@@ -1179,6 +1189,11 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 
   fn with_scroll_bar_style(mut self, style: ScrollBarStyle) -> Self {
     self.platform_specific.scroll_bar_style = style;
+    self
+  }
+
+  fn with_browser_extensions_enabled(mut self, enabled: bool) -> Self {
+    self.platform_specific.browser_extensions_enabled = enabled;
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1160,7 +1160,7 @@ pub trait WebViewBuilderExtWindows {
   ///
   /// By default, extensions are disabled.
   ///
-  /// Requires WebView2 Runtime version 1.0.2210.55 or higher, does nothing on older versions,,
+  /// Requires WebView2 Runtime version 1.0.2210.55 or higher, does nothing on older versions,
   /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10221055
   fn with_browser_extensions_enabled(self, enabled: bool) -> Self;
 }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -293,6 +293,7 @@ impl InnerWebView {
         let options = CoreWebView2EnvironmentOptions::default();
 
         options.set_additional_browser_arguments(additional_browser_args);
+        options.set_are_browser_extensions_enabled(pl_attrs.browser_extensions_enabled);
 
         // Get user's system language
         let lcid = GetUserDefaultUILanguage();


### PR DESCRIPTION
Addresses one half of https://github.com/tauri-apps/tauri/issues/10909. Adds the `with_browser_extensions_enabled` fn to `WebViewBuilderExtWindows` that will enable browser extension loading/installation on the webview window.



<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
