### PR TITLE
fix(android): skip duplicated Content-Type/Content-Length header to fix tauri-apps/tauri#8857

### DIFF
--- a/.changes/fix-android-headers-skip-content-type-and-content-length.md
+++ b/.changes/fix-android-headers-skip-content-type-and-content-length.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix web resource loading in android binding by skip duplicate Content-Type/Content-Length headers.

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -216,6 +216,8 @@ fn handle_request(
       let response_headers = {
         let headers_map = JMap::from_env(env, &obj)?;
         for (name, value) in headers.iter() {
+          // WebResourceResponse will automatically generate Content-Type and
+          // Content-Length headers so we should skip them to avoid duplication.
           if name == CONTENT_TYPE || name == CONTENT_LENGTH {
             continue;
           }

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use http::{
-  header::{HeaderName, HeaderValue, CONTENT_TYPE},
+  header::{HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE},
   Request,
 };
 use jni::errors::Result as JniResult;
@@ -216,6 +216,9 @@ fn handle_request(
       let response_headers = {
         let headers_map = JMap::from_env(env, &obj)?;
         for (name, value) in headers.iter() {
+          if name == CONTENT_TYPE || name == CONTENT_LENGTH {
+            continue;
+          }
           let key = env.new_string(name)?;
           let value = env.new_string(value.to_str().unwrap_or_default())?;
           headers_map.put(env, &key, &value)?;


### PR DESCRIPTION
As title follows, currently Android binding need to pass `Content-Type` separately when creating `WebResourceReponse` objects, but the `response_headers` doesn't skip `Content-Type` and `Content-Length` headers, which will be append into auto-generated headers with comma, which causes issue tauri-apps/tauri#8857 (e.g. `application/wasm` becomes `application/wasm, application/wasm`)

This PR fixed it by adding single conditional statement to skip these headers inside for loop when putting header into objects.
