### PR TITLE
fix(macos): clear_all_browsing_data segfault with null completionHandler

### DIFF
--- a/.changes/fix-clear-browsing-data-macos.md
+++ b/.changes/fix-clear-browsing-data-macos.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixes `WebView::clear_all_browsing_data` crashing with a segfault on macOS.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1136,7 +1136,7 @@ r#"Object.defineProperty(window, 'ipc', {
       let store: id = msg_send![config, websiteDataStore];
       let all_data_types: id = msg_send![class!(WKWebsiteDataStore), allWebsiteDataTypes];
       let date: id = msg_send![class!(NSDate), dateWithTimeIntervalSince1970: 0.0];
-      let handler = null::<*const c_void>();
+      let handler = block::ConcreteBlock::new(move || {}).copy();
       let _: () = msg_send![store, removeDataOfTypes:all_data_types modifiedSince:date completionHandler:handler];
     }
     Ok(())

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1136,7 +1136,7 @@ r#"Object.defineProperty(window, 'ipc', {
       let store: id = msg_send![config, websiteDataStore];
       let all_data_types: id = msg_send![class!(WKWebsiteDataStore), allWebsiteDataTypes];
       let date: id = msg_send![class!(NSDate), dateWithTimeIntervalSince1970: 0.0];
-      let handler = block::ConcreteBlock::new(move || {}).copy();
+      let handler = block::ConcreteBlock::new(|| {}).copy();
       let _: () = msg_send![store, removeDataOfTypes:all_data_types modifiedSince:date completionHandler:handler];
     }
     Ok(())


### PR DESCRIPTION
the completionHandler cannot be null: https://developer.apple.com/documentation/webkit/wkwebsitedatastore/1532936-removedata

