### PR TITLE
feat: add `WebView::load_html` for loading HTML after intialization

### DIFF
--- a/.changes/load-html.md
+++ b/.changes/load-html.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add `Webview::load_html`.

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -300,6 +300,12 @@ impl<'a> MainPipe<'a> {
               .call_method(webview, "clearAllBrowsingData", "()V", &[])?;
           }
         }
+        WebViewMessage::LoadHtml(html) => {
+          if let Some(webview) = &self.webview {
+            let html = self.env.new_string(html)?;
+            load_html(&mut self.env, webview.as_obj(), &html)?;
+          }
+        }
       }
     }
     Ok(())
@@ -369,6 +375,7 @@ pub(crate) enum WebViewMessage {
   GetUrl(Sender<String>),
   Jni(Box<dyn FnOnce(&mut JNIEnv, &JObject, &JObject) + Send>),
   LoadUrl(String, Option<http::HeaderMap>),
+  LoadHtml(String),
   ClearAllBrowsingData,
 }
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -351,6 +351,11 @@ impl InnerWebView {
     Ok(())
   }
 
+  pub fn load_html(&self, html: &str) -> Result<()> {
+    MainPipe::send(WebViewMessage::LoadHtml(html.to_string()));
+    Ok(())
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     MainPipe::send(WebViewMessage::ClearAllBrowsingData);
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1477,6 +1477,7 @@ impl WebView {
     self.webview.load_url_with_headers(url, headers)
   }
 
+  /// Load html content into the webview
   pub fn load_html(&self, html: &str) -> Result<()> {
     self.webview.load_html(html)
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1477,6 +1477,10 @@ impl WebView {
     self.webview.load_url_with_headers(url, headers)
   }
 
+  pub fn load_html(&self, html: &str) -> Result<()> {
+    self.webview.load_html(html)
+  }
+
   /// Clear all browsing data
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     self.webview.clear_all_browsing_data()

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -673,6 +673,11 @@ impl InnerWebView {
     Ok(())
   }
 
+  pub fn load_html(&self, html: &str) -> Result<()> {
+    self.webview.load_html(html, None);
+    Ok(())
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     if let Some(context) = self.webview.context() {
       if let Some(data_manger) = context.website_data_manager() {

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1205,6 +1205,11 @@ impl InnerWebView {
     load_url_with_headers(&self.webview, &self.env, url, headers)
   }
 
+  pub fn load_html(&self, html: &str) -> Result<()> {
+    let html = HSTRING::from(html);
+    unsafe { self.webview.NavigateToString(&html) }.map_err(Into::into)
+  }
+
   pub fn bounds(&self) -> Result<Rect> {
     let mut bounds = Rect::default();
     let mut rect = RECT::default();

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1130,6 +1130,11 @@ r#"Object.defineProperty(window, 'ipc', {
     self.navigate_to_url(url, Some(headers))
   }
 
+  pub fn load_html(&self, html: &str) -> crate::Result<()> {
+    self.navigate_to_string(html);
+    Ok(())
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     unsafe {
       let config: id = msg_send![self.webview, configuration];


### PR DESCRIPTION
This PR aims to implement `load_html`, a companion of `load_url` to balance out the current implementation. Currently, the webview can be initialized with either a URL or HTML via `.with_url` or `.with_html` in the builder. After creation `.load_url` can be used to load a different URL, but the same can't be said for `.load_html`. 

In #1367 I noted that refreshing a webview initialized with `.load_html` causes the webview to be left with an empty screen. While that's not ideal, if this method existed it'd be easy enough to simply call `load_html` with the same payload as what the webview was initialized with to get it back in the correct state. 

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
