### PR TITLE
fix(macos): do not ignore errors on sending HTTP responses

### DIFF
--- a/.changes/dont-ignore-response-errors-macos.md
+++ b/.changes/dont-ignore-response-errors-macos.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, do not ignore errors on sending HTTP resopnses. Errors now cause panics.

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,8 +55,6 @@ pub enum Error {
   #[cfg(target_os = "android")]
   #[error(transparent)]
   CrossBeamRecvError(#[from] crossbeam_channel::RecvError),
-  #[error("Custom protocol task is invalid.")]
-  CustomProtocolTaskInvalid,
   #[error("Failed to register URL scheme: {0}, could be due to invalid URL scheme or the scheme is already registered.")]
   UrlSchemeRegisterError(String),
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

All errors on sending HTTP responses are ignored on macOS.

https://github.com/tauri-apps/wry/blob/eafaadb9b35f74f07ef83da3d3e738c9ae631f7c/src/wkwebview/mod.rs#L345

This PR changes to check the errors. When some error happens, it now causes a panic.


