### PR TITLE
fix(android): use unescaped Android package id for the proguard rules

### DIFF
--- a/.changes/proguard-unescapted-package.md
+++ b/.changes/proguard-unescapted-package.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Use unescaped Android package identifier for the proguard rules.

--- a/build.rs
+++ b/build.rs
@@ -64,6 +64,7 @@ fn main() {
         let content = fs::read_to_string(file.path())
           .expect("failed to read kotlin file as string")
           .replace("{{package}}", &package)
+          .replace("{{package-unescaped}}", &package.replace('`', ""))
           .replace("{{library}}", &library)
           .replace(
             "{{class-extension}}",

--- a/src/android/kotlin/proguard-wry.pro
+++ b/src/android/kotlin/proguard-wry.pro
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
 
--keep class {{package}}.* {
+-keep class {{package-unescaped}}.* {
   native <methods>;
 }
 
--keep class {{package}}.WryActivity {
+-keep class {{package-unescaped}}.WryActivity {
   public <init>(...);
 
-  void setWebView({{package}}.RustWebView);
+  void setWebView({{package-unescaped}}.RustWebView);
   java.lang.Class getAppClass(...);
   java.lang.String getVersion();
 }
 
--keep class {{package}}.Ipc {
+-keep class {{package-unescaped}}.Ipc {
   public <init>(...);
 
   @android.webkit.JavascriptInterface public <methods>;
 }
 
--keep class {{package}}.RustWebView {
+-keep class {{package-unescaped}}.RustWebView {
   public <init>(...);
 
   void loadUrlMainThread(...);
@@ -30,6 +30,6 @@
   void evalScript(...);
 }
 
--keep class {{package}}.RustWebChromeClient,{{package}}.RustWebViewClient {
+-keep class {{package-unescaped}}.RustWebChromeClient,{{package-unescaped}}.RustWebViewClient {
   public <init>(...);
 }


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/pull/11314
