### PR TITLE
feat: Allow setting extension path for Windows and Linux

### DIFF
--- a/.changes/extension-path.md
+++ b/.changes/extension-path.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+Add `with_extension_path` API to Windows and Linux.

--- a/.changes/extension-path.md
+++ b/.changes/extension-path.md
@@ -2,4 +2,4 @@
 "wry": "patch"
 ---
 
-Add `with_extension_path` API to Windows and Linux.
+Add `WebViewBuilder::with_extension_path` API to Windows and Linux.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,15 @@ use self::webview2::*;
 #[cfg(target_os = "windows")]
 use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 
+#[cfg(any(
+  target_os = "linux",
+  target_os = "dragonfly",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+))]
+use webkit2gtk::WebContextExt;
+
 use std::{borrow::Cow, collections::HashMap, path::PathBuf, rc::Rc};
 
 use http::{Request, Response};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1402,6 +1402,18 @@ impl WebViewBuilderExtAndroid for WebViewBuilder<'_> {
   target_os = "netbsd",
   target_os = "openbsd",
 ))]
+#[derive(Default)]
+pub(crate) struct PlatformSpecificWebViewAttributes {
+  extension_path: Option<PathBuf>,
+}
+
+#[cfg(any(
+  target_os = "linux",
+  target_os = "dragonfly",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+))]
 pub trait WebViewBuilderExtUnix<'a> {
   /// Consume the builder and create the webview inside a GTK container widget, such as GTK window.
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,15 +244,6 @@ use self::webview2::*;
 #[cfg(target_os = "windows")]
 use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller;
 
-#[cfg(any(
-  target_os = "linux",
-  target_os = "dragonfly",
-  target_os = "freebsd",
-  target_os = "netbsd",
-  target_os = "openbsd",
-))]
-use webkit2gtk::WebContextExt;
-
 use std::{borrow::Cow, collections::HashMap, path::PathBuf, rc::Rc};
 
 use http::{Request, Response};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1261,7 +1261,7 @@ pub trait WebViewBuilderExtWindows {
   fn with_browser_extensions_enabled(self, enabled: bool) -> Self;
 
   /// Swt the path from which to load extensions from. Extensions stored in this path should be unpacked.
-  /// 
+  ///
   /// Does nothing if browser extensions are disabled. See [`with_browser_extensions_enabled`](Self::with_browser_extensions_enabled)
   fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1440,8 +1440,10 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
   }
 
   fn with_extension_path(mut self, path: impl Into<PathBuf>) -> Self {
-    self.inner.platform_specific.extension_path = Some(path.into());
-    self
+    self.and_then(|mut b| {
+      b.platform_specific.extension_path = Some(path.into());
+      Ok(b)
+    })
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1915,16 +1915,6 @@ pub enum PageLoadEvent {
   Finished,
 }
 
-#[cfg(any(
-  target_os = "linux",
-  target_os = "dragonfly",
-  target_os = "freebsd",
-  target_os = "netbsd",
-  target_os = "openbsd",
-))]
-#[derive(Default)]
-pub(crate) struct PlatformSpecificWebViewAttributes;
-
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1260,9 +1260,9 @@ pub trait WebViewBuilderExtWindows {
   /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10221055
   fn with_browser_extensions_enabled(self, enabled: bool) -> Self;
 
-  /// Determines the path from which to load extensions from. Extensions stored in this path should be unpacked.
+  /// Swt the path from which to load extensions from. Extensions stored in this path should be unpacked.
   /// 
-  /// Does nothing if browser extensions are disabled.
+  /// Does nothing if browser extensions are disabled. See [`with_browser_extensions_enabled`](Self::with_browser_extensions_enabled)
   fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
 }
 
@@ -1429,7 +1429,7 @@ pub trait WebViewBuilderExtUnix<'a> {
   where
     W: gtk::prelude::IsA<gtk::Container>;
 
-  /// Determines the path from which to load extensions from.
+  /// Set the path from which to load extensions from.
   fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1262,7 +1262,7 @@ pub trait WebViewBuilderExtWindows {
 
   /// Determines the path from which to load extensions from. Extensions stored in this path should be unpacked.
   /// 
-  /// Does nothing if extensions are disabled, or the platform does not support them.
+  /// Does nothing if browser extensions are disabled.
   fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1440,7 +1440,7 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
   }
 
   fn with_extension_path(mut self, path: impl Into<PathBuf>) -> Self {
-    self.platform_specific.extension_path = Some(path.into());
+    self.inner.platform_specific.extension_path = Some(path.into());
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1260,7 +1260,7 @@ pub trait WebViewBuilderExtWindows {
   /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10221055
   fn with_browser_extensions_enabled(self, enabled: bool) -> Self;
 
-  /// Swt the path from which to load extensions from. Extensions stored in this path should be unpacked.
+  /// Set the path from which to load extensions from. Extensions stored in this path should be unpacked.
   ///
   /// Does nothing if browser extensions are disabled. See [`with_browser_extensions_enabled`](Self::with_browser_extensions_enabled)
   fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1451,7 +1451,7 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
       .map(|webview| WebView { webview })
   }
 
-  fn with_extension_path(mut self, path: impl Into<PathBuf>) -> Self {
+  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.extension_path = Some(path.into());
       Ok(b)

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -276,7 +276,7 @@ impl InnerWebView {
     // Extension loading
     if let Some(extension_path) = pl_attrs.extension_path {
       if let Some(extension_path) = extension_path.to_str() {
-        web_context.set_web_extensions_directory(extension_path);
+        web_context.os.context.set_web_extensions_directory(extension_path);
       }
     }
 

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -244,9 +244,7 @@ impl InnerWebView {
 
     // Extension loading
     if let Some(extension_path) = pl_attrs.extension_path {
-      if let Some(extension_path) = extension_path.to_str() {
-        web_context.os.set_web_extensions_directory(extension_path);
-      }
+      web_context.os.set_web_extensions_directory(extension_path);
     }
 
     let webview = Self::create_webview(web_context, &attributes);

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -242,6 +242,13 @@ impl InnerWebView {
       }
     }
 
+    // Extension loading
+    if let Some(extension_path) = pl_attrs.extension_path {
+      if let Some(extension_path) = extension_path.to_str() {
+        web_context.os.set_web_extensions_directory(extension_path);
+      }
+    }
+
     let webview = Self::create_webview(web_context, &attributes);
 
     // Transparent
@@ -271,13 +278,6 @@ impl InnerWebView {
     // Drag drop handler
     if let Some(drag_drop_handler) = attributes.drag_drop_handler.take() {
       drag_drop::connect_drag_event(&webview, drag_drop_handler);
-    }
-
-    // Extension loading
-    if let Some(extension_path) = pl_attrs.extension_path {
-      if let Some(extension_path) = extension_path.to_str() {
-        web_context.os.set_web_extensions_directory(extension_path);
-      }
     }
 
     web_context.register_automation(webview.clone());

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -244,7 +244,7 @@ impl InnerWebView {
 
     // Extension loading
     if let Some(extension_path) = pl_attrs.extension_path {
-      web_context.os.set_web_extensions_directory(extension_path);
+      web_context.os.set_web_extensions_directory(&extension_path);
     }
 
     let webview = Self::create_webview(web_context, &attributes);

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -276,7 +276,7 @@ impl InnerWebView {
     // Extension loading
     if let Some(extension_path) = pl_attrs.extension_path {
       if let Some(extension_path) = extension_path.to_str() {
-        web_context.os.context.set_web_extensions_directory(extension_path);
+        web_context.os.set_web_extensions_directory(extension_path);
       }
     }
 

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -209,7 +209,7 @@ impl InnerWebView {
   pub fn new_gtk<W>(
     container: &W,
     mut attributes: WebViewAttributes,
-    _pl_attrs: super::PlatformSpecificWebViewAttributes,
+    pl_attrs: super::PlatformSpecificWebViewAttributes,
   ) -> Result<Self>
   where
     W: IsA<gtk::Container>,
@@ -271,6 +271,13 @@ impl InnerWebView {
     // Drag drop handler
     if let Some(drag_drop_handler) = attributes.drag_drop_handler.take() {
       drag_drop::connect_drag_event(&webview, drag_drop_handler);
+    }
+
+    // Extension loading
+    if let Some(extension_path) = pl_attrs.extension_path {
+      if let Some(extension_path) = extension_path.to_str() {
+        web_context.set_web_extensions_directory(extension_path);
+      }
     }
 
     web_context.register_automation(webview.clone());

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -93,8 +93,8 @@ impl WebContextImpl {
     self.context.set_automation_allowed(flag);
   }
 
-  pub fn set_web_extensions_directory(&mut self, path: &str) {
-    self.context.set_web_extensions_directory(path);
+  pub fn set_web_extensions_directory(&mut self, path: &Path) {
+    self.context.set_web_extensions_directory(path.to_string_lossy());
   }
 }
 

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -96,7 +96,7 @@ impl WebContextImpl {
   pub fn set_web_extensions_directory(&mut self, path: &Path) {
     self
       .context
-      .set_web_extensions_directory(path.to_string_lossy());
+      .set_web_extensions_directory(&path.to_string_lossy());
   }
 }
 

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -94,7 +94,9 @@ impl WebContextImpl {
   }
 
   pub fn set_web_extensions_directory(&mut self, path: &Path) {
-    self.context.set_web_extensions_directory(path.to_string_lossy());
+    self
+      .context
+      .set_web_extensions_directory(path.to_string_lossy());
   }
 }
 

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -92,6 +92,10 @@ impl WebContextImpl {
     self.automation = flag;
     self.context.set_automation_allowed(flag);
   }
+
+  pub fn set_web_extensions_directory(&mut self, path: &str) {
+    self.context.set_web_extensions_directory(path);
+  }
 }
 
 /// [`WebContext`](super::WebContext) items that only matter on unix.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1195,7 +1195,7 @@ impl InnerWebView {
     // Iterate over all folders in the extension path
     for entry in fs::read_dir(extension_path)? {
       let path = entry?.path();
-      let path_hs = HSTRING::from(path);
+      let path_hs = HSTRING::from(path.as_path());
 
       profile.AddBrowserExtension(&path_hs, None)?;
     }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -6,7 +6,7 @@ mod drag_drop;
 mod util;
 
 use std::{
-  borrow::Cow, cell::RefCell, collections::HashSet, fmt::Write, path::PathBuf, rc::Rc, sync::mpsc,
+  borrow::Cow, cell::RefCell, collections::HashSet, fmt::Write, fs, path::PathBuf, rc::Rc, sync::mpsc
 };
 
 use dpi::{PhysicalPosition, PhysicalSize};
@@ -496,6 +496,15 @@ impl InnerWebView {
 
       if attributes.focused {
         controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC)?;
+      }
+    }
+
+    // Extension loading
+    unsafe {
+      if pl_attrs.browser_extensions_enabled {
+        if let Some(extension_path) = pl_attrs.extension_path {
+          Self::load_extensions(&webview, &extension_path)?;
+        }
       }
     }
 
@@ -1173,6 +1182,31 @@ impl InnerWebView {
     let mut pwstr = PWSTR::null();
     unsafe { webview.Source(&mut pwstr)? };
     Ok(take_pwstr(pwstr))
+  }
+
+  
+  #[inline]
+  unsafe fn load_extensions(webview: &ICoreWebView2, extension_path: &PathBuf) -> Result<()> {
+    let profile = webview
+      .cast::<ICoreWebView2_13>()?
+      .Profile()?
+      .cast::<ICoreWebView2Profile7>()?;
+
+    if let Some(extension_path) = extension_path.to_str() {
+      // Iterate over all folders in the extension path
+      for entry in fs::read_dir(extension_path)? {
+        let path = entry?.path();
+        let path_str = path.to_str();
+
+        if let Some(path_str) = path_str {
+          let path_hs = HSTRING::from(path_str);
+
+          profile.AddBrowserExtension(&path_hs, None)?;
+        }
+      }
+    }
+
+    Ok(())
   }
 }
 

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -6,7 +6,8 @@ mod drag_drop;
 mod util;
 
 use std::{
-  borrow::Cow, cell::RefCell, collections::HashSet, fmt::Write, fs, path::PathBuf, rc::Rc, sync::mpsc
+  borrow::Cow, cell::RefCell, collections::HashSet, fmt::Write, fs, path::PathBuf, rc::Rc,
+  sync::mpsc,
 };
 
 use dpi::{PhysicalPosition, PhysicalSize};
@@ -502,7 +503,9 @@ impl InnerWebView {
     // Extension loading
     if pl_attrs.browser_extensions_enabled {
       if let Some(extension_path) = pl_attrs.extension_path {
-        unsafe { Self::load_extensions(&webview, &extension_path)?; }
+        unsafe {
+          Self::load_extensions(&webview, &extension_path)?;
+        }
       }
     }
 
@@ -1182,7 +1185,6 @@ impl InnerWebView {
     Ok(take_pwstr(pwstr))
   }
 
-  
   #[inline]
   unsafe fn load_extensions(webview: &ICoreWebView2, extension_path: &PathBuf) -> Result<()> {
     let profile = webview

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -500,11 +500,9 @@ impl InnerWebView {
     }
 
     // Extension loading
-    unsafe {
-      if pl_attrs.browser_extensions_enabled {
-        if let Some(extension_path) = pl_attrs.extension_path {
-          Self::load_extensions(&webview, &extension_path)?;
-        }
+    if pl_attrs.browser_extensions_enabled {
+      if let Some(extension_path) = pl_attrs.extension_path {
+        unsafe { Self::load_extensions(&webview, &extension_path)?; }
       }
     }
 
@@ -1192,18 +1190,12 @@ impl InnerWebView {
       .Profile()?
       .cast::<ICoreWebView2Profile7>()?;
 
-    if let Some(extension_path) = extension_path.to_str() {
-      // Iterate over all folders in the extension path
-      for entry in fs::read_dir(extension_path)? {
-        let path = entry?.path();
-        let path_str = path.to_str();
+    // Iterate over all folders in the extension path
+    for entry in fs::read_dir(extension_path)? {
+      let path = entry?.path();
+      let path_hs = HSTRING::from(path);
 
-        if let Some(path_str) = path_str {
-          let path_hs = HSTRING::from(path_str);
-
-          profile.AddBrowserExtension(&path_hs, None)?;
-        }
-      }
+      profile.AddBrowserExtension(&path_hs, None)?;
     }
 
     Ok(())


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
Introduces `with_extension_path`, which is now used by Windows and Linux to load extensions from.

Linux doesn't include `browser_extensions_enabled` because there is no setting to turn them on or off in WebkitGTK, only to set their directory. I assume if no directory is set, then no extensions are loaded from anywhere, so the option would be redundant.