### PR TITLE
fix(windows): set WebView2 `AllowExternalDrop` to false

### DIFF
--- a/.changes/windows-drag-files.md
+++ b/.changes/windows-drag-files.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Windows, disable Webview2's file drop when using `WebViewBuilder::with_drag_drop_handler` which fix drag events for files from "Recent files" view.

--- a/src/webview2/drag_drop.rs
+++ b/src/webview2/drag_drop.rs
@@ -167,20 +167,29 @@ impl IDropTarget_Impl for DragDropTarget_Impl {
 
     let mut paths = Vec::new();
     let hdrop = unsafe { DragDropTarget::iterate_filenames(pDataObj, |path| paths.push(path)) };
+
+    let enter_is_valid = hdrop.is_some();
+
+    if !enter_is_valid {
+      return Ok(());
+    };
+
+    unsafe {
+      *self.enter_is_valid.get() = enter_is_valid;
+    }
+
     (self.listener)(DragDropEvent::Enter {
       paths,
       position: (pt.x as _, pt.y as _),
     });
 
-    unsafe {
-      let enter_is_valid = hdrop.is_some();
-      *self.enter_is_valid.get() = enter_is_valid;
+    let cursor_effect = if enter_is_valid {
+      DROPEFFECT_COPY
+    } else {
+      DROPEFFECT_NONE
+    };
 
-      let cursor_effect = if enter_is_valid {
-        DROPEFFECT_COPY
-      } else {
-        DROPEFFECT_NONE
-      };
+    unsafe {
       *pdwEffect = cursor_effect;
       *self.cursor_effect.get() = cursor_effect;
     }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -654,27 +654,6 @@ impl InnerWebView {
       )?;
     }
 
-    webview.add_NewWindowRequested(
-      &NewWindowRequestedEventHandler::create(Box::new(move |_, args| {
-        let Some(args) = args else {
-          return Ok(());
-        };
-
-        let uri = {
-          let mut uri = PWSTR::null();
-          args.Uri(&mut uri)?;
-          take_pwstr(uri)
-        };
-
-        dbg!(uri);
-
-        args.SetHandled(true)?;
-
-        Ok(())
-      })),
-      token,
-    )?;
-
     // New window handler
     if let Some(new_window_req_handler) = attributes.new_window_req_handler.take() {
       webview.add_NewWindowRequested(

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -134,7 +134,15 @@ impl InnerWebView {
       is_child,
     )?;
 
-    let drag_drop_controller = drop_handler.map(|handler| DragDropController::new(hwnd, handler));
+    let drag_drop_controller = drop_handler.map(|handler| {
+      // Disable file drops, so our handler can capture it
+      unsafe {
+        let _ = controller
+          .cast::<ICoreWebView2Controller4>()
+          .and_then(|c| c.SetAllowExternalDrop(false));
+      }
+      DragDropController::new(hwnd, handler)
+    });
 
     let w = Self {
       id,
@@ -645,6 +653,27 @@ impl InnerWebView {
         token,
       )?;
     }
+
+    webview.add_NewWindowRequested(
+      &NewWindowRequestedEventHandler::create(Box::new(move |_, args| {
+        let Some(args) = args else {
+          return Ok(());
+        };
+
+        let uri = {
+          let mut uri = PWSTR::null();
+          args.Uri(&mut uri)?;
+          take_pwstr(uri)
+        };
+
+        dbg!(uri);
+
+        args.SetHandled(true)?;
+
+        Ok(())
+      })),
+      token,
+    )?;
 
     // New window handler
     if let Some(new_window_req_handler) = attributes.new_window_req_handler.take() {


### PR DESCRIPTION
closes tauri-apps/tauri#11274

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
