### PR TITLE
fix: call `ctx.drop_finish` in webkit2gtk drop handler

### DIFF
--- a/.changes/gnome-dragged-icon-stuck.md
+++ b/.changes/gnome-dragged-icon-stuck.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+Fix icons of dragged items getting stuck when using `WebViewBuilder::with_drag_drop_handler` on some distros like Gnome.

--- a/src/webkitgtk/drag_drop.rs
+++ b/src/webkitgtk/drag_drop.rs
@@ -92,9 +92,10 @@ pub(crate) fn connect_drag_event(webview: &WebView, handler: Box<dyn Fn(DragDrop
 
   {
     let controller = controller.clone();
-    webview.connect_drag_drop(move |_, _, x, y, _| {
+    webview.connect_drag_drop(move |_, ctx, x, y, time| {
       if controller.has_entered() {
         if let Some(paths) = controller.take_paths() {
+          ctx.drop_finish(true, time);
           controller.leave();
           return controller.call(DragDropEvent::Drop {
             paths,


### PR DESCRIPTION
closes tauri-apps/tauri#11343