### PR TITLE
fix(android): drop MainPipe on activity destroy

### DIFF
--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -32,6 +32,8 @@ macro_rules! android_binding {
   ($domain:ident, $package:ident, $wry:path) => {{
     use $wry::{android_setup as _, prelude::*};
 
+    android_fn!($domain, $package, WryActivity, onActivityDestroy, [JObject]);
+
     android_fn!(
       $domain,
       $package,
@@ -256,6 +258,11 @@ fn handle_request(
   }
 
   Ok(*JObject::null())
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn onActivityDestroy(_: JNIEnv, _: JClass, _: JObject) {
+  super::MainPipe::send(super::WebViewMessage::OnDestroy);
 }
 
 #[allow(non_snake_case)]

--- a/src/android/kotlin/WryActivity.kt
+++ b/src/android/kotlin/WryActivity.kt
@@ -93,6 +93,7 @@ abstract class WryActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         destroy()
+        onActivityDestroy()
     }
 
     override fun onLowMemory() {
@@ -125,6 +126,7 @@ abstract class WryActivity : AppCompatActivity() {
     private external fun stop()
     private external fun save()
     private external fun destroy()
+    private external fun onActivityDestroy()
     private external fun memory()
     private external fun focus(focus: Boolean)
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
   NulError(#[from] std::ffi::NulError),
   #[error(transparent)]
   ReceiverError(#[from] std::sync::mpsc::RecvError),
+  #[cfg(target_os = "android")]
+  #[error(transparent)]
+  ReceiverTimeoutError(#[from] crossbeam_channel::RecvTimeoutError),
   #[error(transparent)]
   SenderError(#[from] std::sync::mpsc::SendError<String>),
   #[error("Failed to send the message")]


### PR DESCRIPTION
fixes a memory leak when the activity is destroyed but the app is opened in the foreground

ref https://github.com/tauri-apps/tauri/issues/11609
