### PR TITLE
fix: Prevent `Invalid Pointer` when loading extensions on Windows, rename `with_extension_path` -> `with_extensions_path`

### DIFF
--- a/.changes/extension_fix.md
+++ b/.changes/extension_fix.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+Fix extension loading on Windows.

--- a/.changes/extension_fix.md
+++ b/.changes/extension_fix.md
@@ -2,4 +2,4 @@
 "wry": "patch"
 ---
 
-Fix extension loading on Windows and rename `with_extension_path` to `with_extensions_path`.
+Fix extension loading on Windows.

--- a/.changes/extension_fix.md
+++ b/.changes/extension_fix.md
@@ -2,4 +2,4 @@
 "wry": "patch"
 ---
 
-Fix extension loading on Windows.
+Fix extension loading on Windows and rename `with_extension_path` to `with_extensions_path`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1302,7 +1302,7 @@ pub trait WebViewBuilderExtWindows {
   /// Set the path from which to load extensions from. Extensions stored in this path should be unpacked.
   ///
   /// Does nothing if browser extensions are disabled. See [`with_browser_extensions_enabled`](Self::with_browser_extensions_enabled)
-  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
+  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self;
 }
 
 #[cfg(windows)]
@@ -1349,7 +1349,7 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
     })
   }
 
-  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self {
+  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.extension_path = Some(path.into());
       Ok(b)
@@ -1469,7 +1469,7 @@ pub trait WebViewBuilderExtUnix<'a> {
     W: gtk::prelude::IsA<gtk::Container>;
 
   /// Set the path from which to load extensions from.
-  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
+  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self;
 }
 
 #[cfg(any(
@@ -1490,7 +1490,7 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
       .map(|webview| WebView { webview })
   }
 
-  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self {
+  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.extension_path = Some(path.into());
       Ok(b)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1302,7 +1302,7 @@ pub trait WebViewBuilderExtWindows {
   /// Set the path from which to load extensions from. Extensions stored in this path should be unpacked.
   ///
   /// Does nothing if browser extensions are disabled. See [`with_browser_extensions_enabled`](Self::with_browser_extensions_enabled)
-  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self;
+  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
 }
 
 #[cfg(windows)]
@@ -1349,7 +1349,7 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
     })
   }
 
-  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self {
+  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.extension_path = Some(path.into());
       Ok(b)
@@ -1469,7 +1469,7 @@ pub trait WebViewBuilderExtUnix<'a> {
     W: gtk::prelude::IsA<gtk::Container>;
 
   /// Set the path from which to load extensions from.
-  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self;
+  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self;
 }
 
 #[cfg(any(
@@ -1490,7 +1490,7 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
       .map(|webview| WebView { webview })
   }
 
-  fn with_extensions_path(self, path: impl Into<PathBuf>) -> Self {
+  fn with_extension_path(self, path: impl Into<PathBuf>) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.extension_path = Some(path.into());
       Ok(b)

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1252,8 +1252,9 @@ impl InnerWebView {
     for entry in fs::read_dir(extension_path)? {
       let path = entry?.path();
       let path_hs = HSTRING::from(path.as_path());
+      let handler = ProfileAddBrowserExtensionCompletedHandler::create(Box::new(|_, _| Ok(())));
 
-      profile.AddBrowserExtension(&path_hs, None)?;
+      profile.AddBrowserExtension(&path_hs, &handler)?;
     }
 
     Ok(())


### PR DESCRIPTION
Fixes loading extensions on Windows by providing a handler function to `AddBrowserExtension`, rather than `None`, which causes a `Invalid Pointer` error.

Also renames the function `with_extension_path` -> `with_extensions_path`, as the name might be misleading/confusing.