### PR TITLE
fix: log postmessage errors

### DIFF
--- a/.changes/postmessage-assert-panic.md
+++ b/.changes/postmessage-assert-panic.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Windows, Wry will now log PostMessage errors instead of panicking.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1040,15 +1040,19 @@ impl InnerWebView {
 
     let raw = Box::into_raw(boxed2);
 
-    let res = PostMessageW(hwnd, *EXEC_MSG_ID, WPARAM(raw as _), LPARAM(0));
+    let _res = PostMessageW(hwnd, *EXEC_MSG_ID, WPARAM(raw as _), LPARAM(0));
 
     #[cfg(any(debug_assertions, feature = "tracing"))]
-    if res.is_err() {
-      let error_code = windows::Win32::Foundation::GetLastError();
+    if let Err(err) = _res {
+      let msg = format!(
+        "PostMessage failed ; is the messages queue full? Error code {} - {}",
+        err.code(),
+        err.message()
+      );
       #[cfg(feature = "tracing")]
-      tracing::error!("PostMessage failed ; is the messages queue full? Error code {error_code:?}");
+      tracing::error!("{}", &msg);
       #[cfg(debug_assertions)]
-      eprintln!("PostMessage failed ; is the messages queue full? {error_code:?}");
+      eprintln!("{}", msg);
     }
   }
 


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/issues/10546

i still don't know what's happening tbh, i don't think we can realistically fill the queue. For the appWindow.close() panic i think this is just a timing issue. Anyway, panicking like this is toxic af and now we also print the error code which _hopefully_ tells us a bit about the actual issue.