### PR TITLE
feat: disable background throttling

### DIFF
--- a/.changes/disable-background-throttling.md
+++ b/.changes/disable-background-throttling.md
@@ -1,5 +1,5 @@
 ---
-'wry': 'minor:enhance'
+'wry': 'patch:enhance'
 ---
 
 Add an option to disable background throttling (currently for WebKit only).

--- a/.changes/disable-background-throttling.md
+++ b/.changes/disable-background-throttling.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add an option to disable background throttling (currently for WebKit only).

--- a/.changes/disable-background-throttling.md
+++ b/.changes/disable-background-throttling.md
@@ -2,4 +2,4 @@
 'wry': 'minor:enhance'
 ---
 
-Add an option to disable background throttling (currently for WebKit only).
+Add an option to change the default background throttling policy (currently for WebKit only).

--- a/.changes/disable-background-throttling.md
+++ b/.changes/disable-background-throttling.md
@@ -1,5 +1,5 @@
 ---
-"wry": minor
+'wry': 'minor:enhance'
 ---
 
 Add an option to disable background throttling (currently for WebKit only).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,9 +1210,9 @@ impl<'a> WebViewBuilder<'a> {
   /// - **macOS**: Supported since version 14.0+.
   ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
-  pub fn with_background_throttling(self, policy: Option<BackgroundThrottlingPolicy>) -> Self {
+  pub fn with_background_throttling(self, policy: BackgroundThrottlingPolicy) -> Self {
     self.and_then(|mut b| {
-      b.attrs.background_throttling = policy;
+      b.attrs.background_throttling = Some(policy);
       Ok(b)
     })
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,6 +574,18 @@ pub struct WebViewAttributes<'a> {
   /// This is only effective if the webview was created by [`WebView::new_as_child`] or [`WebViewBuilder::new_as_child`]
   /// or on Linux, if was created by [`WebViewExtUnix::new_gtk`] or [`WebViewBuilderExtUnix::new_gtk`] with [`gtk::Fixed`].
   pub bounds: Option<Rect>,
+
+  /// Whether background throttling should be disabled.
+  ///
+  /// By default, browsers throttle timers and even unload the whole tab (view) to free resources after roughly 5 minutes when
+  /// a view became minimized or hidden. This will permanently suspend all tasks until the documents visibility state
+  /// changes back from hidden to visible by bringing the view back to the foreground.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / Windows / Android**: Unsupported yet. But workarounds like a pending WebLock transaction might suffice.
+  /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
+  pub disable_background_throttling: bool,
 }
 
 impl<'a> Default for WebViewAttributes<'a> {
@@ -614,6 +626,7 @@ impl<'a> Default for WebViewAttributes<'a> {
         position: dpi::LogicalPosition::new(0, 0).into(),
         size: dpi::LogicalSize::new(200, 200).into(),
       }),
+      disable_background_throttling: false,
     }
   }
 }
@@ -1177,6 +1190,23 @@ impl<'a> WebViewBuilder<'a> {
   pub fn with_bounds(self, bounds: Rect) -> Self {
     self.and_then(|mut b| {
       b.attrs.bounds = Some(bounds);
+      Ok(b)
+    })
+  }
+
+  /// Set whether background throttling should be disabled.
+  ///
+  /// By default, browsers throttle timers and even unload the whole tab (view) to free resources after roughly 5 minutes when
+  /// a view became minimized or hidden. This will permanently suspend all tasks until the documents visibility state
+  /// changes back from hidden to visible by bringing the view back to the foreground.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / Windows / Android**: Unsupported yet. But workarounds like a pending WebLock transaction might suffice.
+  /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
+  pub fn with_disable_background_throttling(self, disable: bool) -> Self {
+    self.and_then(|mut b| {
+      b.attrs.disable_background_throttling = disable;
       Ok(b)
     })
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,7 +583,9 @@ pub struct WebViewAttributes<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Linux / Windows / Android**: Unsupported yet. But workarounds like a pending WebLock transaction might suffice.
+  /// - **Linux / Windows / Android**: Unsupported. Workarounds like a pending WebLock transaction might suffice.
+  /// - **iOS / macOS**: Supported since version 17.0+.
+  ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
   pub disable_background_throttling: bool,
 }
@@ -1202,7 +1204,9 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Linux / Windows / Android**: Unsupported yet. But workarounds like a pending WebLock transaction might suffice.
+  /// - **Linux / Windows / Android**: Unsupported. Workarounds like a pending WebLock transaction might suffice.
+  /// - **iOS / macOS**: Supported since version 17.0+.
+  ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
   pub fn with_disable_background_throttling(self, disable: bool) -> Self {
     self.and_then(|mut b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,7 +588,7 @@ pub struct WebViewAttributes<'a> {
   /// - **macOS**: Supported since version 14.0+.
   ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
-  pub disable_background_throttling: bool,
+  pub background_throttling: Option<BackgroundThrottlingPolicy>,
 }
 
 impl<'a> Default for WebViewAttributes<'a> {
@@ -629,7 +629,7 @@ impl<'a> Default for WebViewAttributes<'a> {
         position: dpi::LogicalPosition::new(0, 0).into(),
         size: dpi::LogicalSize::new(200, 200).into(),
       }),
-      disable_background_throttling: false,
+      background_throttling: None,
     }
   }
 }
@@ -1210,9 +1210,9 @@ impl<'a> WebViewBuilder<'a> {
   /// - **macOS**: Supported since version 14.0+.
   ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
-  pub fn with_disable_background_throttling(self, disable: bool) -> Self {
+  pub fn with_background_throttling(self, policy: Option<BackgroundThrottlingPolicy>) -> Self {
     self.and_then(|mut b| {
-      b.attrs.disable_background_throttling = disable;
+      b.attrs.background_throttling = policy;
       Ok(b)
     })
   }
@@ -2031,6 +2031,17 @@ pub enum PageLoadEvent {
   Started,
   /// Indicates that the page content has finished loading
   Finished,
+}
+
+/// Background throttling policy
+#[derive(Debug, Clone)]
+pub enum BackgroundThrottlingPolicy {
+  /// A policy where background throttling is disabled
+  Disabled,
+  /// A policy where a web view that’s not in a window fully suspends tasks.
+  Suspend,
+  /// A policy where a web view that’s not in a window limits processing, but does not fully suspend tasks.
+  Throttle,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,8 @@ pub struct WebViewAttributes<'a> {
   /// ## Platform-specific
   ///
   /// - **Linux / Windows / Android**: Unsupported. Workarounds like a pending WebLock transaction might suffice.
-  /// - **iOS / macOS**: Supported since version 17.0+.
+  /// - **iOS**: Supported since version 17.0+.
+  /// - **macOS**: Supported since version 14.0+.
   ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
   pub disable_background_throttling: bool,
@@ -1205,7 +1206,8 @@ impl<'a> WebViewBuilder<'a> {
   /// ## Platform-specific
   ///
   /// - **Linux / Windows / Android**: Unsupported. Workarounds like a pending WebLock transaction might suffice.
-  /// - **iOS / macOS**: Supported since version 17.0+.
+  /// - **iOS**: Supported since version 17.0+.
+  /// - **macOS**: Supported since version 14.0+.
   ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
   pub fn with_disable_background_throttling(self, disable: bool) -> Self {

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -63,8 +63,8 @@ use crate::wkwebview::ios::WKWebView::WKWebView;
 use objc2_web_kit::WKWebView;
 
 use objc2_web_kit::{
-  WKAudiovisualMediaTypes, WKURLSchemeHandler, WKUserContentController, WKUserScript,
-  WKUserScriptInjectionTime, WKWebViewConfiguration, WKWebsiteDataStore,
+  WKAudiovisualMediaTypes, WKInactiveSchedulingPolicy, WKURLSchemeHandler, WKUserContentController,
+  WKUserScript, WKUserScriptInjectionTime, WKWebViewConfiguration, WKWebsiteDataStore,
 };
 use once_cell::sync::Lazy;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -346,6 +346,18 @@ impl InnerWebView {
           objc2::msg_send_id![super(webview), initWithFrame:frame configuration:&**config];
         webview
       };
+
+      // disable background throttling if attributes.disable_background_throttling is true
+      // which works for iOS 17.0+,iPadOS 17.0+,Mac Catalyst 17.0+, macOS 14.0+, visionOS 1.0+
+      if attributes.disable_background_throttling {
+        // Set inactive scheduling policy to None enum value (2)
+        _preference.setValue_forKey(
+          Some(&NSNumber::numberWithInt(
+            WKInactiveSchedulingPolicy::None.0.try_into().unwrap(),
+          )),
+          ns_string!("inactiveSchedulingPolicy"),
+        );
+      }
 
       #[cfg(target_os = "macos")]
       {

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -88,7 +88,9 @@ use crate::{
   },
 };
 
-use crate::{Error, Rect, RequestAsyncResponder, Result, WebViewAttributes, RGBA};
+use crate::{
+  BackgroundThrottlingPolicy, Error, Rect, RequestAsyncResponder, Result, WebViewAttributes, RGBA,
+};
 
 use http::Request;
 
@@ -347,21 +349,29 @@ impl InnerWebView {
         webview
       };
 
-      // disable background throttling if attributes.disable_background_throttling is true
+      // change background throttling policy if attributes.background_throttling is set
       // which works for iOS 17.0+,iPadOS 17.0+,Mac Catalyst 17.0+, macOS 14.0+, visionOS 1.0+
       #[cfg(any(target_os = "ios", target_os = "macos"))]
       {
         let is_supported_os = (cfg!(target_os = "ios") && os_major_version >= 17)
           || (cfg!(target_os = "macos") && os_major_version >= 14);
 
-        if is_supported_os && attributes.disable_background_throttling {
-          // Set inactive scheduling policy to None enum value (2)
-          _preference.setValue_forKey(
-            Some(&NSNumber::numberWithInt(
-              WKInactiveSchedulingPolicy::None.0.try_into().unwrap(),
-            )),
-            ns_string!("inactiveSchedulingPolicy"),
-          );
+        if is_supported_os {
+          if let Some(policy) = attributes.background_throttling {
+            let policy_value = match policy {
+              BackgroundThrottlingPolicy::Disabled => WKInactiveSchedulingPolicy::None.0,
+              BackgroundThrottlingPolicy::Suspend => WKInactiveSchedulingPolicy::Suspend.0,
+              BackgroundThrottlingPolicy::Throttle => WKInactiveSchedulingPolicy::Throttle.0,
+            };
+
+            // Convert and set the value
+            if let Ok(policy_number) = policy_value.try_into() {
+              _preference.setValue_forKey(
+                Some(&NSNumber::numberWithInt(policy_number)),
+                ns_string!("inactiveSchedulingPolicy"),
+              );
+            }
+          }
         }
       }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -349,14 +349,20 @@ impl InnerWebView {
 
       // disable background throttling if attributes.disable_background_throttling is true
       // which works for iOS 17.0+,iPadOS 17.0+,Mac Catalyst 17.0+, macOS 14.0+, visionOS 1.0+
-      if attributes.disable_background_throttling {
-        // Set inactive scheduling policy to None enum value (2)
-        _preference.setValue_forKey(
-          Some(&NSNumber::numberWithInt(
-            WKInactiveSchedulingPolicy::None.0.try_into().unwrap(),
-          )),
-          ns_string!("inactiveSchedulingPolicy"),
-        );
+      #[cfg(any(target_os = "ios", target_os = "macos"))]
+      {
+        let is_supported_os = (cfg!(target_os = "ios") && os_major_version >= 17)
+          || (cfg!(target_os = "macos") && os_major_version >= 14);
+
+        if is_supported_os && attributes.disable_background_throttling {
+          // Set inactive scheduling policy to None enum value (2)
+          _preference.setValue_forKey(
+            Some(&NSNumber::numberWithInt(
+              WKInactiveSchedulingPolicy::None.0.try_into().unwrap(),
+            )),
+            ns_string!("inactiveSchedulingPolicy"),
+          );
+        }
       }
 
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
This PR relates to https://github.com/tauri-apps/tauri/issues/5250

It requires a change of tauri for which I've opened another PR: https://github.com/tauri-apps/tauri/pull/12181

I've added an option `disableBackgroundThrottling` to allow developers to choose if their view should automatically be throttled / suspended by the browser after a certain time of being hidden or minimised. In the worst case, this default behaviour of browsers can lead to broken applications running in the background. 

For instance if a websocket connection is the only reason not to suspend a "tab" and the machine goes into sleep mode and wakes up again, the connection is often lost and the browser won't have any reason to keep the background tab active and therefore unload it, which will not allow the hidden view to "heal" itself. 

This default behaviour effectively renders any browser capabilities unusable for long running background processes. One alternative might be moving logic from the frontend to the backend, but browsers have meanwhile become a great choice for local first apps and if the browser already offers the required features easily accessible, why force developers to leave a territory they feel comfortable with?

As of now, this is only available for WebKit based browsers on iOS 17.0+,iPadOS 17.0+,Mac Catalyst 17.0+, macOS 14.0+, visionOS 1.0+ ( see https://developer.apple.com/documentation/webkit/wkpreferences/inactiveschedulingpolicy-swift.enum?language=objc ).

It can be assumed that it will also be implemented for WebView2 (Windows). And it might be that it's already usable for linux and android, although I couldn't find any documentation about it and also cannot test it locally due to a lack of devices. 

As an alternative for windows and non-webkit browsers, one can setup a pending WebLock transaction, which, according to the docs, can also keep the browser from suspending it.

----

I needed to update a snapshot test and am unsure if this is at all related to this change. Please let me know if I did something wrong here.