### PR TITLE
fix(windows): Fix the issue where TAB cannot cycle through focus elements.

### DIFF
--- a/.changes/element-focus.md
+++ b/.changes/element-focus.md
@@ -1,0 +1,5 @@
+---
+'wry': 'patch:enhance'
+---
+
+Allow the use of TAB to cycle through focus elements in an HTML document.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -179,8 +179,8 @@ impl InnerWebView {
       if msg == WM_SETFOCUS {
         // Fix https://github.com/DioxusLabs/dioxus/issues/2900
         // Get the first child window of the window
-        let child = GetWindow(hwnd, GW_CHILD).unwrap_or_default();
-        if child != HWND::default() {
+        let child = GetWindow(hwnd, GW_CHILD).ok();
+        if child.is_some() {
           // Set focus to the child window(WebView document)
           let _ = SetFocus(child);
         }
@@ -1681,14 +1681,19 @@ unsafe fn set_background_color(
   controller: &ICoreWebView2Controller,
   background_color: RGBA,
 ) -> Result<()> {
-  let (R, G, B, mut A) = background_color;
-  if is_windows_7() || A != 0 {
-    A = 255;
+  let (r, g, b, mut a) = background_color;
+  if is_windows_7() || a != 0 {
+    a = 255;
   }
 
   let controller2: ICoreWebView2Controller2 = controller.cast()?;
   controller2
-    .SetDefaultBackgroundColor(COREWEBVIEW2_COLOR { R, G, B, A })
+    .SetDefaultBackgroundColor(COREWEBVIEW2_COLOR {
+      R: r,
+      G: g,
+      B: b,
+      A: a,
+    })
     .map_err(Into::into)
 }
 

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -176,6 +176,16 @@ impl InnerWebView {
       wparam: WPARAM,
       lparam: LPARAM,
     ) -> LRESULT {
+      if msg == WM_SETFOCUS {
+        // Fix https://github.com/DioxusLabs/dioxus/issues/2900
+        // Get the first child window of the window
+        let child = GetWindow(hwnd, GW_CHILD).unwrap_or_default();
+        if child != HWND::default() {
+          // Set focus to the child window(WebView document)
+          let _ = SetFocus(child);
+        }
+      }
+
       DefWindowProcW(hwnd, msg, wparam, lparam)
     }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

This PR fixes a minor issue, which is discussed [here](https://github.com/DioxusLabs/dioxus/issues/2900):
Specifically, when a user switches focus within a web element using the keyboard's tab, if they continue to press the tab after switching to the last web element, the focus will jump to the control with the class name WRY_WEBVIEW. At this point, no matter how much they press the tab, they cannot continue switching web elements;
The solution to this problem is to first switch to another application (such as the desktop), and then switch to the dioxus application again. At this point, the system will reset the focus to the web document, and you can continue to use the tab to switch elements, but this requires the user to operate it themselves, and the experience is very poor.

Expected behavior
The control with the class name WRY_WEBVIEW should not be allowed to grab keyboard focus, so that the tab key can be used to cyclically switch web elements.