### PR TITLE
fix(macos): fix race condition in wkwebview implementation of cookie fetching

### DIFF
--- a/.changes/fix-cookies-deadlock.md
+++ b/.changes/fix-cookies-deadlock.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix `Webview::cookies` and `Webview::cookies_for_url` deadlock on macOS.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -78,7 +78,7 @@ use std::{
   panic::AssertUnwindSafe,
   ptr::{null_mut, NonNull},
   str::{self, FromStr},
-  sync::{Arc, Mutex},
+  sync::{Arc, Mutex}, time::Duration,
 };
 
 #[cfg(feature = "mac-proxy")]
@@ -1054,16 +1054,14 @@ unsafe fn window_position(view: &NSView, x: i32, y: i32, height: f64) -> CGPoint
   CGPoint::new(x as f64, frame.size.height - y as f64 - height)
 }
 
+/// Wait synchronously for the NSRunLoop to run until a receiver has a message.
 unsafe fn wait_for_blocking_operation<T>(rx: std::sync::mpsc::Receiver<T>) -> Result<T> {
-  let interval = 0.0002;
+  let interval = 0.002;
   let limit = 1.;
   let mut elapsed = 0.;
   // run event loop until we get the response back, blocking for at most 3 seconds
   loop {
-    let rl = objc2_foundation::NSRunLoop::mainRunLoop();
-    let d = NSDate::dateWithTimeIntervalSinceNow(interval);
-    rl.runUntilDate(&d);
-    if let Ok(response) = rx.try_recv() {
+    if let Ok(response) = rx.recv_timeout(Duration::from_secs_f64(interval)) {
       return Ok(response);
     }
     elapsed += interval;
@@ -1073,5 +1071,13 @@ unsafe fn wait_for_blocking_operation<T>(rx: std::sync::mpsc::Receiver<T>) -> Re
         "timed out waiting for cookies response",
       )));
     }
+
+    // Go progress the event loop if we didn't get the result
+    let rl = objc2_foundation::NSRunLoop::mainRunLoop();
+    let limit_date = NSDate::dateWithTimeIntervalSinceNow(interval);
+
+    let mode = NSString::from_str("NSDefaultRunLoopMode");
+
+    rl.acceptInputForMode_beforeDate(&mode, &limit_date);
   }
 }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -78,7 +78,8 @@ use std::{
   panic::AssertUnwindSafe,
   ptr::{null_mut, NonNull},
   str::{self, FromStr},
-  sync::{Arc, Mutex}, time::Duration,
+  sync::{Arc, Mutex},
+  time::Duration,
 };
 
 #[cfg(feature = "mac-proxy")]
@@ -1056,15 +1057,16 @@ unsafe fn window_position(view: &NSView, x: i32, y: i32, height: f64) -> CGPoint
 
 /// Wait synchronously for the NSRunLoop to run until a receiver has a message.
 unsafe fn wait_for_blocking_operation<T>(rx: std::sync::mpsc::Receiver<T>) -> Result<T> {
-  let interval = 0.002;
+  let interval = Duration::from_millis(2);
+  let interval_as_secs = interval.as_secs_f64();
   let limit = 1.;
   let mut elapsed = 0.;
   // run event loop until we get the response back, blocking for at most 3 seconds
   loop {
-    if let Ok(response) = rx.recv_timeout(Duration::from_secs_f64(interval)) {
+    if let Ok(response) = rx.recv_timeout(interval) {
       return Ok(response);
     }
-    elapsed += interval;
+    elapsed += interval_as_secs;
     if elapsed >= limit {
       return Err(Error::Io(std::io::Error::new(
         std::io::ErrorKind::TimedOut,
@@ -1074,7 +1076,7 @@ unsafe fn wait_for_blocking_operation<T>(rx: std::sync::mpsc::Receiver<T>) -> Re
 
     // Go progress the event loop if we didn't get the result
     let rl = objc2_foundation::NSRunLoop::mainRunLoop();
-    let limit_date = NSDate::dateWithTimeIntervalSinceNow(interval);
+    let limit_date = NSDate::dateWithTimeIntervalSinceNow(interval_as_secs);
 
     let mode = NSString::from_str("NSDefaultRunLoopMode");
 


### PR DESCRIPTION
As I was implementing https://github.com/tauri-apps/tauri/pull/12665 I noticed a completed hang of the application if `cookies_for_url()` was called multiple times in quick succession.

I'm no expect in rust or objc but my understanding of the code here is as follows:

- `WKHTTPCookieStore.getAllCookies()` takes a callback to receive the cookies.
- The interface we expose for fetching cookies is synchronous, so we need to loop and block for some period of time until we receive our results.
- Looping purely in rust won't actually do the work properly, since the objc runloop (running on another thread? (potentially?) needs to be told to progress.
- `runUntilDate()` didn't necessarily block until that date on the rust site of this operation.

In order to fix this I had to do a few things. Notably I had to do **_all_** of these things for the issue to go away consistently.

- Replace `runUntilDate()` with `acceptInputForMode_beforeDate()`.
- Add some waiting in rust with by using `recv_timeout()` instead of `try_recv`

Now I'm sure there's something nasty under the hood causing this to happen, but I'm not really knowledgable enough to dive any deeper myself. I will say these changes fix the issue I was running into at the cost of an extra ms on my end.
