### PR TITLE
fix(windows): enable use of custom protocols for all request source kinds when new enough.

### DIFF
--- a/.changes/windows-iframe-custom-protocol.md
+++ b/.changes/windows-iframe-custom-protocol.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Windows, Add support for iframe requests in custom protocols. Requires WebView2 1.0.2365.46 or higher.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -844,11 +844,15 @@ impl InnerWebView {
       // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
       let filter = HSTRING::from(format!("{scheme}://{name}.*"));
 
-      // If WebView2 version is high enough, use the new API to add the filter to allow Shared Workers and 
+      // If WebView2 version is high enough, use the new API to add the filter to allow Shared Workers and
       // iframes to work with custom protocols
       // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/1114
       if let Ok(webview_22) = webview.cast::<ICoreWebView2_22>() {
-        webview_22.AddWebResourceRequestedFilterWithRequestSourceKinds(&filter, COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL, COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL)?;
+        webview_22.AddWebResourceRequestedFilterWithRequestSourceKinds(
+          &filter,
+          COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL,
+          COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL,
+        )?;
       } else {
         // Fallback to the old API
         webview.AddWebResourceRequestedFilter(&filter, COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL)?;

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -843,7 +843,16 @@ impl InnerWebView {
       // WebView2 supports non-standard protocols only on Windows 10+, so we have to use this workaround
       // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/73
       let filter = HSTRING::from(format!("{scheme}://{name}.*"));
-      webview.AddWebResourceRequestedFilter(&filter, COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL)?;
+
+      // If WebView2 version is high enough, use the new API to add the filter to allow Shared Workers and 
+      // iframes to work with custom protocols
+      // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/1114
+      if let Ok(webview_22) = webview.cast::<ICoreWebView2_22>() {
+        webview_22.AddWebResourceRequestedFilterWithRequestSourceKinds(&filter, COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL, COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL)?;
+      } else {
+        // Fallback to the old API
+        webview.AddWebResourceRequestedFilter(&filter, COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL)?;
+      }
     }
 
     let env = env.clone();


### PR DESCRIPTION
WebView2 introduced the ability to handle WebResourceRequests for specific Sources. This includes Shared Workers and iframes. This change allows us to handle requests to custom protocols in WebView2 that support the new method while falling back to the old method if the newer interface is not implemented.

The method exists as of WebView2 1.0.2365.46+ (April 2024 version)

See [https://github.com/MicrosoftEdge/WebView2Feedback/issues/1114](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1114) and [https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_22?view=webview2-1.0.2420.47](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_22?view=webview2-1.0.2420.47)

Potentially closes #949 