### PR TITLE
feat: add `WebViewBuilder.with_javascript_disabled`

### DIFF
--- a/.changes/disable-javascript.md
+++ b/.changes/disable-javascript.md
@@ -1,5 +1,5 @@
 ---
-"wry": minor
+"wry": patch
 ---
 
 Add `WebViewBuilder.with_javascript_disabled` api to disable JavaScript.

--- a/.changes/disable-javascript.md
+++ b/.changes/disable-javascript.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add `WebViewBuilder.with_javascript_disabled` api to disable JavaScript.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "base64",
  "block2 0.6.0",

--- a/src/android/kotlin/RustWebView.kt
+++ b/src/android/kotlin/RustWebView.kt
@@ -87,16 +87,6 @@ class RustWebView(context: Context, val initScripts: Array<String>, val id: Stri
         }
     }
 
-    fun setAutoPlay(enable: Boolean) {
-        val settings = super.getSettings()
-        settings.mediaPlaybackRequiresUserGesture = !enable
-    }
-
-    fun setUserAgent(ua: String) {
-        val settings = super.getSettings()
-        settings.userAgentString = ua
-    }
-
     fun getCookies(url: String): String {
         val cookieManager = CookieManager.getInstance()
         return cookieManager.getCookie(url)

--- a/src/android/kotlin/proguard-wry.pro
+++ b/src/android/kotlin/proguard-wry.pro
@@ -25,8 +25,6 @@
 
   void loadUrlMainThread(...);
   void loadHTMLMainThread(...);
-  void setAutoPlay(...);
-  void setUserAgent(...);
   void evalScript(...);
 }
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -176,6 +176,7 @@ impl InnerWebView {
       headers,
       autoplay,
       user_agent,
+      javascript_disabled,
       ..
     } = attributes;
 
@@ -336,6 +337,7 @@ impl InnerWebView {
       autoplay,
       user_agent,
       initialization_scripts,
+      javascript_disabled,
     }));
 
     Ok(Self { id })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,7 +692,7 @@ pub struct WebViewAttributes<'a> {
   /// Whether JavaScript should be disabled.
   ///
   /// ## Platform-specific
-  /// only implemented on macOS for now
+  /// only implemented on macOS and windows for now
   /// TODO
   pub javascript_disabled: bool,
 }
@@ -1326,7 +1326,7 @@ impl<'a> WebViewBuilder<'a> {
   /// Whether JavaScript should be disabled.
   ///
   /// ## Platform-specific
-  /// only implemented on macOS for now
+  /// only implemented on macOS and windows for now
   /// TODO
   pub fn with_javascript_disabled(self) -> Self {
     self.and_then(|mut b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,6 +688,13 @@ pub struct WebViewAttributes<'a> {
   ///
   /// see https://github.com/tauri-apps/tauri/issues/5250#issuecomment-2569380578
   pub background_throttling: Option<BackgroundThrottlingPolicy>,
+
+  /// Whether JavaScript should be disabled.
+  ///
+  /// ## Platform-specific
+  /// only implemented on macOS for now
+  /// TODO
+  pub javascript_disabled: bool,
 }
 
 impl Default for WebViewAttributes<'_> {
@@ -729,6 +736,7 @@ impl Default for WebViewAttributes<'_> {
         size: dpi::LogicalSize::new(200, 200).into(),
       }),
       background_throttling: None,
+      javascript_disabled: false,
     }
   }
 }
@@ -1312,6 +1320,17 @@ impl<'a> WebViewBuilder<'a> {
   pub fn with_background_throttling(self, policy: BackgroundThrottlingPolicy) -> Self {
     self.and_then(|mut b| {
       b.attrs.background_throttling = Some(policy);
+      Ok(b)
+    })
+  }
+  /// Whether JavaScript should be disabled.
+  ///
+  /// ## Platform-specific
+  /// only implemented on macOS for now
+  /// TODO
+  pub fn with_javascript_disabled(self) -> Self {
+    self.and_then(|mut b| {
+      b.attrs.javascript_disabled = true;
       Ok(b)
     })
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,8 +692,8 @@ pub struct WebViewAttributes<'a> {
   /// Whether JavaScript should be disabled.
   ///
   /// ## Platform-specific
-  /// only implemented on macOS and windows for now
-  /// TODO
+  ///
+  /// - **Android:** Not implemented yet.
   pub javascript_disabled: bool,
 }
 
@@ -1326,8 +1326,8 @@ impl<'a> WebViewBuilder<'a> {
   /// Whether JavaScript should be disabled.
   ///
   /// ## Platform-specific
-  /// only implemented on macOS and windows for now
-  /// TODO
+  ///
+  /// - **Android:** Not implemented yet.
   pub fn with_javascript_disabled(self) -> Self {
     self.and_then(|mut b| {
       b.attrs.javascript_disabled = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,10 +691,6 @@ pub struct WebViewAttributes<'a> {
   pub background_throttling: Option<BackgroundThrottlingPolicy>,
 
   /// Whether JavaScript should be disabled.
-  ///
-  /// ## Platform-specific
-  ///
-  /// - **Android:** Not implemented yet.
   pub javascript_disabled: bool,
 }
 
@@ -1335,10 +1331,6 @@ impl<'a> WebViewBuilder<'a> {
     })
   }
   /// Whether JavaScript should be disabled.
-  ///
-  /// ## Platform-specific
-  ///
-  /// - **Android:** Not implemented yet.
   pub fn with_javascript_disabled(self) -> Self {
     self.and_then(|mut b| {
       b.attrs.javascript_disabled = true;

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -396,6 +396,10 @@ impl InnerWebView {
       if attributes.devtools {
         settings.set_enable_developer_extras(true);
       }
+
+      if attributes.javascript_disabled {
+        settings.set_enable_javascript(false);
+      }
     }
   }
 

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -570,6 +570,10 @@ impl InnerWebView {
       settings9.SetIsNonClientRegionSupportEnabled(true)?;
     }
 
+    if attributes.javascript_disabled {
+      settings.SetIsScriptEnabled(false)?;
+    }
+
     Ok(())
   }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -293,8 +293,10 @@ impl InnerWebView {
         ns_string!("allowsPictureInPictureMediaPlayback"),
       );
 
-      let web_page_preferences = config.defaultWebpagePreferences();
-      web_page_preferences.setAllowsContentJavaScript(!attributes.javascript_disabled);
+      if attributes.javascript_disabled {
+        let web_page_preferences = config.defaultWebpagePreferences();
+        web_page_preferences.setAllowsContentJavaScript(false);
+      }
 
       #[cfg(target_os = "ios")]
       config.setValue_forKey(Some(&_yes), ns_string!("allowsInlineMediaPlayback"));

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -293,6 +293,9 @@ impl InnerWebView {
         ns_string!("allowsPictureInPictureMediaPlayback"),
       );
 
+      let web_page_preferences = config.defaultWebpagePreferences();
+      web_page_preferences.setAllowsContentJavaScript(!attributes.javascript_disabled);
+
       #[cfg(target_os = "ios")]
       config.setValue_forKey(Some(&_yes), ns_string!("allowsInlineMediaPlayback"));
 


### PR DESCRIPTION
add `WebViewBuilder.with_javascript_disabled` to disable javascript.

There are some cases where this is nessesary.
For example I need this for safely displaying HTML emails in delta chat:
-  https://github.com/deltachat/deltachat-desktop/pull/4699

closes https://github.com/tauri-apps/wry/issues/986 (which was only solved for windows before)

example to try out: https://github.com/Simon-Laux/tauri-experiments/tree/main/examples/disable_js_wry

### Progress

- [x] MacOS (implemented and tested)
- [x] Windows (implemented and tested)
- [x] Linux (implemented and tested)
- [x] change `wry` import to git branch instead of local checkout in example
- [x] If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
- [x] Ensure that all commits are signed
