### PR TITLE
docs: improve documentation around incognito and data store

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,9 +645,10 @@ pub struct WebViewAttributes<'a> {
   ///
   /// ## Platform-specific:
   ///
-  /// - Windows: Requires WebView2 Runtime version 101.0.1210.39 or higher, does nothing on older versions,
+  /// - **Windows**: Requires WebView2 Runtime version 101.0.1210.39 or higher, does nothing on older versions,
   /// see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10121039
   /// - **Android:** Unsupported yet.
+  /// - **macOS / iOS**: Uses the nonPersistent DataStore.
   pub incognito: bool,
 
   /// Whether all media can be played without user interaction.
@@ -1382,6 +1383,8 @@ pub trait WebViewBuilderExtDarwin {
   /// Can be used as a replacement for data_directory not being available in WKWebView.
   ///
   /// - **macOS / iOS**: Available on macOS >= 14 and iOS >= 17
+  ///
+  /// Note: Enable incognito mode to use the `nonPersistent` DataStore.
   fn with_data_store_identifier(self, identifier: [u8; 16]) -> Self;
   /// Move the window controls to the specified position.
   /// Normally this is handled by the Window but because `WebViewBuilder::build()` overwrites the window's NSView the controls will flicker on resizing.


### PR DESCRIPTION
Small improvements to the documentation:
- document that icognito uses the nonPersistant data store on MacOS.
- on `with_data_store_identifier` documentation point to the incognito mode to use the non persistant store.

Why?
Because I was a bit confused about this at fist and want to make things more clear for others.

I don't think this needs a changes file or version bump.
