### PR TITLE
fix(windows): webview not resized with parent when it gets maximized

### DIFF
--- a/.changes/fix-not-resized-when-maximized.md
+++ b/.changes/fix-not-resized-when-maximized.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix webview not resized with parent when it gets maximized on Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "base64",
  "block2 0.6.0",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Fix a regression from #1483, same as https://github.com/tauri-apps/tao/pull/1075