### PR TITLE
docs: `WebViewBuilder::with_asynchronous_custom_protocol` - copy over important missing docs that the custom uri schemes are implemented differently on windows and android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -968,6 +968,16 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// When registering a custom protocol with the same name, only the last regisered one will be used.
   ///
+  /// # Warning
+  ///
+  /// Pages loaded from custom protocol will have different Origin on different platforms. And
+  /// servers which enforce CORS will need to add exact same Origin header in `Access-Control-Allow-Origin`
+  /// if you wish to send requests with native `fetch` and `XmlHttpRequest` APIs. Here are the
+  /// different Origin headers across platforms:
+  ///
+  /// - macOS, iOS and Linux: `<scheme_name>://<path>` (so it will be `wry://path/to/page).
+  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://wry.path/to/page`). To use `https` instead of `http`, use [`WebViewBuilderExtWindows::with_https_scheme`] and [`WebViewBuilderExtAndroid::with_https_scheme`].
+  ///
   /// # Examples
   ///
   /// ```no_run


### PR DESCRIPTION
Took me quite a while to figure this out, this should help others to understand it faster than me.

pr for the tauri side of things: https://github.com/tauri-apps/tauri/pull/12830