### PR TITLE
fix(linux): fix examples/gtk_multiwebview.rs layout misaligned

### DIFF
--- a/examples/gtk_multiwebview.rs
+++ b/examples/gtk_multiwebview.rs
@@ -16,6 +16,22 @@ fn main() -> wry::Result<()> {
   let event_loop = EventLoop::new();
   let window = WindowBuilder::new().build(&event_loop).unwrap();
 
+  #[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+  )))]
+  let fixed = {
+    use gtk::prelude::*;
+    use tao::platform::unix::WindowExtUnix;
+    let fixed = gtk::Fixed::new();
+    let vbox = window.default_vbox().unwrap();
+    vbox.pack_start(&fixed, true, true, 0);
+    fixed.show_all();
+    fixed
+  };
+
   let build_webview = |builder: WebViewBuilder<'_>| -> wry::Result<wry::WebView> {
     #[cfg(any(
       target_os = "windows",
@@ -32,14 +48,7 @@ fn main() -> wry::Result<()> {
       target_os = "android"
     )))]
     let webview = {
-      use gtk::prelude::*;
-      use tao::platform::unix::WindowExtUnix;
       use wry::WebViewBuilderExtUnix;
-
-      let fixed = gtk::Fixed::new();
-      let vbox = window.default_vbox().unwrap();
-      vbox.pack_start(&fixed, true, true, 0);
-      fixed.show_all();
       builder.build_gtk(&fixed)?
     };
 


### PR DESCRIPTION
GTK requires a single gtk::Fixed container as the parent for all WebView instances.</br>
However, the current code creates a new gtk::Fixed for each WebView, leading to incorrect layout behavior.</br>

before 
![befor](https://github.com/user-attachments/assets/9787d4fe-cd54-40bd-9354-7ee2a1cca0d9)
after
![after](https://github.com/user-attachments/assets/f20d2af9-bb70-4398-ac7a-ab399536f3a1)
