### PR TITLE
fix(android): BorrowError crash when loading assets on Android

### DIFF
--- a/.changes/fix-android-race-condition.md
+++ b/.changes/fix-android-race-condition.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix `already mutably borrowed: BorrowError` panic on webview initialization on Android.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "base64",
  "block2 0.6.0",

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -23,7 +23,6 @@ use raw_window_handle::HasWindowHandle;
 use sha2::{Digest, Sha256};
 use std::{
   borrow::Cow,
-  cell::RefCell,
   collections::HashMap,
   os::fd::{AsFd as _, AsRawFd as _},
   sync::{mpsc::channel, Mutex},
@@ -45,13 +44,13 @@ pub struct Context<'a, 'b> {
   pub webview: &'a JObject<'b>,
 }
 
-pub(crate) struct StaticCell<T>(RefCell<T>);
+pub(crate) struct StaticValue<T>(Mutex<T>);
 
-unsafe impl<T> Send for StaticCell<T> {}
-unsafe impl<T> Sync for StaticCell<T> {}
+unsafe impl<T> Send for StaticValue<T> {}
+unsafe impl<T> Sync for StaticValue<T> {}
 
-impl<T> std::ops::Deref for StaticCell<T> {
-  type Target = RefCell<T>;
+impl<T> std::ops::Deref for StaticValue<T> {
+  type Target = Mutex<T>;
 
   fn deref(&self) -> &Self::Target {
     &self.0
@@ -60,7 +59,7 @@ impl<T> std::ops::Deref for StaticCell<T> {
 
 macro_rules! define_static_handlers {
   ($($var:ident = $type_name:ident { $($fields:ident:$types:ty),+ $(,)? });+ $(;)?) => {
-    $(pub static $var: StaticCell<Option<$type_name>> = StaticCell(RefCell::new(None));
+    $(pub static $var: StaticValue<Option<$type_name>> = StaticValue(Mutex::new(None));
     pub struct $type_name {
       $($fields: $types,)*
     }
@@ -84,8 +83,8 @@ define_static_handlers! {
   ON_LOAD_HANDLER = UnsafeOnPageLoadHandler { handler: Box<dyn Fn(PageLoadEvent, String)> };
 }
 
-pub static WITH_ASSET_LOADER: StaticCell<Option<bool>> = StaticCell(RefCell::new(None));
-pub static ASSET_LOADER_DOMAIN: StaticCell<Option<String>> = StaticCell(RefCell::new(None));
+pub static WITH_ASSET_LOADER: StaticValue<Option<bool>> = StaticValue(Mutex::new(None));
+pub static ASSET_LOADER_DOMAIN: StaticValue<Option<String>> = StaticValue(Mutex::new(None));
 
 pub(crate) static PACKAGE: OnceCell<String> = OnceCell::new();
 
@@ -208,13 +207,14 @@ impl InnerWebView {
       .map(|id| id.to_string())
       .unwrap_or_else(|| COUNTER.next().to_string());
 
-    WITH_ASSET_LOADER.replace(Some(with_asset_loader));
+    WITH_ASSET_LOADER.lock().unwrap().replace(with_asset_loader);
     if let Some(domain) = asset_loader_domain {
-      ASSET_LOADER_DOMAIN.replace(Some(domain));
+      ASSET_LOADER_DOMAIN.lock().unwrap().replace(domain);
     }
 
     let initialization_scripts_ = initialization_scripts.clone();
-    REQUEST_HANDLER.replace(Some(
+    REQUEST_HANDLER.lock()
+        .unwrap().replace(
       UnsafeRequestHandler::new(Box::new(
         move |webview_id: &str, mut request, is_document_start_script_enabled| {
           let uri = request.uri().to_string();
@@ -295,23 +295,32 @@ impl InnerWebView {
           }
           None
         },
-      ))
+      )
     ));
 
     if let Some(i) = ipc_handler {
-      IPC.replace(Some(UnsafeIpc::new(Box::new(i))));
+      IPC.lock().unwrap().replace(UnsafeIpc::new(Box::new(i)));
     }
 
     if let Some(i) = attributes.document_title_changed_handler {
-      TITLE_CHANGE_HANDLER.replace(Some(UnsafeTitleHandler::new(i)));
+      TITLE_CHANGE_HANDLER
+        .lock()
+        .unwrap()
+        .replace(UnsafeTitleHandler::new(i));
     }
 
     if let Some(i) = attributes.navigation_handler {
-      URL_LOADING_OVERRIDE.replace(Some(UnsafeUrlLoadingOverride::new(i)));
+      URL_LOADING_OVERRIDE
+        .lock()
+        .unwrap()
+        .replace(UnsafeUrlLoadingOverride::new(i));
     }
 
     if let Some(h) = attributes.on_page_load_handler {
-      ON_LOAD_HANDLER.replace(Some(UnsafeOnPageLoadHandler::new(h)));
+      ON_LOAD_HANDLER
+        .lock()
+        .unwrap()
+        .replace(UnsafeOnPageLoadHandler::new(h));
     }
 
     MainPipe::send(WebViewMessage::CreateWebView(CreateWebViewAttributes {

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -208,26 +208,12 @@ impl InnerWebView {
       .map(|id| id.to_string())
       .unwrap_or_else(|| COUNTER.next().to_string());
 
-    MainPipe::send(WebViewMessage::CreateWebView(CreateWebViewAttributes {
-      id: id.clone(),
-      url,
-      html,
-      #[cfg(any(debug_assertions, feature = "devtools"))]
-      devtools,
-      background_color,
-      transparent,
-      headers,
-      on_webview_created,
-      autoplay,
-      user_agent,
-      initialization_scripts: initialization_scripts.clone(),
-    }));
-
     WITH_ASSET_LOADER.replace(Some(with_asset_loader));
     if let Some(domain) = asset_loader_domain {
       ASSET_LOADER_DOMAIN.replace(Some(domain));
     }
 
+    let initialization_scripts_ = initialization_scripts.clone();
     REQUEST_HANDLER.replace(Some(
       UnsafeRequestHandler::new(Box::new(
         move |webview_id: &str, mut request, is_document_start_script_enabled| {
@@ -247,7 +233,7 @@ impl InnerWebView {
             }
 
             let (tx, rx) = channel();
-            let initialization_scripts = initialization_scripts.clone();
+            let initialization_scripts = initialization_scripts_.clone();
             let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
               Box::new(move |mut response| {
                 if !is_document_start_script_enabled {
@@ -327,6 +313,21 @@ impl InnerWebView {
     if let Some(h) = attributes.on_page_load_handler {
       ON_LOAD_HANDLER.replace(Some(UnsafeOnPageLoadHandler::new(h)));
     }
+
+    MainPipe::send(WebViewMessage::CreateWebView(CreateWebViewAttributes {
+      id: id.clone(),
+      url,
+      html,
+      #[cfg(any(debug_assertions, feature = "devtools"))]
+      devtools,
+      background_color,
+      transparent,
+      headers,
+      on_webview_created,
+      autoplay,
+      user_agent,
+      initialization_scripts,
+    }));
 
     Ok(Self { id })
   }


### PR DESCRIPTION
There is a race condition on the Android asset loading where the custom asset loading function is checked by the Java side while Rust is still setting it up, leading to a `already mutably borrowed: BorrowError` panic in the withAssetLoader function. 
Using Mutex instead of RefCell is the safer approach. Performance impact shouldn't be relevant here, since it's only a small lookup overhead every IPC and asset loading call.

ref https://github.com/tauri-apps/tauri/issues/12812
