### PR TITLE
fix crate version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "base64",
  "block2 0.6.0",


### PR DESCRIPTION
this is annoying as rustanalyzer makes the git checkout dirty by updating the file. This change is missing on dev branch.
