### PR TITLE
fix typo in url parse error

### DIFF
--- a/.changes/fix-error-variant-typo.md
+++ b/.changes/fix-error-variant-typo.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+fix: typo in `Error` from `Error::UrlPrase` to `Error::UrlParse`

--- a/.changes/fix-error-variant-typo.md
+++ b/.changes/fix-error-variant-typo.md
@@ -2,4 +2,4 @@
 "wry": minor
 ---
 
-fix: typo in `Error` from `Error::UrlPrase` to `Error::UrlParse`
+Renamed `Error::UrlPrase` to `Error::UrlParse` to fix typo.

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,5 +70,5 @@ pub enum Error {
   ContextDuplicateCustomProtocol(String),
   #[error(transparent)]
   #[cfg(any(target_os = "macos", target_os = "ios"))]
-  UrlPrase(#[from] url::ParseError),
+  UrlParse(#[from] url::ParseError),
 }


### PR DESCRIPTION
- **fix: typo in `Error` from `Error::UrlPrase` to `Error::UrlParse`**

---

- [x] Rebase after #1506 is merged
- [ ] maybe this would need to be a breaking change because it changes public api? 
