### PR TITLE
fix(windows): Enable edge's white flicker fix (requires v134+)

### DIFF
--- a/.changes/wv2-white-flicker.md
+++ b/.changes/wv2-white-flicker.md
@@ -1,0 +1,5 @@
+---
+wry: "patch:enhance"
+---
+
+Wry by default now passes `--enable-features=RemoveRedirectionBitmap` to WebView2 to hide the initial white flash of newly created webviews. Only takes effect on WebView2 Runtime versions 134 and above.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1466,10 +1466,10 @@ pub trait WebViewBuilderExtWindows {
   /// ## Warning
   ///
   /// - Webview instances with different browser arguments must also have different [data directories](struct.WebContext.html#method.new).
-  /// - By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
-  /// `--autoplay-policy=no-user-gesture-required` if autoplay is enabled
-  /// and `--proxy-server=<scheme>://<host>:<port>` if a proxy is set.
-  /// so if you use this method, you have to add these arguments yourself if you want to keep the same behavior.
+  /// - By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --enable-features=RemoveRedirectionBitmap`
+  ///   `--autoplay-policy=no-user-gesture-required` if autoplay is enabled
+  ///   and `--proxy-server=<scheme>://<host>:<port>` if a proxy is set.
+  ///   so if you use this method, you have to add these arguments yourself if you want to keep the same behavior.
   fn with_additional_browser_args<S: Into<String>>(self, additional_args: S) -> Self;
 
   /// Determines whether browser-specific accelerator keys are enabled. When this setting is set to

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -283,7 +283,8 @@ impl InnerWebView {
     let additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
       // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
       // and "smart screen" - See https://github.com/tauri-apps/tauri/issues/1345
-      let default_args = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection";
+      // enable white flicker fix
+      let default_args = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --enable-features=RemoveRedirectionBitmap";
       let mut arguments = String::from(default_args);
 
       if attributes.autoplay {


### PR DESCRIPTION
in a typical tauri app there's still a one frame flicker left from tao due to windows' insane drawing behavior. will see if i can dig out my research on that, i think i had a fix but ditched it for Amr's drawing PR.

idk why they ditched the first version but this flag will show a mica/acrylic background while it loads