### PR TITLE
fix: WebView2: disable "host objects"

### DIFF
--- a/.changes/windows-disable-host-objects.md
+++ b/.changes/windows-disable-host-objects.md
@@ -1,0 +1,5 @@
+---
+wry: "patch:sec"
+---
+
+Windows (WebView2): disable [host objects](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/security#restrict-web-content-functionality) for extra security.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -541,6 +541,10 @@ impl InnerWebView {
     pl_attrs: &super::PlatformSpecificWebViewAttributes,
   ) -> Result<()> {
     let settings = webview.Settings()?;
+    // We don't use host objects, let's disable them extra for security. See
+    // https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/security#restrict-web-content-functionality
+    // Discussion about adding host objects: https://github.com/tauri-apps/wry/issues/454.
+    settings.SetAreHostObjectsAllowed(false)?;
     settings.SetIsStatusBarEnabled(false)?;
     settings.SetAreDefaultContextMenusEnabled(pl_attrs.default_context_menus)?;
     settings.SetIsZoomControlEnabled(attributes.zoom_hotkeys_enabled)?;


### PR DESCRIPTION
We don't use them, and Microsoft recommends to disable them
if we don't use them.

This does not fix any known vulnerabilities.
It's just an extra security measure.

- [ ] Please verify that this won't break things. My assumption is that we don't use them in this library, thus it's safe to disable.

See also discussion on host objects:
https://github.com/tauri-apps/wry/issues/454.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
