### PR TITLE
feat: add x11 feature flag to allow disabling x11 dependencies

### DIFF
--- a/.changes/x11-feature.md
+++ b/.changes/x11-feature.md
@@ -1,0 +1,5 @@
+---
+wry: minor
+---
+
+Added `x11` feature flag (enabled by default).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["drag-drop", "protocol", "os-webview"]
+default = ["drag-drop", "protocol", "os-webview", "x11"]
 serde = ["dpi/serde"]
 drag-drop = []
 protocol = []
@@ -41,6 +41,8 @@ os-webview = [
   "webkit2gtk-sys",
   "dep:gtk",
   "soup3",
+]
+x11 = [
   "x11-dl",
   "gdkx11",
 ]

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Wry uses a set of feature flags to toggle several advanced features.
   loading assets.
 - `drag-drop` (default): Enables [`WebViewBuilder::with_drag_drop_handler`] to control the behaviour when there are files
   interacting with the window.
+- `x11` (default): Enables x11 support and dependencies on Linux.
 - `devtools`: Enables devtools on release builds. Devtools are always enabled in debug builds.
   On **macOS**, enabling devtools, requires calling private apis so you should not enable this flag in release
   build if your app needs to publish to App Store.

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
   #[cfg(gtk)]
   #[error("Couldn't find X11 Display")]
   X11DisplayNotFound,
-  #[cfg(gtk)]
+  #[cfg(all(gtk, feature = "x11"))]
   #[error(transparent)]
   XlibError(#[from] x11_dl::error::OpenError),
   #[error("Failed to initialize the script")]


### PR DESCRIPTION
This allows me to reduce the number of dependencies and final binary size of my tauri app which is running on a wayland only kiosk.