### PR TITLE
fix(macos): fix unused variables warnings from `cargo check` when `tracing` feature is disabled

### DIFF
--- a/.changes/fix-unused-warnings.md
+++ b/.changes/fix-unused-warnings.md
@@ -1,5 +1,0 @@
----
-wry: patch
----
-
-Fix the unused variable warnings from `cargo check` on macOS when `tracing` feature is not enabled.

--- a/.changes/fix-unused-warnings.md
+++ b/.changes/fix-unused-warnings.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Fix the unused variable warnings from `cargo check` on macOS when `tracing` feature is not enabled.

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -192,9 +192,9 @@ extern "C" fn start_task(
               };
 
               // Perform an upfront validation
-              if let Err(e) = validate() {
+              if let Err(_e) = validate() {
                 #[cfg(feature = "tracing")]
-                tracing::warn!("Task invalid before sending response: {:?}", e);
+                tracing::warn!("Task invalid before sending response: {:?}", _e);
                 return; // If invalid, return early without calling task methods.
               }
 
@@ -304,7 +304,7 @@ extern "C" fn start_task(
               #[cfg(feature = "tracing")]
               let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
 
-              if let Err(e) = response(
+              if let Err(_e) = response(
                 task,
                 webview,
                 task_key,
@@ -314,7 +314,7 @@ extern "C" fn start_task(
                 sent_response,
               ) {
                 #[cfg(feature = "tracing")]
-                tracing::error!("Error responding to task: {:?}", e);
+                tracing::error!("Error responding to task: {:?}", _e);
               }
             });
 

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -30,11 +30,11 @@ pub fn create(name: &str) -> &AnyClass {
   unsafe {
     let scheme_name = format!("{}URLSchemeHandler\0", name);
     let scheme_name = CStr::from_bytes_with_nul(scheme_name.as_bytes()).unwrap();
-    let cls = ClassBuilder::new(&scheme_name, NSObject::class());
+    let cls = ClassBuilder::new(scheme_name, NSObject::class());
     match cls {
       Some(mut cls) => {
-        cls.add_ivar::<*mut c_void>(CStr::from_bytes_with_nul(b"function\0").unwrap());
-        cls.add_ivar::<*mut c_char>(CStr::from_bytes_with_nul(b"webview_id\0").unwrap());
+        cls.add_ivar::<*mut c_void>(c"function");
+        cls.add_ivar::<*mut c_char>(c"webview_id");
         cls.add_method(
           objc2::sel!(webView:startURLSchemeTask:),
           start_task as extern "C" fn(_, _, _, _),
@@ -45,7 +45,7 @@ pub fn create(name: &str) -> &AnyClass {
         );
         cls.register()
       }
-      None => AnyClass::get(&scheme_name).expect("Failed to get the class definition"),
+      None => AnyClass::get(scheme_name).expect("Failed to get the class definition"),
     }
   }
 }
@@ -67,7 +67,7 @@ extern "C" fn start_task(
 
     let ivar = this
       .class()
-      .instance_variable(CStr::from_bytes_with_nul(b"webview_id\0").unwrap())
+      .instance_variable(c"webview_id")
       .unwrap();
     let webview_id_ptr: *mut c_char = *ivar.load(this);
     let webview_id = CStr::from_ptr(webview_id_ptr)
@@ -77,7 +77,7 @@ extern "C" fn start_task(
 
     let ivar = this
       .class()
-      .instance_variable(CStr::from_bytes_with_nul(b"function\0").unwrap())
+      .instance_variable(c"function")
       .unwrap();
     let function: &*mut c_void = ivar.load(this);
     if !function.is_null() {

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -65,20 +65,14 @@ extern "C" fn start_task(
     let task_key = task.hash(); // hash by task object address
     let task_uuid = webview.add_custom_task_key(task_key);
 
-    let ivar = this
-      .class()
-      .instance_variable(c"webview_id")
-      .unwrap();
+    let ivar = this.class().instance_variable(c"webview_id").unwrap();
     let webview_id_ptr: *mut c_char = *ivar.load(this);
     let webview_id = CStr::from_ptr(webview_id_ptr)
       .to_str()
       .ok()
       .unwrap_or_default();
 
-    let ivar = this
-      .class()
-      .instance_variable(c"function")
-      .unwrap();
+    let ivar = this.class().instance_variable(c"function").unwrap();
     let function: &*mut c_void = ivar.load(this);
     if !function.is_null() {
       let function = &mut *(*function

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -73,7 +73,7 @@ use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use std::{
   cell::RefCell,
   collections::HashSet,
-  ffi::{c_void, CStr, CString},
+  ffi::{c_void, CString},
   net::Ipv4Addr,
   os::raw::c_char,
   panic::AssertUnwindSafe,
@@ -232,14 +232,14 @@ impl InnerWebView {
 
         let ivar = (*handler)
           .class()
-          .instance_variable(CStr::from_bytes_with_nul(b"function\0").unwrap())
+          .instance_variable(c"function")
           .unwrap();
         let ivar_delegate = ivar.load_mut(&mut *handler);
         *ivar_delegate = function as *mut _ as *mut c_void;
 
         let ivar = (*handler)
           .class()
-          .instance_variable(CStr::from_bytes_with_nul(b"webview_id\0").unwrap())
+          .instance_variable(c"webview_id")
           .unwrap();
         let ivar_delegate: &mut *mut c_char = ivar.load_mut(&mut *handler);
         *ivar_delegate = CString::new(webview_id.as_bytes()).unwrap().into_raw();
@@ -1042,10 +1042,8 @@ r#"Object.defineProperty(window, 'ipc', {
         if let Some(cb) = cb.take() {
           cb(Ok(()));
         }
-      } else {
-        if let Some(cb) = cb.take() {
-          cb(Err(Error::DataStoreInUse));
-        }
+      } else if let Some(cb) = cb.take() {
+        cb(Err(Error::DataStoreInUse));
       }
     });
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -230,17 +230,11 @@ impl InnerWebView {
         let function = Box::into_raw(Box::new(function));
         protocol_ptrs.push(function);
 
-        let ivar = (*handler)
-          .class()
-          .instance_variable(c"function")
-          .unwrap();
+        let ivar = (*handler).class().instance_variable(c"function").unwrap();
         let ivar_delegate = ivar.load_mut(&mut *handler);
         *ivar_delegate = function as *mut _ as *mut c_void;
 
-        let ivar = (*handler)
-          .class()
-          .instance_variable(c"webview_id")
-          .unwrap();
+        let ivar = (*handler).class().instance_variable(c"webview_id").unwrap();
         let ivar_delegate: &mut *mut c_char = ivar.load_mut(&mut *handler);
         *ivar_delegate = CString::new(webview_id.as_bytes()).unwrap().into_raw();
 

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -64,7 +64,7 @@ pub(crate) fn navigation_policy(
     let request = action.request();
     let url = request.URL().unwrap().absoluteString().unwrap();
     let target_frame = action.targetFrame();
-    let is_main_frame = target_frame.map_or(false, |frame| frame.isMainFrame());
+    let is_main_frame = target_frame.is_some_and(|frame| frame.isMainFrame());
 
     if should_download {
       let has_download_handler = this.ivars().has_download_handler;


### PR DESCRIPTION
I noticed that the HEAD of `dev` branch caused warnings as follows with `cargo check`.

```
warning: unused variable: `e`
   --> src/wkwebview/class/url_scheme_handler.rs:195:26
    |
195 |               if let Err(e) = validate() {
    |                          ^ help: if this is intentional, prefix it with an underscore: `_e`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `e`
   --> src/wkwebview/class/url_scheme_handler.rs:307:26
    |
307 |               if let Err(e) = response(
    |                          ^ help: if this is intentional, prefix it with an underscore: `_e`

warning: `wry` (lib) generated 2 warnings
```

This PR fixes the warnings. And it fixes clippy warnings reported on macOS as well.