### PR TITLE
fix(windows): init scripts sometimes get executed too late

### DIFF
--- a/.changes/init-script-struct.md
+++ b/.changes/init-script-struct.md
@@ -1,0 +1,5 @@
+---
+wry: minor
+---
+
+**Breaking Change**: `WebViewAttributes::initialization_scripts` takes `Vec::<InitializationScript>` now instead of `Vec::<(String, bool)>`

--- a/.changes/windows-init-script-main-only.md
+++ b/.changes/windows-init-script-main-only.md
@@ -1,0 +1,5 @@
+---
+wry: minor
+---
+
+Init scripts are always executed on all frames on Windows WebView2

--- a/.changes/windows-init-script-timing.md
+++ b/.changes/windows-init-script-timing.md
@@ -1,0 +1,5 @@
+---
+wry: minor
+---
+
+Fix init script sometimes get executed too late on Windows WebView2

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{Error, RGBA};
+use crate::{Error, InitializationScript, RGBA};
 use crossbeam_channel::*;
 use jni::{
   errors::Result as JniResult,
@@ -75,11 +75,11 @@ impl<'a> MainPipe<'a> {
             string_class,
             self.env.new_string("")?,
           )?;
-          for (i, (script, _)) in initialization_scripts.into_iter().enumerate() {
+          for (i, init_script) in initialization_scripts.into_iter().enumerate() {
             self.env.set_object_array_element(
               &initialization_scripts_array,
               i as i32,
-              self.env.new_string(script)?,
+              self.env.new_string(init_script.script)?,
             )?;
           }
 
@@ -472,7 +472,7 @@ pub(crate) struct CreateWebViewAttributes {
   pub autoplay: bool,
   pub on_webview_created: Option<Box<dyn Fn(super::Context) -> JniResult<()> + Send>>,
   pub user_agent: Option<String>,
-  pub initialization_scripts: Vec<(String, bool)>,
+  pub initialization_scripts: Vec<InitializationScript>,
   pub javascript_disabled: bool,
 }
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -260,15 +260,15 @@ impl InnerWebView {
                     let mut hashes = Vec::new();
                     with_html_head(&mut document, |head| {
                       // iterate in reverse order since we are prepending each script to the head tag
-                      for (script, _) in initialization_scripts.iter().rev() {
+                      for init_script in initialization_scripts.iter().rev() {
                         let script_el = NodeRef::new_element(
                           QualName::new(None, ns!(html), "script".into()),
                           None,
                         );
-                        script_el.append(NodeRef::new_text(script.as_str()));
+                        script_el.append(NodeRef::new_text(init_script.script.as_str()));
                         head.prepend(script_el);
                         if csp.is_some() {
-                          hashes.push(hash_script(script.as_str()));
+                          hashes.push(hash_script(init_script.script.as_str()));
                         }
                       }
                     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,14 +513,15 @@ pub struct WebViewAttributes<'a> {
   /// When webview load a new page, this initialization code will be executed.
   /// It is guaranteed that code is executed before `window.onload`.
   ///
-  /// Second parameter represents if script should be added to main frame only or sub frames also.
-  /// `true` for main frame only, `false` for sub frames.
-  ///
   /// ## Platform-specific
   ///
-  /// - **Windows**: scripts are injected into sub frames.
-  /// - **Android:** The Android WebView does not provide an API for initialization scripts,
-  ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
+  /// - **Windows**: scripts are always injected into sub frames.
+  /// - **Android:** When [addDocumentStartJavaScript] is not supported,
+  ///   we prepend them to each HTML head (implementation only supported on custom protocol URLs).
+  ///   For remote URLs, we use [onPageStarted] which is not guaranteed to run before other scripts.
+  ///
+  /// [addDocumentStartJavaScript]: https://developer.android.com/reference/androidx/webkit/WebViewCompat#addDocumentStartJavaScript(android.webkit.WebView,java.lang.String,java.util.Set%3Cjava.lang.String%3E)
+  /// [onPageStarted]: https://developer.android.com/reference/android/webkit/WebViewClient#onPageStarted(android.webkit.WebView,%20java.lang.String,%20android.graphics.Bitmap)
   pub initialization_scripts: Vec<InitializationScript>,
 
   /// A list of custom loading protocols with pairs of scheme uri string and a handling
@@ -881,7 +882,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows:** scripts are added to subframes as well.
+  ///- **Windows:** scripts are always added to subframes.
   /// - **Android:** When [addDocumentStartJavaScript] is not supported,
   ///   we prepend them to each HTML head (implementation only supported on custom protocol URLs).
   ///   For remote URLs, we use [onPageStarted] which is not guaranteed to run before other scripts.
@@ -906,7 +907,10 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platform-specific:
   ///
-  /// - **Windows:** scripts are always added to subframes regardless of the option.
+  /// - **Windows:** scripts are always added to subframes regardless of the `for_main_frame_only` option.
+  /// - **Android**: When [addDocumentStartJavaScript] is not supported, scripts are always injected into main frame only.
+  ///
+  /// [addDocumentStartJavaScript]: https://developer.android.com/reference/androidx/webkit/WebViewCompat#addDocumentStartJavaScript(android.webkit.WebView,java.lang.String,java.util.Set%3Cjava.lang.String%3E)
   pub fn with_initialization_script_for_main_only<S: Into<String>>(
     self,
     js: S,
@@ -2264,7 +2268,17 @@ pub enum BackgroundThrottlingPolicy {
 pub struct InitializationScript {
   /// The script to run
   pub script: String,
-  /// Whether the script should be injected to main frame only
+  /// Whether the script should be injected to main frame only.
+  ///
+  /// When set to false, the script is also injected to subframes.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows**: scripts are always injected into subframes regardless of this option.
+  ///   This will be the case until Webview2 implements a proper API to inject a script only on the main frame.
+  /// - **Android**: When [addDocumentStartJavaScript] is not supported, scripts are always injected into main frame only.
+  ///
+  /// [addDocumentStartJavaScript]: https://developer.android.com/reference/androidx/webkit/WebViewCompat#addDocumentStartJavaScript(android.webkit.WebView,java.lang.String,java.util.Set%3Cjava.lang.String%3E)
   pub for_main_frame_only: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,9 +518,10 @@ pub struct WebViewAttributes<'a> {
   ///
   /// ## Platform-specific
   ///
+  /// - **Windows**: scripts are injected into sub frames.
   /// - **Android:** The Android WebView does not provide an API for initialization scripts,
   ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
-  pub initialization_scripts: Vec<(String, bool)>,
+  pub initialization_scripts: Vec<InitializationScript>,
 
   /// A list of custom loading protocols with pairs of scheme uri string and a handling
   /// closure.
@@ -880,6 +881,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platform-specific
   ///
+  /// - **Windows:** scripts are added to subframes as well.
   /// - **Android:** When [addDocumentStartJavaScript] is not supported,
   ///   we prepend them to each HTML head (implementation only supported on custom protocol URLs).
   ///   For remote URLs, we use [onPageStarted] which is not guaranteed to run before other scripts.
@@ -901,12 +903,21 @@ impl<'a> WebViewBuilder<'a> {
   ///   .build(&window)
   ///   .unwrap();
   /// ```
-  pub fn with_initialization_script_for_main_only(self, js: &str, main_only: bool) -> Self {
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Windows:** scripts are always added to subframes regardless of the option.
+  pub fn with_initialization_script_for_main_only(
+    self,
+    js: &str,
+    for_main_frame_only: bool,
+  ) -> Self {
     self.and_then(|mut b| {
       if !js.is_empty() {
-        b.attrs
-          .initialization_scripts
-          .push((js.to_string(), main_only));
+        b.attrs.initialization_scripts.push(InitializationScript {
+          script: js.to_string(),
+          for_main_frame_only,
+        });
       }
       Ok(b)
     })
@@ -2245,6 +2256,15 @@ pub enum BackgroundThrottlingPolicy {
   Suspend,
   /// A policy where a web view that's not in a window limits processing, but does not fully suspend tasks.
   Throttle,
+}
+
+/// An initialization script
+#[derive(Debug, Clone)]
+pub struct InitializationScript {
+  /// The script to run
+  pub script: String,
+  /// Whether the script should be injected to main frame only
+  pub for_main_frame_only: bool,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,7 +888,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// [addDocumentStartJavaScript]: https://developer.android.com/reference/androidx/webkit/WebViewCompat#addDocumentStartJavaScript(android.webkit.WebView,java.lang.String,java.util.Set%3Cjava.lang.String%3E)
   /// [onPageStarted]: https://developer.android.com/reference/android/webkit/WebViewClient#onPageStarted(android.webkit.WebView,%20java.lang.String,%20android.graphics.Bitmap)
-  pub fn with_initialization_script(self, js: &str) -> Self {
+  pub fn with_initialization_script<S: Into<String>>(self, js: S) -> Self {
     self.with_initialization_script_for_main_only(js, true)
   }
 
@@ -907,15 +907,16 @@ impl<'a> WebViewBuilder<'a> {
   /// ## Platform-specific:
   ///
   /// - **Windows:** scripts are always added to subframes regardless of the option.
-  pub fn with_initialization_script_for_main_only(
+  pub fn with_initialization_script_for_main_only<S: Into<String>>(
     self,
-    js: &str,
+    js: S,
     for_main_frame_only: bool,
   ) -> Self {
     self.and_then(|mut b| {
-      if !js.is_empty() {
+      let script = js.into();
+      if !script.is_empty() {
         b.attrs.initialization_scripts.push(InitializationScript {
-          script: js.to_string(),
+          script,
           for_main_frame_only,
         });
       }

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -304,8 +304,8 @@ impl InnerWebView {
     w.init("Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: function(x) { window.webkit.messageHandlers['ipc'].postMessage(x) } }) })", true)?;
 
     // Initialize scripts
-    for (js, for_main_only) in attributes.initialization_scripts {
-      w.init(&js, for_main_only)?;
+    for init_script in attributes.initialization_scripts {
+      w.init(&init_script.script, init_script.for_main_frame_only)?;
     }
 
     // Run pending webview.eval() scripts once webview loads.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -459,12 +459,8 @@ impl InnerWebView {
     }
 
     // Initialize main and subframe scripts
-    for (js, _) in attributes
-      .initialization_scripts
-      .iter()
-      .filter(|(_, for_main)| !*for_main)
-    {
-      Self::add_script_to_execute_on_document_created(&webview, js.clone())?;
+    for init_script in attributes.initialization_scripts {
+      Self::add_script_to_execute_on_document_created(&webview, init_script.script)?;
     }
 
     // Enable clipboard
@@ -607,22 +603,6 @@ impl InnerWebView {
         token,
       )?;
     }
-    let scripts = attributes.initialization_scripts.clone();
-
-    webview.add_ContentLoading(
-      &ContentLoadingEventHandler::create(Box::new(move |webview, _| {
-        let Some(webview) = webview else {
-          return Ok(());
-        };
-
-        for (script, _) in scripts.iter().filter(|(_, for_main)| *for_main) {
-          Self::execute_script(&webview, script.clone(), |_| ())?;
-        }
-
-        Ok(())
-      })),
-      token,
-    )?;
 
     // Page load handler
     if let Some(on_page_load_handler) = attributes.on_page_load_handler.take() {

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -528,8 +528,8 @@ r#"Object.defineProperty(window, 'ipc', {
 });"#,
       true
       );
-      for (js, for_main_only) in attributes.initialization_scripts {
-        w.init(&js, for_main_only);
+      for init_script in attributes.initialization_scripts {
+        w.init(&init_script.js, init_script.for_main_frame_only);
       }
 
       // Set user agent

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -529,7 +529,7 @@ r#"Object.defineProperty(window, 'ipc', {
       true
       );
       for init_script in attributes.initialization_scripts {
-        w.init(&init_script.js, init_script.for_main_frame_only);
+        w.init(&init_script.script, init_script.for_main_frame_only);
       }
 
       // Set user agent


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Reference: https://github.com/tauri-apps/wry/pull/1418#discussion_r2005617414, https://github.com/tauri-apps/tauri/issues/12990

- Fix init script sometimes get executed too late on Windows WebView2
- Init scripts are always executed on all frames on Windows WebView2
- `WebViewAttributes::initialization_scripts` takes `Vec::<InitializationScript>` now instead of `Vec::<(String, bool)>`

@amrbashir @tweidinger 