### PR TITLE
fix(macos): fix warnings reported from `cargo check --release`

### DIFF
--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -37,6 +37,10 @@ jobs:
 
       - run: cargo clippy --all-targets
 
+      - run: cargo check --release
+        env:
+          RUSTFLAGS: -D warnings
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/src/wkwebview/download.rs
+++ b/src/wkwebview/download.rs
@@ -87,13 +87,13 @@ pub(crate) fn download_did_finish(this: &WryDownloadDelegate, download: &WKDownl
 pub(crate) fn download_did_fail(
   this: &WryDownloadDelegate,
   download: &WKDownload,
-  error: &NSError,
+  _error: &NSError,
   _resume_data: &NSData,
 ) {
   unsafe {
     #[cfg(debug_assertions)]
     {
-      let description = error.localizedDescription().to_string();
+      let description = _error.localizedDescription().to_string();
       eprintln!("Download failed with error: {}", description);
     }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -34,7 +34,7 @@ use dpi::{LogicalPosition, LogicalSize};
 use objc2::runtime::Bool;
 use objc2::{
   rc::Retained,
-  runtime::{AnyObject, NSObject, ProtocolObject},
+  runtime::{AnyObject, ProtocolObject},
   AllocAnyThread, DeclaredClass, MainThreadOnly, Message,
 };
 #[cfg(target_os = "macos")]
@@ -280,7 +280,8 @@ impl InnerWebView {
           }
         };
 
-        let proxies: Retained<NSArray<NSObject>> = NSArray::arrayWithObject(&*proxy_config);
+        let proxies: Retained<NSArray<objc2::runtime::NSObject>> =
+          NSArray::arrayWithObject(&*proxy_config);
         data_store.setValue_forKey(Some(&proxies), ns_string!("proxyConfigurations"));
       }
 
@@ -425,7 +426,7 @@ impl InnerWebView {
       #[cfg(any(debug_assertions, feature = "devtools"))]
       if attributes.devtools {
         let has_inspectable_property: bool =
-          NSObject::respondsToSelector(&webview, objc2::sel!(setInspectable:));
+          objc2::runtime::NSObject::respondsToSelector(&webview, objc2::sel!(setInspectable:));
         if has_inspectable_property {
           webview.setInspectable(true);
         }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

This PR fixes the following two warnings reported by `cargo check --release`.

```
warning: unused import: `NSObject`
  --> src/wkwebview/mod.rs:37:24
   |
37 |   runtime::{AnyObject, NSObject, ProtocolObject},
   |                        ^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `error`
  --> src/wkwebview/download.rs:90:3
   |
90 |   error: &NSError,
   |   ^^^^^ help: if this is intentional, prefix it with an underscore: `_error`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: `wry` (lib) generated 2 warnings (run `cargo fix --lib -p wry` to apply 1 suggestion)
```

These warnings are only caused on release build because some implementation is switched by `debug_assertions` gate. This PR also adds the check by `cargo check --release` in CI workflow so that we can notice warnings.
