### PR TITLE
feat: macOS/iOS: add option to disable or enable link previews when building a webview

### DIFF
--- a/.changes/macOS_allow_link_preview.md
+++ b/.changes/macOS_allow_link_preview.md
@@ -2,5 +2,5 @@
 "wry": patch:feat
 ---
 
-macOS/iOS: add option to disable or enable link previews when building a webview (the webkit api has it enabled by default)
-  - `WebViewBuilderExtDarwin.allow_link_preview(allow_link_preview: bool)`
+macOS/iOS: add option to disable link previews when building a webview (the webkit API has it enabled by default)
+  - `WebViewBuilderExtDarwin.with_allow_link_preview(bool)`

--- a/.changes/macOS_allow_link_preview.md
+++ b/.changes/macOS_allow_link_preview.md
@@ -1,0 +1,6 @@
+---
+"wry": patch:feat
+---
+
+macOS/iOS: add option to disable or enable link previews when building a webview (the webkit api has it enabled by default)
+  - `WebViewBuilderExtDarwin.allow_link_preview(allow_link_preview: bool)`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1394,10 +1394,23 @@ impl<'a> WebViewBuilder<'a> {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct PlatformSpecificWebViewAttributes {
   data_store_identifier: Option<[u8; 16]>,
   traffic_light_inset: Option<dpi::Position>,
+  allow_link_preview: bool,
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+impl Default for PlatformSpecificWebViewAttributes {
+  fn default() -> Self {
+    Self {
+      data_store_identifier: None,
+      traffic_light_inset: None,
+      // platform default for this is true
+      allow_link_preview: true,
+    }
+  }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -1415,6 +1428,12 @@ pub trait WebViewBuilderExtDarwin {
   /// Warning: Do not use this if your chosen window library does not support traffic light insets.
   /// Warning: Only use this in **decorated** windows with a **hidden titlebar**!
   fn with_traffic_light_inset<P: Into<dpi::Position>>(self, position: P) -> Self;
+  /// Whether to show a link preview when long pressing on links. Available on macOS and iOS only.
+  ///
+  /// Default is true.
+  ///
+  /// See https://docs.rs/objc2-web-kit/latest/objc2_web_kit/struct.WKWebView.html#method.allowsLinkPreview
+  fn allow_link_preview(self, allow_link_preview: bool) -> Self;
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -1429,6 +1448,13 @@ impl WebViewBuilderExtDarwin for WebViewBuilder<'_> {
   fn with_traffic_light_inset<P: Into<dpi::Position>>(self, position: P) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.traffic_light_inset = Some(position.into());
+      Ok(b)
+    })
+  }
+
+  fn allow_link_preview(self, allow_link_preview: bool) -> Self {
+    self.and_then(|mut b| {
+      b.platform_specific.allow_link_preview = allow_link_preview;
       Ok(b)
     })
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1432,8 +1432,8 @@ pub trait WebViewBuilderExtDarwin {
   ///
   /// Default is true.
   ///
-  /// See https://docs.rs/objc2-web-kit/latest/objc2_web_kit/struct.WKWebView.html#method.allowsLinkPreview
-  fn allow_link_preview(self, allow_link_preview: bool) -> Self;
+  /// See https://developer.apple.com/documentation/webkit/wkwebview/allowslinkpreview
+  fn with_allow_link_preview(self, allow_link_preview: bool) -> Self;
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -1452,7 +1452,7 @@ impl WebViewBuilderExtDarwin for WebViewBuilder<'_> {
     })
   }
 
-  fn allow_link_preview(self, allow_link_preview: bool) -> Self {
+  fn with_allow_link_preview(self, allow_link_preview: bool) -> Self {
     self.and_then(|mut b| {
       b.platform_specific.allow_link_preview = allow_link_preview;
       Ok(b)

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -544,6 +544,12 @@ r#"Object.defineProperty(window, 'ipc', {
         w.navigate_to_string(&html);
       }
 
+      // Allow Link Preview
+      #[cfg(target_vendor = "apple")]
+      {
+        w.webview.setAllowsLinkPreview(pl_attrs.allow_link_preview);
+      }
+
       // Inject the web view into the window as main content
       #[cfg(target_os = "macos")]
       {

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -545,10 +545,7 @@ r#"Object.defineProperty(window, 'ipc', {
       }
 
       // Allow Link Preview
-      #[cfg(target_vendor = "apple")]
-      {
-        w.webview.setAllowsLinkPreview(pl_attrs.allow_link_preview);
-      }
+      w.webview.setAllowsLinkPreview(pl_attrs.allow_link_preview);
 
       // Inject the web view into the window as main content
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
macOS/iOS: add option to disable or enable link previews when building a webview (the webkit api has it enabled by default)
  - `WebViewBuilderExtDarwin.allow_link_preview(allow_link_preview: bool)`

I personally only need this to disable link previews, so I would be fine with setting a different default for tauri (like turning it off by default). Or even always disable it and don't expose api to change it.

- [x] If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
- [x] Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- [x] Ensure `cargo test` passes.
