### PR TITLE
fix(macos): fix race condition in protocol handlers

### DIFF
--- a/.changes/macos-global-protocol-handlers.md
+++ b/.changes/macos-global-protocol-handlers.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Moved protocol handler functions to a thread local instead of storing them as ivars.

--- a/.changes/macos-global-protocol-handlers.md
+++ b/.changes/macos-global-protocol-handlers.md
@@ -2,4 +2,4 @@
 wry: patch
 ---
 
-Moved protocol handler functions to a thread local instead of storing them as ivars.
+Moved protocol handler functions to a thread local instead of storing them as ivars to prevent a race condition between webview close and custom protocol handling.

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -191,7 +191,17 @@ extern "C" fn start_task(
             return; // If invalid, return early without calling task methods.
           }
 
-          let response = |url: Retained<NSURL>| -> crate::Result<()> {
+          unsafe fn response(
+            // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
+            task: Retained<ProtocolObject<dyn WKURLSchemeTask>>,
+            // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
+            webview: Retained<WryWebView>,
+            task_key: usize,
+            task_uuid: Retained<NSUUID>,
+            webview_id: &str,
+            url: Retained<NSURL>,
+            sent_response: HttpResponse<Cow<'_, [u8]>>,
+          ) -> crate::Result<()> {
             // Validate
             // check_webview_id_valid(webview_id)?;
             check_task_is_valid(&webview, task_key, task_uuid.clone())?;
@@ -278,12 +288,20 @@ extern "C" fn start_task(
                 Err(crate::Error::CustomProtocolTaskInvalid)
               }
             })
-          };
+          }
 
           #[cfg(feature = "tracing")]
           let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
 
-          if let Err(e) = response(url.clone()) {
+          if let Err(e) = response(
+            task,
+            webview,
+            task_key,
+            task_uuid,
+            webview_id,
+            url.clone(),
+            sent_response,
+          ) {
             #[cfg(feature = "tracing")]
             tracing::error!("Error responding to task: {:?}", e);
           }

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -33,8 +33,8 @@ pub fn create(name: &str) -> &AnyClass {
     let cls = ClassBuilder::new(scheme_name, NSObject::class());
     match cls {
       Some(mut cls) => {
-        cls.add_ivar::<*mut c_char>(CStr::from_bytes_with_nul(b"webview_id\0").unwrap());
-        cls.add_ivar::<usize>(CStr::from_bytes_with_nul(b"protocol_i\0").unwrap());
+        cls.add_ivar::<*mut c_char>(c"webview_id");
+        cls.add_ivar::<usize>(c"protocol_i");
         cls.add_method(
           objc2::sel!(webView:startURLSchemeTask:),
           start_task as extern "C" fn(_, _, _, _),
@@ -72,10 +72,7 @@ extern "C" fn start_task(
       .ok()
       .unwrap_or_default();
 
-    let ivar = this
-      .class()
-      .instance_variable(CStr::from_bytes_with_nul(b"protocol_i\0").unwrap())
-      .unwrap();
+    let ivar = this.class().instance_variable(c"protocol_i").unwrap();
     let protocol_i: usize = *ivar.load(this);
 
     let function = WEBVIEW_STATE.with_borrow(|v| {
@@ -84,229 +81,228 @@ extern "C" fn start_task(
         .cloned()
     });
 
-    let Some(function) = function else {
+    if let Some(function) = function {
+      // Get url request
+      let request = task.request();
+      let url = request.URL().unwrap();
+
+      let uri = url.absoluteString().unwrap().to_string();
+
+      #[cfg(feature = "tracing")]
+      span.record("uri", uri.clone());
+
+      // Get request method (GET, POST, PUT etc...)
+      let method = request.HTTPMethod().unwrap().to_string();
+
+      // Prepare our HttpRequest
+      let mut http_request = Request::builder().uri(uri).method(method.as_str());
+
+      // Get body
+      let mut sent_form_body = Vec::new();
+      let body = request.HTTPBody();
+      let body_stream = request.HTTPBodyStream();
+      if let Some(body) = body {
+        sent_form_body = body.to_vec();
+      } else if let Some(body_stream) = body_stream {
+        body_stream.open();
+
+        while body_stream.hasBytesAvailable() {
+          sent_form_body.reserve(128);
+          let p = sent_form_body.as_mut_ptr().add(sent_form_body.len());
+          let read_length = sent_form_body.capacity() - sent_form_body.len();
+          let count = body_stream.read_maxLength(NonNull::new(p).unwrap(), read_length);
+          sent_form_body.set_len(sent_form_body.len() + count as usize);
+        }
+
+        body_stream.close();
+      }
+
+      // Extract all headers fields
+      let all_headers = request.allHTTPHeaderFields();
+
+      // get all our headers values and inject them in our request
+      if let Some(all_headers) = all_headers {
+        for current_header in all_headers.allKeys().to_vec() {
+          let header_value = all_headers.valueForKey(&current_header).unwrap();
+          // inject the header into the request
+          http_request = http_request.header(current_header.to_string(), header_value.to_string());
+        }
+      }
+
+      let respond_with_404 = || {
+        let urlresponse = NSHTTPURLResponse::alloc();
+        let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
+          urlresponse,
+          &url,
+          StatusCode::NOT_FOUND.as_u16().try_into().unwrap(),
+          Some(&NSString::from_str(
+            format!("{:#?}", Version::HTTP_11).as_str(),
+          )),
+          None,
+        )
+        .unwrap();
+        task.didReceiveResponse(&response);
+        // Finish
+        task.didFinish();
+      };
+
+      /// Task may not live longer than async custom protocol handler.
+      ///
+      /// There are roughly 2 ways to cause segfault:
+      /// 1. Task has stopped. pointer of the task not valid anymore.
+      /// 2. Task had stopped, but the pointer of the task has allocated to a new task.
+      ///    Outdated custom handler may call to the new task instance and cause segfault.
+      fn check_task_is_valid(
+        webview: &WryWebView,
+        task_key: usize,
+        current_uuid: Retained<NSUUID>,
+      ) -> crate::Result<()> {
+        let latest_task_uuid = webview.get_custom_task_uuid(task_key);
+        if let Some(latest_uuid) = latest_task_uuid {
+          if latest_uuid != current_uuid {
+            return Err(crate::Error::CustomProtocolTaskInvalid);
+          }
+        } else {
+          return Err(crate::Error::CustomProtocolTaskInvalid);
+        }
+        Ok(())
+      }
+
+      // send response
+      let Ok(final_request) = http_request.body(sent_form_body) else {
+        return respond_with_404();
+      };
+
+      let webview = webview.retain();
+      let task = task.retain();
+      let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
+        Box::new(move |sent_response| {
+          // Consolidate checks before calling into `did*` methods.
+          let validate = || -> crate::Result<()> {
+            // check_webview_id_valid(webview_id)?;
+            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+            Ok(())
+          };
+
+          // Perform an upfront validation
+          if let Err(e) = validate() {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("Task invalid before sending response: {:?}", e);
+            return; // If invalid, return early without calling task methods.
+          }
+
+          let response = |url: Retained<NSURL>| -> crate::Result<()> {
+            // Validate
+            // check_webview_id_valid(webview_id)?;
+            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+            let content = sent_response.body();
+            // default: application/octet-stream, but should be provided by the client
+            let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
+            // default to 200
+            let wanted_status_code = sent_response.status().as_u16() as i32;
+            // default to HTTP/1.1
+            let wanted_version = format!("{:#?}", sent_response.version());
+
+            let headers = NSMutableDictionary::new();
+            if let Some(mime) = wanted_mime {
+              headers.insert(
+                &*NSString::from_str(CONTENT_TYPE.as_str()),
+                &*NSString::from_str(mime.to_str().unwrap()),
+              );
+            }
+            headers.insert(
+              &*NSString::from_str(CONTENT_LENGTH.as_str()),
+              &*NSString::from_str(&content.len().to_string()),
+            );
+
+            // add headers
+            for (name, value) in sent_response.headers().iter() {
+              if let Ok(value) = value.to_str() {
+                headers.insert(
+                  &*NSString::from_str(name.as_str()),
+                  &*NSString::from_str(value),
+                );
+              }
+            }
+
+            let urlresponse = NSHTTPURLResponse::alloc();
+            let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
+              urlresponse,
+              &url,
+              wanted_status_code.try_into().unwrap(),
+              Some(&NSString::from_str(&wanted_version)),
+              Some(&headers),
+            )
+            .unwrap();
+
+            // Re-validate before calling didReceiveResponse
+            // check_webview_id_valid(webview_id)?;
+            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+            // Use map_err to convert Option<Retained<Exception>> to crate::Error
+            objc2::exception::catch(AssertUnwindSafe(|| {
+              task.didReceiveResponse(&response);
+            }))
+            .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+            // Send data
+            let data = NSData::alloc();
+            // MIGRATE NOTE: we copied the content to the NSData because content will be freed
+            // when out of scope but NSData will also free the content when it's done and cause doube free.
+            let data =
+              NSData::initWithBytes_length(data, content.as_ptr() as *mut c_void, content.len());
+
+            // Check validity again
+            // check_webview_id_valid(webview_id)?;
+            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+            objc2::exception::catch(AssertUnwindSafe(|| {
+              task.didReceiveData(&data);
+            }))
+            .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+            // check_webview_id_valid(webview_id)?;
+            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+            objc2::exception::catch(AssertUnwindSafe(|| {
+              task.didFinish();
+            }))
+            .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+            WEBVIEW_STATE.with_borrow_mut(|ids| {
+              if ids.contains_key(webview_id) {
+                webview.remove_custom_task_key(task_key);
+                Ok(())
+              } else {
+                Err(crate::Error::CustomProtocolTaskInvalid)
+              }
+            })
+          };
+
+          #[cfg(feature = "tracing")]
+          let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
+
+          if let Err(e) = response(url.clone()) {
+            #[cfg(feature = "tracing")]
+            tracing::error!("Error responding to task: {:?}", e);
+          }
+        });
+
+      #[cfg(feature = "tracing")]
+      let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
+
+      function(
+        webview_id,
+        final_request,
+        RequestAsyncResponder { responder },
+      );
+    } else {
       #[cfg(feature = "tracing")]
       tracing::warn!(
         "Either WebView or WebContext instance is dropped! This handler shouldn't be called."
       );
-      return;
     };
-
-    // Get url request
-    let request = task.request();
-    let url = request.URL().unwrap();
-
-    let uri = url.absoluteString().unwrap().to_string();
-
-    #[cfg(feature = "tracing")]
-    span.record("uri", uri.clone());
-
-    // Get request method (GET, POST, PUT etc...)
-    let method = request.HTTPMethod().unwrap().to_string();
-
-    // Prepare our HttpRequest
-    let mut http_request = Request::builder().uri(uri).method(method.as_str());
-
-    // Get body
-    let mut sent_form_body = Vec::new();
-    let body = request.HTTPBody();
-    let body_stream = request.HTTPBodyStream();
-    if let Some(body) = body {
-      sent_form_body = body.to_vec();
-    } else if let Some(body_stream) = body_stream {
-      body_stream.open();
-
-      while body_stream.hasBytesAvailable() {
-        sent_form_body.reserve(128);
-        let p = sent_form_body.as_mut_ptr().add(sent_form_body.len());
-        let read_length = sent_form_body.capacity() - sent_form_body.len();
-        let count = body_stream.read_maxLength(NonNull::new(p).unwrap(), read_length);
-        sent_form_body.set_len(sent_form_body.len() + count as usize);
-      }
-
-      body_stream.close();
-    }
-
-    // Extract all headers fields
-    let all_headers = request.allHTTPHeaderFields();
-
-    // get all our headers values and inject them in our request
-    if let Some(all_headers) = all_headers {
-      for current_header in all_headers.allKeys().to_vec() {
-        let header_value = all_headers.valueForKey(&current_header).unwrap();
-        // inject the header into the request
-        http_request = http_request.header(current_header.to_string(), header_value.to_string());
-      }
-    }
-
-    let respond_with_404 = || {
-      let urlresponse = NSHTTPURLResponse::alloc();
-      let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
-        urlresponse,
-        &url,
-        StatusCode::NOT_FOUND.as_u16().try_into().unwrap(),
-        Some(&NSString::from_str(
-          format!("{:#?}", Version::HTTP_11).as_str(),
-        )),
-        None,
-      )
-      .unwrap();
-      task.didReceiveResponse(&response);
-      // Finish
-      task.didFinish();
-    };
-
-    /// Task may not live longer than async custom protocol handler.
-    ///
-    /// There are roughly 2 ways to cause segfault:
-    /// 1. Task has stopped. pointer of the task not valid anymore.
-    /// 2. Task had stopped, but the pointer of the task has allocated to a new task.
-    ///    Outdated custom handler may call to the new task instance and cause segfault.
-    fn check_task_is_valid(
-      webview: &WryWebView,
-      task_key: usize,
-      current_uuid: Retained<NSUUID>,
-    ) -> crate::Result<()> {
-      let latest_task_uuid = webview.get_custom_task_uuid(task_key);
-      if let Some(latest_uuid) = latest_task_uuid {
-        if latest_uuid != current_uuid {
-          return Err(crate::Error::CustomProtocolTaskInvalid);
-        }
-      } else {
-        return Err(crate::Error::CustomProtocolTaskInvalid);
-      }
-      Ok(())
-    }
-
-    // send response
-    let Ok(final_request) = http_request.body(sent_form_body) else {
-      return respond_with_404();
-    };
-
-    let webview = webview.retain();
-    let task = task.retain();
-    let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
-      Box::new(move |sent_response| {
-        // Consolidate checks before calling into `did*` methods.
-        let validate = || -> crate::Result<()> {
-          // check_webview_id_valid(webview_id)?;
-          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-          Ok(())
-        };
-
-        // Perform an upfront validation
-        if let Err(e) = validate() {
-          #[cfg(feature = "tracing")]
-          tracing::warn!("Task invalid before sending response: {:?}", e);
-          return; // If invalid, return early without calling task methods.
-        }
-
-        let response = |url: Retained<NSURL>| -> crate::Result<()> {
-          // Validate
-          // check_webview_id_valid(webview_id)?;
-          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-          let content = sent_response.body();
-          // default: application/octet-stream, but should be provided by the client
-          let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
-          // default to 200
-          let wanted_status_code = sent_response.status().as_u16() as i32;
-          // default to HTTP/1.1
-          let wanted_version = format!("{:#?}", sent_response.version());
-
-          let headers = NSMutableDictionary::new();
-          if let Some(mime) = wanted_mime {
-            headers.insert(
-              &*NSString::from_str(CONTENT_TYPE.as_str()),
-              &*NSString::from_str(mime.to_str().unwrap()),
-            );
-          }
-          headers.insert(
-            &*NSString::from_str(CONTENT_LENGTH.as_str()),
-            &*NSString::from_str(&content.len().to_string()),
-          );
-
-          // add headers
-          for (name, value) in sent_response.headers().iter() {
-            if let Ok(value) = value.to_str() {
-              headers.insert(
-                &*NSString::from_str(name.as_str()),
-                &*NSString::from_str(value),
-              );
-            }
-          }
-
-          let urlresponse = NSHTTPURLResponse::alloc();
-          let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
-            urlresponse,
-            &url,
-            wanted_status_code.try_into().unwrap(),
-            Some(&NSString::from_str(&wanted_version)),
-            Some(&headers),
-          )
-          .unwrap();
-
-          // Re-validate before calling didReceiveResponse
-          // check_webview_id_valid(webview_id)?;
-          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-          // Use map_err to convert Option<Retained<Exception>> to crate::Error
-          objc2::exception::catch(AssertUnwindSafe(|| {
-            task.didReceiveResponse(&response);
-          }))
-          .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-          // Send data
-          let data = NSData::alloc();
-          // MIGRATE NOTE: we copied the content to the NSData because content will be freed
-          // when out of scope but NSData will also free the content when it's done and cause doube free.
-          let data =
-            NSData::initWithBytes_length(data, content.as_ptr() as *mut c_void, content.len());
-
-          // Check validity again
-          // check_webview_id_valid(webview_id)?;
-          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-          objc2::exception::catch(AssertUnwindSafe(|| {
-            task.didReceiveData(&data);
-          }))
-          .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-          // check_webview_id_valid(webview_id)?;
-          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-          objc2::exception::catch(AssertUnwindSafe(|| {
-            task.didFinish();
-          }))
-          .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-          WEBVIEW_STATE.with_borrow_mut(|ids| {
-            if ids.contains_key(webview_id) {
-              webview.remove_custom_task_key(task_key);
-              Ok(())
-            } else {
-              Err(crate::Error::CustomProtocolTaskInvalid)
-            }
-          })
-        };
-
-        #[cfg(feature = "tracing")]
-        let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
-
-        if let Err(e) = response(url.clone()) {
-          #[cfg(feature = "tracing")]
-          tracing::error!("Error responding to task: {:?}", e);
-        }
-      });
-
-    #[cfg(feature = "tracing")]
-    let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
-
-    function(
-      webview_id,
-      final_request,
-      RequestAsyncResponder { responder },
-    );
   }
 }
 

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -146,6 +146,13 @@ extern "C" fn start_task(
         task.didFinish();
       };
 
+      fn check_webview_id_valid(webview_id: &str) -> crate::Result<()> {
+        if !WEBVIEW_STATE.with_borrow(|s| s.contains_key(webview_id)) {
+          return Err(crate::Error::CustomProtocolTaskInvalid);
+        }
+        Ok(())
+      }
+
       /// Task may not live longer than async custom protocol handler.
       ///
       /// There are roughly 2 ways to cause segfault:
@@ -177,15 +184,15 @@ extern "C" fn start_task(
             Box::new(move |sent_response| {
               // Consolidate checks before calling into `did*` methods.
               let validate = || -> crate::Result<()> {
-                // check_webview_id_valid(webview_id)?;
+                check_webview_id_valid(webview_id)?;
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
                 Ok(())
               };
 
               // Perform an upfront validation
-              if let Err(e) = validate() {
+              if let Err(_e) = validate() {
                 #[cfg(feature = "tracing")]
-                tracing::warn!("Task invalid before sending response: {:?}", e);
+                tracing::warn!("Task invalid before sending response: {:?}", _e);
                 return; // If invalid, return early without calling task methods.
               }
 
@@ -201,7 +208,7 @@ extern "C" fn start_task(
                 sent_response: HttpResponse<Cow<'_, [u8]>>,
               ) -> crate::Result<()> {
                 // Validate
-                // check_webview_id_valid(webview_id)?;
+                check_webview_id_valid(webview_id)?;
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
 
                 let content = sent_response.body();
@@ -245,7 +252,7 @@ extern "C" fn start_task(
                 .unwrap();
 
                 // Re-validate before calling didReceiveResponse
-                // check_webview_id_valid(webview_id)?;
+                check_webview_id_valid(webview_id)?;
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
 
                 // Use map_err to convert Option<Retained<Exception>> to crate::Error
@@ -265,7 +272,7 @@ extern "C" fn start_task(
                 );
 
                 // Check validity again
-                // check_webview_id_valid(webview_id)?;
+                check_webview_id_valid(webview_id)?;
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
 
                 objc2::exception::catch(AssertUnwindSafe(|| {
@@ -273,7 +280,7 @@ extern "C" fn start_task(
                 }))
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
-                // check_webview_id_valid(webview_id)?;
+                check_webview_id_valid(webview_id)?;
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
 
                 objc2::exception::catch(AssertUnwindSafe(|| {
@@ -294,7 +301,7 @@ extern "C" fn start_task(
               #[cfg(feature = "tracing")]
               let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
 
-              if let Err(e) = response(
+              if let Err(_e) = response(
                 task,
                 webview,
                 task_key,
@@ -304,7 +311,7 @@ extern "C" fn start_task(
                 sent_response,
               ) {
                 #[cfg(feature = "tracing")]
-                tracing::error!("Error responding to task: {:?}", e);
+                tracing::error!("Error responding to task: {:?}", _e);
               }
             });
 

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -169,152 +169,156 @@ extern "C" fn start_task(
       }
 
       // send response
-      let Ok(final_request) = http_request.body(sent_form_body) else {
-        return respond_with_404();
-      };
-
-      let webview = webview.retain();
-      let task = task.retain();
-      let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
-        Box::new(move |sent_response| {
-          // Consolidate checks before calling into `did*` methods.
-          let validate = || -> crate::Result<()> {
-            // check_webview_id_valid(webview_id)?;
-            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-            Ok(())
-          };
-
-          // Perform an upfront validation
-          if let Err(e) = validate() {
-            #[cfg(feature = "tracing")]
-            tracing::warn!("Task invalid before sending response: {:?}", e);
-            return; // If invalid, return early without calling task methods.
-          }
-
-          unsafe fn response(
-            // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
-            task: Retained<ProtocolObject<dyn WKURLSchemeTask>>,
-            // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
-            webview: Retained<WryWebView>,
-            task_key: usize,
-            task_uuid: Retained<NSUUID>,
-            webview_id: &str,
-            url: Retained<NSURL>,
-            sent_response: HttpResponse<Cow<'_, [u8]>>,
-          ) -> crate::Result<()> {
-            // Validate
-            // check_webview_id_valid(webview_id)?;
-            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-            let content = sent_response.body();
-            // default: application/octet-stream, but should be provided by the client
-            let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
-            // default to 200
-            let wanted_status_code = sent_response.status().as_u16() as i32;
-            // default to HTTP/1.1
-            let wanted_version = format!("{:#?}", sent_response.version());
-
-            let headers = NSMutableDictionary::new();
-            if let Some(mime) = wanted_mime {
-              headers.insert(
-                &*NSString::from_str(CONTENT_TYPE.as_str()),
-                &*NSString::from_str(mime.to_str().unwrap()),
-              );
-            }
-            headers.insert(
-              &*NSString::from_str(CONTENT_LENGTH.as_str()),
-              &*NSString::from_str(&content.len().to_string()),
-            );
-
-            // add headers
-            for (name, value) in sent_response.headers().iter() {
-              if let Ok(value) = value.to_str() {
-                headers.insert(
-                  &*NSString::from_str(name.as_str()),
-                  &*NSString::from_str(value),
-                );
-              }
-            }
-
-            let urlresponse = NSHTTPURLResponse::alloc();
-            let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
-              urlresponse,
-              &url,
-              wanted_status_code.try_into().unwrap(),
-              Some(&NSString::from_str(&wanted_version)),
-              Some(&headers),
-            )
-            .unwrap();
-
-            // Re-validate before calling didReceiveResponse
-            // check_webview_id_valid(webview_id)?;
-            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-            // Use map_err to convert Option<Retained<Exception>> to crate::Error
-            objc2::exception::catch(AssertUnwindSafe(|| {
-              task.didReceiveResponse(&response);
-            }))
-            .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-            // Send data
-            let data = NSData::alloc();
-            // MIGRATE NOTE: we copied the content to the NSData because content will be freed
-            // when out of scope but NSData will also free the content when it's done and cause doube free.
-            let data =
-              NSData::initWithBytes_length(data, content.as_ptr() as *mut c_void, content.len());
-
-            // Check validity again
-            // check_webview_id_valid(webview_id)?;
-            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-            objc2::exception::catch(AssertUnwindSafe(|| {
-              task.didReceiveData(&data);
-            }))
-            .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-            // check_webview_id_valid(webview_id)?;
-            check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-            objc2::exception::catch(AssertUnwindSafe(|| {
-              task.didFinish();
-            }))
-            .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-            WEBVIEW_STATE.with_borrow_mut(|ids| {
-              if ids.contains_key(webview_id) {
-                webview.remove_custom_task_key(task_key);
+      match http_request.body(sent_form_body) {
+        Ok(final_request) => {
+          let webview = webview.retain();
+          let task = task.retain();
+          let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
+            Box::new(move |sent_response| {
+              // Consolidate checks before calling into `did*` methods.
+              let validate = || -> crate::Result<()> {
+                // check_webview_id_valid(webview_id)?;
+                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
                 Ok(())
-              } else {
-                Err(crate::Error::CustomProtocolTaskInvalid)
+              };
+
+              // Perform an upfront validation
+              if let Err(e) = validate() {
+                #[cfg(feature = "tracing")]
+                tracing::warn!("Task invalid before sending response: {:?}", e);
+                return; // If invalid, return early without calling task methods.
               }
-            })
-          }
+
+              unsafe fn response(
+                // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
+                task: Retained<ProtocolObject<dyn WKURLSchemeTask>>,
+                // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
+                webview: Retained<WryWebView>,
+                task_key: usize,
+                task_uuid: Retained<NSUUID>,
+                webview_id: &str,
+                url: Retained<NSURL>,
+                sent_response: HttpResponse<Cow<'_, [u8]>>,
+              ) -> crate::Result<()> {
+                // Validate
+                // check_webview_id_valid(webview_id)?;
+                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+                let content = sent_response.body();
+                // default: application/octet-stream, but should be provided by the client
+                let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
+                // default to 200
+                let wanted_status_code = sent_response.status().as_u16() as i32;
+                // default to HTTP/1.1
+                let wanted_version = format!("{:#?}", sent_response.version());
+
+                let headers = NSMutableDictionary::new();
+                if let Some(mime) = wanted_mime {
+                  headers.insert(
+                    &*NSString::from_str(CONTENT_TYPE.as_str()),
+                    &*NSString::from_str(mime.to_str().unwrap()),
+                  );
+                }
+                headers.insert(
+                  &*NSString::from_str(CONTENT_LENGTH.as_str()),
+                  &*NSString::from_str(&content.len().to_string()),
+                );
+
+                // add headers
+                for (name, value) in sent_response.headers().iter() {
+                  if let Ok(value) = value.to_str() {
+                    headers.insert(
+                      &*NSString::from_str(name.as_str()),
+                      &*NSString::from_str(value),
+                    );
+                  }
+                }
+
+                let urlresponse = NSHTTPURLResponse::alloc();
+                let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
+                  urlresponse,
+                  &url,
+                  wanted_status_code.try_into().unwrap(),
+                  Some(&NSString::from_str(&wanted_version)),
+                  Some(&headers),
+                )
+                .unwrap();
+
+                // Re-validate before calling didReceiveResponse
+                // check_webview_id_valid(webview_id)?;
+                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+                // Use map_err to convert Option<Retained<Exception>> to crate::Error
+                objc2::exception::catch(AssertUnwindSafe(|| {
+                  task.didReceiveResponse(&response);
+                }))
+                .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+                // Send data
+                let data = NSData::alloc();
+                // MIGRATE NOTE: we copied the content to the NSData because content will be freed
+                // when out of scope but NSData will also free the content when it's done and cause doube free.
+                let data = NSData::initWithBytes_length(
+                  data,
+                  content.as_ptr() as *mut c_void,
+                  content.len(),
+                );
+
+                // Check validity again
+                // check_webview_id_valid(webview_id)?;
+                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+                objc2::exception::catch(AssertUnwindSafe(|| {
+                  task.didReceiveData(&data);
+                }))
+                .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+                // check_webview_id_valid(webview_id)?;
+                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+                objc2::exception::catch(AssertUnwindSafe(|| {
+                  task.didFinish();
+                }))
+                .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+                WEBVIEW_STATE.with_borrow_mut(|ids| {
+                  if ids.contains_key(webview_id) {
+                    webview.remove_custom_task_key(task_key);
+                    Ok(())
+                  } else {
+                    Err(crate::Error::CustomProtocolTaskInvalid)
+                  }
+                })
+              }
+
+              #[cfg(feature = "tracing")]
+              let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
+
+              if let Err(e) = response(
+                task,
+                webview,
+                task_key,
+                task_uuid,
+                webview_id,
+                url.clone(),
+                sent_response,
+              ) {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Error responding to task: {:?}", e);
+              }
+            });
 
           #[cfg(feature = "tracing")]
           let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
 
-          if let Err(e) = response(
-            task,
-            webview,
-            task_key,
-            task_uuid,
+          function(
             webview_id,
-            url.clone(),
-            sent_response,
-          ) {
-            #[cfg(feature = "tracing")]
-            tracing::error!("Error responding to task: {:?}", e);
-          }
-        });
-
-      #[cfg(feature = "tracing")]
-      let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
-
-      function(
-        webview_id,
-        final_request,
-        RequestAsyncResponder { responder },
-      );
+            final_request,
+            RequestAsyncResponder { responder },
+          );
+        }
+        Err(_) => respond_with_404(),
+      };
     } else {
       #[cfg(feature = "tracing")]
       tracing::warn!(

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -24,7 +24,7 @@ use objc2_foundation::{
 };
 use objc2_web_kit::{WKURLSchemeHandler, WKURLSchemeTask};
 
-use crate::{wkwebview::WEBVIEW_IDS, RequestAsyncResponder, WryWebView};
+use crate::{wkwebview::WEBVIEW_STATE, RequestAsyncResponder, WryWebView};
 
 pub fn create(name: &str) -> &AnyClass {
   unsafe {
@@ -33,8 +33,8 @@ pub fn create(name: &str) -> &AnyClass {
     let cls = ClassBuilder::new(scheme_name, NSObject::class());
     match cls {
       Some(mut cls) => {
-        cls.add_ivar::<*mut c_void>(c"function");
-        cls.add_ivar::<*mut c_char>(c"webview_id");
+        cls.add_ivar::<*mut c_char>(CStr::from_bytes_with_nul(b"webview_id\0").unwrap());
+        cls.add_ivar::<usize>(CStr::from_bytes_with_nul(b"protocol_i\0").unwrap());
         cls.add_method(
           objc2::sel!(webView:startURLSchemeTask:),
           start_task as extern "C" fn(_, _, _, _),
@@ -72,262 +72,241 @@ extern "C" fn start_task(
       .ok()
       .unwrap_or_default();
 
-    let ivar = this.class().instance_variable(c"function").unwrap();
-    let function: &*mut c_void = ivar.load(this);
-    if !function.is_null() {
-      let function = &mut *(*function
-        as *mut Box<dyn Fn(crate::WebViewId, Request<Vec<u8>>, RequestAsyncResponder)>);
+    let ivar = this
+      .class()
+      .instance_variable(CStr::from_bytes_with_nul(b"protocol_i\0").unwrap())
+      .unwrap();
+    let protocol_i: usize = *ivar.load(this);
 
-      // Get url request
-      let request = task.request();
-      let url = request.URL().unwrap();
+    let function = WEBVIEW_STATE.with_borrow(|v| {
+      v.get(webview_id)
+        .and_then(|v| v.protocol_ptrs.get(protocol_i))
+        .cloned()
+    });
 
-      let uri = url.absoluteString().unwrap().to_string();
-
-      #[cfg(feature = "tracing")]
-      span.record("uri", uri.clone());
-
-      // Get request method (GET, POST, PUT etc...)
-      let method = request.HTTPMethod().unwrap().to_string();
-
-      // Prepare our HttpRequest
-      let mut http_request = Request::builder().uri(uri).method(method.as_str());
-
-      // Get body
-      let mut sent_form_body = Vec::new();
-      let body = request.HTTPBody();
-      let body_stream = request.HTTPBodyStream();
-      if let Some(body) = body {
-        sent_form_body = body.to_vec();
-      } else if let Some(body_stream) = body_stream {
-        body_stream.open();
-
-        while body_stream.hasBytesAvailable() {
-          sent_form_body.reserve(128);
-          let p = sent_form_body.as_mut_ptr().add(sent_form_body.len());
-          let read_length = sent_form_body.capacity() - sent_form_body.len();
-          let count = body_stream.read_maxLength(NonNull::new(p).unwrap(), read_length);
-          sent_form_body.set_len(sent_form_body.len() + count as usize);
-        }
-
-        body_stream.close();
-      }
-
-      // Extract all headers fields
-      let all_headers = request.allHTTPHeaderFields();
-
-      // get all our headers values and inject them in our request
-      if let Some(all_headers) = all_headers {
-        for current_header in all_headers.allKeys().to_vec() {
-          let header_value = all_headers.valueForKey(&current_header).unwrap();
-          // inject the header into the request
-          http_request = http_request.header(current_header.to_string(), header_value.to_string());
-        }
-      }
-
-      let respond_with_404 = || {
-        let urlresponse = NSHTTPURLResponse::alloc();
-        let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
-          urlresponse,
-          &url,
-          StatusCode::NOT_FOUND.as_u16().try_into().unwrap(),
-          Some(&NSString::from_str(
-            format!("{:#?}", Version::HTTP_11).as_str(),
-          )),
-          None,
-        )
-        .unwrap();
-        task.didReceiveResponse(&response);
-        // Finish
-        task.didFinish();
-      };
-
-      fn check_webview_id_valid(webview_id: &str) -> crate::Result<()> {
-        if !WEBVIEW_IDS.lock().unwrap().contains(webview_id) {
-          return Err(crate::Error::CustomProtocolTaskInvalid);
-        }
-        Ok(())
-      }
-
-      /// Task may not live longer than async custom protocol handler.
-      ///
-      /// There are roughly 2 ways to cause segfault:
-      /// 1. Task has stopped. pointer of the task not valid anymore.
-      /// 2. Task had stopped, but the pointer of the task has allocated to a new task.
-      ///    Outdated custom handler may call to the new task instance and cause segfault.
-      fn check_task_is_valid(
-        webview: &WryWebView,
-        task_key: usize,
-        current_uuid: Retained<NSUUID>,
-      ) -> crate::Result<()> {
-        let latest_task_uuid = webview.get_custom_task_uuid(task_key);
-        if let Some(latest_uuid) = latest_task_uuid {
-          if latest_uuid != current_uuid {
-            return Err(crate::Error::CustomProtocolTaskInvalid);
-          }
-        } else {
-          return Err(crate::Error::CustomProtocolTaskInvalid);
-        }
-        Ok(())
-      }
-
-      // send response
-      match http_request.body(sent_form_body) {
-        Ok(final_request) => {
-          let webview = webview.retain();
-          let task = task.retain();
-          let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
-            Box::new(move |sent_response| {
-              // Consolidate checks before calling into `did*` methods.
-              let validate = || -> crate::Result<()> {
-                check_webview_id_valid(webview_id)?;
-                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-                Ok(())
-              };
-
-              // Perform an upfront validation
-              if let Err(_e) = validate() {
-                #[cfg(feature = "tracing")]
-                tracing::warn!("Task invalid before sending response: {:?}", _e);
-                return; // If invalid, return early without calling task methods.
-              }
-
-              unsafe fn response(
-                // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
-                task: Retained<ProtocolObject<dyn WKURLSchemeTask>>,
-                // FIXME: though we give it a static lifetime, it's not guaranteed to be valid.
-                webview: Retained<WryWebView>,
-                task_key: usize,
-                task_uuid: Retained<NSUUID>,
-                webview_id: &str,
-                url: Retained<NSURL>,
-                sent_response: HttpResponse<Cow<'_, [u8]>>,
-              ) -> crate::Result<()> {
-                // Validate
-                check_webview_id_valid(webview_id)?;
-                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-                let content = sent_response.body();
-                // default: application/octet-stream, but should be provided by the client
-                let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
-                // default to 200
-                let wanted_status_code = sent_response.status().as_u16() as i32;
-                // default to HTTP/1.1
-                let wanted_version = format!("{:#?}", sent_response.version());
-
-                let headers = NSMutableDictionary::new();
-                if let Some(mime) = wanted_mime {
-                  headers.insert(
-                    &*NSString::from_str(CONTENT_TYPE.as_str()),
-                    &*NSString::from_str(mime.to_str().unwrap()),
-                  );
-                }
-                headers.insert(
-                  &*NSString::from_str(CONTENT_LENGTH.as_str()),
-                  &*NSString::from_str(&content.len().to_string()),
-                );
-
-                // add headers
-                for (name, value) in sent_response.headers().iter() {
-                  if let Ok(value) = value.to_str() {
-                    headers.insert(
-                      &*NSString::from_str(name.as_str()),
-                      &*NSString::from_str(value),
-                    );
-                  }
-                }
-
-                let urlresponse = NSHTTPURLResponse::alloc();
-                let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
-                  urlresponse,
-                  &url,
-                  wanted_status_code.try_into().unwrap(),
-                  Some(&NSString::from_str(&wanted_version)),
-                  Some(&headers),
-                )
-                .unwrap();
-
-                // Re-validate before calling didReceiveResponse
-                check_webview_id_valid(webview_id)?;
-                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-                // Use map_err to convert Option<Retained<Exception>> to crate::Error
-                objc2::exception::catch(AssertUnwindSafe(|| {
-                  task.didReceiveResponse(&response);
-                }))
-                .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-                // Send data
-                let data = NSData::alloc();
-                // MIGRATE NOTE: we copied the content to the NSData because content will be freed
-                // when out of scope but NSData will also free the content when it's done and cause doube free.
-                let data = NSData::initWithBytes_length(
-                  data,
-                  content.as_ptr() as *mut c_void,
-                  content.len(),
-                );
-
-                // Check validity again
-                check_webview_id_valid(webview_id)?;
-                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-                objc2::exception::catch(AssertUnwindSafe(|| {
-                  task.didReceiveData(&data);
-                }))
-                .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-                check_webview_id_valid(webview_id)?;
-                check_task_is_valid(&webview, task_key, task_uuid.clone())?;
-
-                objc2::exception::catch(AssertUnwindSafe(|| {
-                  task.didFinish();
-                }))
-                .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
-
-                {
-                  let ids = WEBVIEW_IDS.lock().unwrap();
-                  if ids.contains(webview_id) {
-                    webview.remove_custom_task_key(task_key);
-                    Ok(())
-                  } else {
-                    Err(crate::Error::CustomProtocolTaskInvalid)
-                  }
-                }
-              }
-
-              #[cfg(feature = "tracing")]
-              let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
-
-              if let Err(_e) = response(
-                task,
-                webview,
-                task_key,
-                task_uuid,
-                webview_id,
-                url.clone(),
-                sent_response,
-              ) {
-                #[cfg(feature = "tracing")]
-                tracing::error!("Error responding to task: {:?}", _e);
-              }
-            });
-
-          #[cfg(feature = "tracing")]
-          let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
-          function(
-            webview_id,
-            final_request,
-            RequestAsyncResponder { responder },
-          );
-        }
-        Err(_) => respond_with_404(),
-      };
-    } else {
+    let Some(function) = function else {
       #[cfg(feature = "tracing")]
       tracing::warn!(
         "Either WebView or WebContext instance is dropped! This handler shouldn't be called."
       );
+      return;
+    };
+
+    // Get url request
+    let request = task.request();
+    let url = request.URL().unwrap();
+
+    let uri = url.absoluteString().unwrap().to_string();
+
+    #[cfg(feature = "tracing")]
+    span.record("uri", uri.clone());
+
+    // Get request method (GET, POST, PUT etc...)
+    let method = request.HTTPMethod().unwrap().to_string();
+
+    // Prepare our HttpRequest
+    let mut http_request = Request::builder().uri(uri).method(method.as_str());
+
+    // Get body
+    let mut sent_form_body = Vec::new();
+    let body = request.HTTPBody();
+    let body_stream = request.HTTPBodyStream();
+    if let Some(body) = body {
+      sent_form_body = body.to_vec();
+    } else if let Some(body_stream) = body_stream {
+      body_stream.open();
+
+      while body_stream.hasBytesAvailable() {
+        sent_form_body.reserve(128);
+        let p = sent_form_body.as_mut_ptr().add(sent_form_body.len());
+        let read_length = sent_form_body.capacity() - sent_form_body.len();
+        let count = body_stream.read_maxLength(NonNull::new(p).unwrap(), read_length);
+        sent_form_body.set_len(sent_form_body.len() + count as usize);
+      }
+
+      body_stream.close();
     }
+
+    // Extract all headers fields
+    let all_headers = request.allHTTPHeaderFields();
+
+    // get all our headers values and inject them in our request
+    if let Some(all_headers) = all_headers {
+      for current_header in all_headers.allKeys().to_vec() {
+        let header_value = all_headers.valueForKey(&current_header).unwrap();
+        // inject the header into the request
+        http_request = http_request.header(current_header.to_string(), header_value.to_string());
+      }
+    }
+
+    let respond_with_404 = || {
+      let urlresponse = NSHTTPURLResponse::alloc();
+      let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
+        urlresponse,
+        &url,
+        StatusCode::NOT_FOUND.as_u16().try_into().unwrap(),
+        Some(&NSString::from_str(
+          format!("{:#?}", Version::HTTP_11).as_str(),
+        )),
+        None,
+      )
+      .unwrap();
+      task.didReceiveResponse(&response);
+      // Finish
+      task.didFinish();
+    };
+
+    /// Task may not live longer than async custom protocol handler.
+    ///
+    /// There are roughly 2 ways to cause segfault:
+    /// 1. Task has stopped. pointer of the task not valid anymore.
+    /// 2. Task had stopped, but the pointer of the task has allocated to a new task.
+    ///    Outdated custom handler may call to the new task instance and cause segfault.
+    fn check_task_is_valid(
+      webview: &WryWebView,
+      task_key: usize,
+      current_uuid: Retained<NSUUID>,
+    ) -> crate::Result<()> {
+      let latest_task_uuid = webview.get_custom_task_uuid(task_key);
+      if let Some(latest_uuid) = latest_task_uuid {
+        if latest_uuid != current_uuid {
+          return Err(crate::Error::CustomProtocolTaskInvalid);
+        }
+      } else {
+        return Err(crate::Error::CustomProtocolTaskInvalid);
+      }
+      Ok(())
+    }
+
+    // send response
+    let Ok(final_request) = http_request.body(sent_form_body) else {
+      return respond_with_404();
+    };
+
+    let webview = webview.retain();
+    let task = task.retain();
+    let responder: Box<dyn FnOnce(HttpResponse<Cow<'static, [u8]>>)> =
+      Box::new(move |sent_response| {
+        // Consolidate checks before calling into `did*` methods.
+        let validate = || -> crate::Result<()> {
+          // check_webview_id_valid(webview_id)?;
+          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+          Ok(())
+        };
+
+        // Perform an upfront validation
+        if let Err(e) = validate() {
+          #[cfg(feature = "tracing")]
+          tracing::warn!("Task invalid before sending response: {:?}", e);
+          return; // If invalid, return early without calling task methods.
+        }
+
+        let response = |url: Retained<NSURL>| -> crate::Result<()> {
+          // Validate
+          // check_webview_id_valid(webview_id)?;
+          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+          let content = sent_response.body();
+          // default: application/octet-stream, but should be provided by the client
+          let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
+          // default to 200
+          let wanted_status_code = sent_response.status().as_u16() as i32;
+          // default to HTTP/1.1
+          let wanted_version = format!("{:#?}", sent_response.version());
+
+          let headers = NSMutableDictionary::new();
+          if let Some(mime) = wanted_mime {
+            headers.insert(
+              &*NSString::from_str(CONTENT_TYPE.as_str()),
+              &*NSString::from_str(mime.to_str().unwrap()),
+            );
+          }
+          headers.insert(
+            &*NSString::from_str(CONTENT_LENGTH.as_str()),
+            &*NSString::from_str(&content.len().to_string()),
+          );
+
+          // add headers
+          for (name, value) in sent_response.headers().iter() {
+            if let Ok(value) = value.to_str() {
+              headers.insert(
+                &*NSString::from_str(name.as_str()),
+                &*NSString::from_str(value),
+              );
+            }
+          }
+
+          let urlresponse = NSHTTPURLResponse::alloc();
+          let response = NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
+            urlresponse,
+            &url,
+            wanted_status_code.try_into().unwrap(),
+            Some(&NSString::from_str(&wanted_version)),
+            Some(&headers),
+          )
+          .unwrap();
+
+          // Re-validate before calling didReceiveResponse
+          // check_webview_id_valid(webview_id)?;
+          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+          // Use map_err to convert Option<Retained<Exception>> to crate::Error
+          objc2::exception::catch(AssertUnwindSafe(|| {
+            task.didReceiveResponse(&response);
+          }))
+          .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+          // Send data
+          let data = NSData::alloc();
+          // MIGRATE NOTE: we copied the content to the NSData because content will be freed
+          // when out of scope but NSData will also free the content when it's done and cause doube free.
+          let data =
+            NSData::initWithBytes_length(data, content.as_ptr() as *mut c_void, content.len());
+
+          // Check validity again
+          // check_webview_id_valid(webview_id)?;
+          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+          objc2::exception::catch(AssertUnwindSafe(|| {
+            task.didReceiveData(&data);
+          }))
+          .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+          // check_webview_id_valid(webview_id)?;
+          check_task_is_valid(&webview, task_key, task_uuid.clone())?;
+
+          objc2::exception::catch(AssertUnwindSafe(|| {
+            task.didFinish();
+          }))
+          .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
+
+          WEBVIEW_STATE.with_borrow_mut(|ids| {
+            if ids.contains_key(webview_id) {
+              webview.remove_custom_task_key(task_key);
+              Ok(())
+            } else {
+              Err(crate::Error::CustomProtocolTaskInvalid)
+            }
+          })
+        };
+
+        #[cfg(feature = "tracing")]
+        let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
+
+        if let Err(e) = response(url.clone()) {
+          #[cfg(feature = "tracing")]
+          tracing::error!("Error responding to task: {:?}", e);
+        }
+      });
+
+    #[cfg(feature = "tracing")]
+    let _span = tracing::info_span!("wry::custom_protocol::call_handler").entered();
+
+    function(
+      webview_id,
+      final_request,
+      RequestAsyncResponder { responder },
+    );
   }
 }
 

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -34,7 +34,7 @@ pub fn create(name: &str) -> &AnyClass {
     match cls {
       Some(mut cls) => {
         cls.add_ivar::<*mut c_char>(c"webview_id");
-        cls.add_ivar::<usize>(c"protocol_i");
+        cls.add_ivar::<usize>(c"protocol_index");
         cls.add_method(
           objc2::sel!(webView:startURLSchemeTask:),
           start_task as extern "C" fn(_, _, _, _),
@@ -72,12 +72,12 @@ extern "C" fn start_task(
       .ok()
       .unwrap_or_default();
 
-    let ivar = this.class().instance_variable(c"protocol_i").unwrap();
-    let protocol_i: usize = *ivar.load(this);
+    let ivar = this.class().instance_variable(c"protocol_index").unwrap();
+    let protocol_index: usize = *ivar.load(this);
 
     let function = WEBVIEW_STATE.with_borrow(|v| {
       v.get(webview_id)
-        .and_then(|v| v.protocol_ptrs.get(protocol_i))
+        .and_then(|v| v.protocol_ptrs.get(protocol_index))
         .cloned()
     });
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -72,15 +72,15 @@ use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use std::{
   cell::RefCell,
-  collections::{HashMap, HashSet},
-  ffi::{c_void, CStr, CString},
+  collections::HashMap,
+  ffi::{CStr, CString},
   net::Ipv4Addr,
   os::raw::c_char,
   panic::AssertUnwindSafe,
   ptr::{null_mut, NonNull},
   rc::Rc,
   str::{self, FromStr},
-  sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+  sync::{Arc, Mutex},
   time::Duration,
 };
 
@@ -230,15 +230,15 @@ impl InnerWebView {
       for (name, function) in attributes.custom_protocols {
         let url_scheme_handler_cls = url_scheme_handler::create(&name);
         let handler: *mut AnyObject = objc2::msg_send![url_scheme_handler_cls, new];
-        let protocol_i = protocol_ptrs.len();
+        let protocol_index = protocol_ptrs.len();
         protocol_ptrs.push(Rc::from(function));
 
         let ivar = (*handler)
           .class()
-          .instance_variable(CStr::from_bytes_with_nul(b"protocol_i\0").unwrap())
+          .instance_variable(CStr::from_bytes_with_nul(b"protocol_index\0").unwrap())
           .unwrap();
         let ivar_delegate: &mut usize = ivar.load_mut(&mut *handler);
-        *ivar_delegate = protocol_i;
+        *ivar_delegate = protocol_index;
 
         let ivar = (*handler).class().instance_variable(c"webview_id").unwrap();
         let ivar_delegate: &mut *mut c_char = ivar.load_mut(&mut *handler);

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -72,14 +72,15 @@ use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use std::{
   cell::RefCell,
-  collections::HashSet,
-  ffi::{c_void, CString},
+  collections::{HashMap, HashSet},
+  ffi::{c_void, CStr, CString},
   net::Ipv4Addr,
   os::raw::c_char,
   panic::AssertUnwindSafe,
   ptr::{null_mut, NonNull},
+  rc::Rc,
   str::{self, FromStr},
-  sync::{Arc, Mutex},
+  sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
   time::Duration,
 };
 
@@ -100,7 +101,14 @@ use http::Request;
 use crate::util::Counter;
 
 static COUNTER: Counter = Counter::new();
-static WEBVIEW_IDS: Lazy<Mutex<HashSet<String>>> = Lazy::new(Default::default);
+
+thread_local! {
+  static WEBVIEW_STATE: RefCell<HashMap<String, WebViewState>> = Default::default();
+}
+
+struct WebViewState {
+  pub protocol_ptrs: Vec<Rc<dyn Fn(crate::WebViewId, Request<Vec<u8>>, RequestAsyncResponder)>>,
+}
 
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PrintMargin {
@@ -140,7 +148,6 @@ pub(crate) struct InnerWebView {
   #[allow(dead_code)]
   // We need this the keep the reference count
   ui_delegate: Retained<WryWebViewUIDelegate>,
-  protocol_ptrs: Vec<*mut Box<dyn Fn(crate::WebViewId, Request<Vec<u8>>, RequestAsyncResponder)>>,
   #[cfg(target_os = "macos")]
   // We need this to update the traffic light inset
   parent_view: Option<Retained<WryWebViewParent>>,
@@ -192,10 +199,6 @@ impl InnerWebView {
       .map(|id| id.to_string())
       .unwrap_or_else(|| COUNTER.next().to_string());
 
-    let mut wv_ids = WEBVIEW_IDS.lock().unwrap();
-    wv_ids.insert(webview_id.clone());
-    drop(wv_ids);
-
     // Safety: objc runtime calls are unsafe
     unsafe {
       let config = WKWebViewConfiguration::new(mtm);
@@ -227,12 +230,15 @@ impl InnerWebView {
       for (name, function) in attributes.custom_protocols {
         let url_scheme_handler_cls = url_scheme_handler::create(&name);
         let handler: *mut AnyObject = objc2::msg_send![url_scheme_handler_cls, new];
-        let function = Box::into_raw(Box::new(function));
-        protocol_ptrs.push(function);
+        let protocol_i = protocol_ptrs.len();
+        protocol_ptrs.push(Rc::from(function));
 
-        let ivar = (*handler).class().instance_variable(c"function").unwrap();
-        let ivar_delegate = ivar.load_mut(&mut *handler);
-        *ivar_delegate = function as *mut _ as *mut c_void;
+        let ivar = (*handler)
+          .class()
+          .instance_variable(CStr::from_bytes_with_nul(b"protocol_i\0").unwrap())
+          .unwrap();
+        let ivar_delegate: &mut usize = ivar.load_mut(&mut *handler);
+        *ivar_delegate = protocol_i;
 
         let ivar = (*handler).class().instance_variable(c"webview_id").unwrap();
         let ivar_delegate: &mut *mut c_char = ivar.load_mut(&mut *handler);
@@ -248,6 +254,10 @@ impl InnerWebView {
           return Err(Error::UrlSchemeRegisterError(name));
         }
       }
+
+      WEBVIEW_STATE.with_borrow_mut(|wv_ids| {
+        wv_ids.insert(webview_id.clone(), WebViewState { protocol_ptrs });
+      });
 
       // WebView and manager
       let manager = config.userContentController();
@@ -509,7 +519,6 @@ impl InnerWebView {
         navigation_policy_delegate,
         download_delegate,
         ui_delegate,
-        protocol_ptrs,
         is_child,
         #[cfg(target_os = "macos")]
         parent_view: None,
@@ -1081,7 +1090,7 @@ pub fn platform_webview_version() -> Result<String> {
 
 impl Drop for InnerWebView {
   fn drop(&mut self) {
-    WEBVIEW_IDS.lock().unwrap().remove(&self.id);
+    WEBVIEW_STATE.with_borrow_mut(|v| v.remove(&self.id));
 
     // We need to drop handler closures here
     unsafe {
@@ -1092,12 +1101,6 @@ impl Drop for InnerWebView {
           .ivars()
           .controller
           .removeScriptMessageHandlerForName(&ipc);
-      }
-
-      for ptr in self.protocol_ptrs.iter() {
-        if !ptr.is_null() {
-          drop(Box::from_raw(*ptr));
-        }
       }
 
       // Remove webview from window's NSView before dropping.


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Recent fixes have wiped out a whole class of crashing problems for us, but the one that remains is the edge case that is actually described in this issue for a while ago: https://github.com/tauri-apps/wry/issues/371
In short, there are cases where the `function` ivar on protocols are accessed after the handler functions have been deallocated by `InnerWebView::drop`, but there's no check for whether the function pointer is valid or not, occasionally causing a segfault.
To remedy this I've extended the `WEBVIEW_IDS` global to `WEBVIEW_STATE`, now holding the webview's protocol functions. Each protocol handler now has an ivar that stores the index of its handler function on its target webview's global state. When a protocol handler needs to invoke its function, it must get the function from global state and add to the function's reference counter, so the function pointer will never be dropped until it's 100% done being used.