### PR TITLE
fix(macos): Handle flipped coordinate system of a parent view

### DIFF
--- a/.changes/macos-handle-flipped-coordinates.md
+++ b/.changes/macos-handle-flipped-coordinates.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+macOS: Handle flipped coordinates when adding a WebView as a child

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1115,7 +1115,18 @@ impl Drop for InnerWebView {
 ///   Flipped coordinate system: a top-left is (0, 0) and y increasing downwards.
 #[allow(dead_code)]
 unsafe fn window_position(view: &NSView, x: i32, y: i32, height: f64) -> CGPoint {
-  if view.isFlipped() {
+  let is_flipped = {
+    #[cfg(target_os = "macos")]
+    {
+      view.isFlipped()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+      false
+    }
+  };
+
+  if is_flipped {
     CGPoint::new(x as f64, y as f64)
   } else {
     let frame: CGRect = view.frame();

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1110,11 +1110,17 @@ impl Drop for InnerWebView {
 
 /// Converts from wry screen-coordinates to macOS screen-coordinates.
 /// wry: top-left is (0, 0) and y increasing downwards
-/// macOS: bottom-left is (0, 0) and y increasing upwards
+/// macOS:
+///   Default coordinate system: a bottom-left is (0, 0) and y increasing upwards.
+///   Flipped coordinate system: a top-left is (0, 0) and y increasing downwards.
 #[allow(dead_code)]
 unsafe fn window_position(view: &NSView, x: i32, y: i32, height: f64) -> CGPoint {
-  let frame: CGRect = view.frame();
-  CGPoint::new(x as f64, frame.size.height - y as f64 - height)
+  if view.isFlipped() {
+    CGPoint::new(x as f64, y as f64)
+  } else {
+    let frame: CGRect = view.frame();
+    CGPoint::new(x as f64, frame.size.height - y as f64 - height)
+  }
 }
 
 /// Wait synchronously for the NSRunLoop to run until a receiver has a message.


### PR DESCRIPTION
Hi

On macOS, in a default (non-flipped) coordinate system, the origin is in the lower-left corner of the view and positive y-values extend upward. `wry` converts positions from its own coordinate system to the one defined on macOS. However, it   assumes that all coordinate systems on macOS are non-flipped, which is not always the case. This PR extends `window_position` with an [isFlipped](https://developer.apple.com/documentation/appkit/nsview/isflipped) check to also support flipped coordinate systems.

As a consequence, it fixes a positioning issue when adding a WebView to a `winit v0.30+`window as a child.