### PR TITLE
fix: async custom protocol not responding

### DIFF
--- a/.changes/fix-async-custom-protocol.md
+++ b/.changes/fix-async-custom-protocol.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix async custom protocol not responding.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -55,6 +55,7 @@ use objc2_ui_kit::{UIScrollView, UIViewAutoresizing};
 use objc2_app_kit::NSWindow;
 #[cfg(target_os = "ios")]
 use objc2_ui_kit::UIView as NSView;
+use once_cell::sync::Lazy;
 // #[cfg(target_os = "ios")]
 // use objc2_ui_kit::UIWindow as NSWindow;
 
@@ -79,7 +80,7 @@ use std::{
   ptr::{null_mut, NonNull},
   rc::Rc,
   str::{self, FromStr},
-  sync::{Arc, LazyLock, Mutex, RwLock},
+  sync::{Arc, Mutex, RwLock},
   time::Duration,
 };
 
@@ -101,8 +102,7 @@ use crate::util::Counter;
 
 static COUNTER: Counter = Counter::new();
 
-static WEBVIEW_STATE: LazyLock<RwLock<HashMap<String, WebViewState>>> =
-  LazyLock::new(Default::default);
+static WEBVIEW_STATE: Lazy<RwLock<HashMap<String, WebViewState>>> = Lazy::new(Default::default);
 
 struct WebViewState {
   pub protocol_ptrs: Vec<Rc<dyn Fn(crate::WebViewId, Request<Vec<u8>>, RequestAsyncResponder)>>,

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -67,7 +67,6 @@ use objc2_web_kit::{
   WKAudiovisualMediaTypes, WKInactiveSchedulingPolicy, WKURLSchemeHandler, WKUserContentController,
   WKUserScript, WKUserScriptInjectionTime, WKWebViewConfiguration, WKWebsiteDataStore,
 };
-use once_cell::sync::Lazy;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use std::{
@@ -80,7 +79,7 @@ use std::{
   ptr::{null_mut, NonNull},
   rc::Rc,
   str::{self, FromStr},
-  sync::{Arc, Mutex},
+  sync::{Arc, LazyLock, Mutex, RwLock},
   time::Duration,
 };
 
@@ -102,13 +101,15 @@ use crate::util::Counter;
 
 static COUNTER: Counter = Counter::new();
 
-thread_local! {
-  static WEBVIEW_STATE: RefCell<HashMap<String, WebViewState>> = Default::default();
-}
+static WEBVIEW_STATE: LazyLock<RwLock<HashMap<String, WebViewState>>> =
+  LazyLock::new(Default::default);
 
 struct WebViewState {
   pub protocol_ptrs: Vec<Rc<dyn Fn(crate::WebViewId, Request<Vec<u8>>, RequestAsyncResponder)>>,
 }
+
+unsafe impl Send for WebViewState {}
+unsafe impl Sync for WebViewState {}
 
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PrintMargin {
@@ -255,9 +256,10 @@ impl InnerWebView {
         }
       }
 
-      WEBVIEW_STATE.with_borrow_mut(|wv_ids| {
-        wv_ids.insert(webview_id.clone(), WebViewState { protocol_ptrs });
-      });
+      WEBVIEW_STATE
+        .write()
+        .unwrap()
+        .insert(webview_id.clone(), WebViewState { protocol_ptrs });
 
       // WebView and manager
       let manager = config.userContentController();
@@ -1093,7 +1095,7 @@ pub fn platform_webview_version() -> Result<String> {
 
 impl Drop for InnerWebView {
   fn drop(&mut self) {
-    WEBVIEW_STATE.with_borrow_mut(|v| v.remove(&self.id));
+    WEBVIEW_STATE.write().unwrap().remove(&self.id);
 
     // We need to drop handler closures here
     unsafe {


### PR DESCRIPTION
the responder from the async custom protocol runs on a separate thread, so it's not able to find the WEBVIEW_STATE which is now a thread local

making it actually global fixes it

regression from #1537

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
