### PR TITLE
fix: set WebKitGTK WebsiteDataManager's base_cache_directory

### DIFF
--- a/.changes/webcontext-cache-directory.md
+++ b/.changes/webcontext-cache-directory.md
@@ -1,8 +1,7 @@
 ---
-"wry": minor
+"wry": patch
 ---
 
-Breaking change: `WebContext::new` now takes a `cache_directory` argument besides `data_directory`.
+Set `WebsiteDataManagerBuilder::base_cache_directory` with the same path as `base_data_directory`.
 
-This change allows users to specify a custom cache directory for the web context,
-instead of using the default one [from WebKitGTK](https://webkitgtk.org/reference/webkit2gtk/stable/property.WebsiteDataManager.base-cache-directory.html).
+This change allows the cache directory to be changed instead of using the default one [from WebKitGTK](https://webkitgtk.org/reference/webkit2gtk/stable/property.WebsiteDataManager.base-cache-directory.html).

--- a/.changes/webcontext-cache-directory.md
+++ b/.changes/webcontext-cache-directory.md
@@ -5,4 +5,4 @@
 Breaking change: `WebContext::new` now takes a `cache_directory` argument besides `data_directory`.
 
 This change allows users to specify a custom cache directory for the web context,
-instead of using the default one [from WebKit2](https://webkitgtk.org/reference/webkit2gtk/stable/property.WebsiteDataManager.base-cache-directory.html).
+instead of using the default one [from WebKitGTK](https://webkitgtk.org/reference/webkit2gtk/stable/property.WebsiteDataManager.base-cache-directory.html).

--- a/.changes/webcontext-cache-directory.md
+++ b/.changes/webcontext-cache-directory.md
@@ -1,0 +1,8 @@
+---
+"wry": minor
+---
+
+Breaking change: `WebContext::new` now takes a `cache_directory` argument besides `data_directory`.
+
+This change allows users to specify a custom cache directory for the web context,
+instead of using the default one [from WebKit2](https://webkitgtk.org/reference/webkit2gtk/stable/property.WebsiteDataManager.base-cache-directory.html).

--- a/src/web_context.rs
+++ b/src/web_context.rs
@@ -23,7 +23,6 @@ use std::{
 /// [`WebView`]: crate::WebView
 #[derive(Debug)]
 pub struct WebContext {
-  cache_directory: Option<PathBuf>,
   data_directory: Option<PathBuf>,
   #[allow(dead_code)] // It's not needed on Windows and macOS.
   pub(crate) os: WebContextImpl,
@@ -39,7 +38,6 @@ impl WebContext {
   ///   when a bundled application can't have the webview data inside `Program Files`.
   pub fn new(data_directory: Option<PathBuf>) -> Self {
     Self {
-      cache_directory: None,
       os: WebContextImpl::new(data_directory.as_deref(), None),
       data_directory,
       custom_protocols: Default::default(),
@@ -49,26 +47,15 @@ impl WebContext {
   #[cfg(gtk)]
   pub(crate) fn new_ephemeral() -> Self {
     Self {
-      cache_directory: None,
       os: WebContextImpl::new_ephemeral(),
       data_directory: None,
       custom_protocols: Default::default(),
     }
   }
 
-  /// A reference to the cache directory the context was created with.
-  pub fn cache_directory(&self) -> Option<&Path> {
-    self.cache_directory.as_deref()
-  }
-
   /// A reference to the data directory the context was created with.
   pub fn data_directory(&self) -> Option<&Path> {
     self.data_directory.as_deref()
-  }
-
-  /// Set the cache directory for the context.
-  pub fn set_cache_directory(&mut self, cache_directory: PathBuf) {
-    self.cache_directory = Some(cache_directory);
   }
 
   #[allow(dead_code)]

--- a/src/web_context.rs
+++ b/src/web_context.rs
@@ -34,17 +34,13 @@ pub struct WebContext {
 impl WebContext {
   /// Create a new [`WebContext`].
   ///
-  /// `cache_directory`:
-  /// * Whether the WebView window should have a custom cache path. This is useful in Windows
-  ///   when a bundled application can't have the webview cache inside `Program Files`.
-  ///
   /// `data_directory`:
   /// * Whether the WebView window should have a custom user data path. This is useful in Windows
   ///   when a bundled application can't have the webview data inside `Program Files`.
-  pub fn new(cache_directory: Option<PathBuf>, data_directory: Option<PathBuf>) -> Self {
+  pub fn new(data_directory: Option<PathBuf>) -> Self {
     Self {
-      os: WebContextImpl::new(cache_directory.as_deref(), data_directory.as_deref()),
-      cache_directory,
+      cache_directory: None,
+      os: WebContextImpl::new(data_directory.as_deref(), None),
       data_directory,
       custom_protocols: Default::default(),
     }
@@ -68,6 +64,11 @@ impl WebContext {
   /// A reference to the data directory the context was created with.
   pub fn data_directory(&self) -> Option<&Path> {
     self.data_directory.as_deref()
+  }
+
+  /// Set the cache directory for the context.
+  pub fn set_cache_directory(&mut self, cache_directory: PathBuf) {
+    self.cache_directory = Some(cache_directory);
   }
 
   #[allow(dead_code)]
@@ -95,7 +96,7 @@ impl WebContext {
 
 impl Default for WebContext {
   fn default() -> Self {
-    Self::new(None, None)
+    Self::new(None)
   }
 }
 

--- a/src/web_context.rs
+++ b/src/web_context.rs
@@ -23,6 +23,7 @@ use std::{
 /// [`WebView`]: crate::WebView
 #[derive(Debug)]
 pub struct WebContext {
+  cache_directory: Option<PathBuf>,
   data_directory: Option<PathBuf>,
   #[allow(dead_code)] // It's not needed on Windows and macOS.
   pub(crate) os: WebContextImpl,
@@ -38,6 +39,7 @@ impl WebContext {
   ///   when a bundled application can't have the webview data inside `Program Files`.
   pub fn new(data_directory: Option<PathBuf>) -> Self {
     Self {
+      cache_directory: None,
       os: WebContextImpl::new(data_directory.as_deref(), None),
       data_directory,
       custom_protocols: Default::default(),
@@ -47,15 +49,26 @@ impl WebContext {
   #[cfg(gtk)]
   pub(crate) fn new_ephemeral() -> Self {
     Self {
+      cache_directory: None,
       os: WebContextImpl::new_ephemeral(),
       data_directory: None,
       custom_protocols: Default::default(),
     }
   }
 
+  /// A reference to the cache directory the context was created with.
+  pub fn cache_directory(&self) -> Option<&Path> {
+    self.cache_directory.as_deref()
+  }
+
   /// A reference to the data directory the context was created with.
   pub fn data_directory(&self) -> Option<&Path> {
     self.data_directory.as_deref()
+  }
+
+  /// Set the cache directory for the context.
+  pub fn set_cache_directory(&mut self, cache_directory: PathBuf) {
+    self.cache_directory = Some(cache_directory);
   }
 
   #[allow(dead_code)]

--- a/src/web_context.rs
+++ b/src/web_context.rs
@@ -38,7 +38,7 @@ impl WebContext {
   ///   when a bundled application can't have the webview data inside `Program Files`.
   pub fn new(data_directory: Option<PathBuf>) -> Self {
     Self {
-      os: WebContextImpl::new(data_directory.as_deref(), None),
+      os: WebContextImpl::new(data_directory.as_deref()),
       data_directory,
       custom_protocols: Default::default(),
     }

--- a/src/web_context.rs
+++ b/src/web_context.rs
@@ -34,13 +34,17 @@ pub struct WebContext {
 impl WebContext {
   /// Create a new [`WebContext`].
   ///
+  /// `cache_directory`:
+  /// * Whether the WebView window should have a custom cache path. This is useful in Windows
+  ///   when a bundled application can't have the webview cache inside `Program Files`.
+  ///
   /// `data_directory`:
   /// * Whether the WebView window should have a custom user data path. This is useful in Windows
   ///   when a bundled application can't have the webview data inside `Program Files`.
-  pub fn new(data_directory: Option<PathBuf>) -> Self {
+  pub fn new(cache_directory: Option<PathBuf>, data_directory: Option<PathBuf>) -> Self {
     Self {
-      cache_directory: None,
-      os: WebContextImpl::new(data_directory.as_deref(), None),
+      os: WebContextImpl::new(cache_directory.as_deref(), data_directory.as_deref()),
+      cache_directory,
       data_directory,
       custom_protocols: Default::default(),
     }
@@ -64,11 +68,6 @@ impl WebContext {
   /// A reference to the data directory the context was created with.
   pub fn data_directory(&self) -> Option<&Path> {
     self.data_directory.as_deref()
-  }
-
-  /// Set the cache directory for the context.
-  pub fn set_cache_directory(&mut self, cache_directory: PathBuf) {
-    self.cache_directory = Some(cache_directory);
   }
 
   #[allow(dead_code)]
@@ -96,7 +95,7 @@ impl WebContext {
 
 impl Default for WebContext {
   fn default() -> Self {
-    Self::new(None)
+    Self::new(None, None)
   }
 }
 

--- a/src/web_context.rs
+++ b/src/web_context.rs
@@ -38,7 +38,7 @@ impl WebContext {
   ///   when a bundled application can't have the webview data inside `Program Files`.
   pub fn new(data_directory: Option<PathBuf>) -> Self {
     Self {
-      os: WebContextImpl::new(data_directory.as_deref()),
+      os: WebContextImpl::new(data_directory.as_deref(), None),
       data_directory,
       custom_protocols: Default::default(),
     }

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -40,6 +40,7 @@ impl WebContextImpl {
     let mut context_builder = WebContext::builder();
     if let Some(data_directory) = data_directory {
       let data_manager = WebsiteDataManager::builder()
+        .base_cache_directory(data_directory.to_string_lossy())
         .base_data_directory(data_directory.to_string_lossy())
         .build();
       if let Some(cookie_manager) = data_manager.cookie_manager() {

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -35,14 +35,29 @@ pub struct WebContextImpl {
 }
 
 impl WebContextImpl {
-  pub fn new(data_directory: Option<&Path>) -> Self {
+  pub fn new(cache_directory: Option<&Path>, data_directory: Option<&Path>) -> Self {
     use webkit2gtk::{CookieManagerExt, WebsiteDataManager, WebsiteDataManagerExt};
+
     let mut context_builder = WebContext::builder();
-    if let Some(data_directory) = data_directory {
-      let data_manager = WebsiteDataManager::builder()
-        .base_data_directory(data_directory.to_string_lossy())
-        .build();
-      if let Some(cookie_manager) = data_manager.cookie_manager() {
+
+    if cache_directory.is_some() || data_directory.is_some() {
+      let mut data_manager_builder = WebsiteDataManager::builder();
+
+      if let Some(cache_directory) = cache_directory {
+        data_manager_builder =
+          data_manager_builder.base_cache_directory(cache_directory.to_string_lossy());
+      }
+
+      if let Some(data_directory) = data_directory {
+        data_manager_builder =
+          data_manager_builder.base_data_directory(data_directory.to_string_lossy());
+      }
+
+      let data_manager = data_manager_builder.build();
+
+      if let (Some(data_directory), Some(cookie_manager)) =
+        (data_directory, data_manager.cookie_manager())
+      {
         cookie_manager.set_persistent_storage(
           &data_directory.join("cookies").to_string_lossy(),
           CookiePersistentStorage::Text,

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -35,29 +35,14 @@ pub struct WebContextImpl {
 }
 
 impl WebContextImpl {
-  pub fn new(cache_directory: Option<&Path>, data_directory: Option<&Path>) -> Self {
+  pub fn new(data_directory: Option<&Path>) -> Self {
     use webkit2gtk::{CookieManagerExt, WebsiteDataManager, WebsiteDataManagerExt};
-
     let mut context_builder = WebContext::builder();
-
-    if cache_directory.is_some() || data_directory.is_some() {
-      let mut data_manager_builder = WebsiteDataManager::builder();
-
-      if let Some(cache_directory) = cache_directory {
-        data_manager_builder =
-          data_manager_builder.base_cache_directory(cache_directory.to_string_lossy());
-      }
-
-      if let Some(data_directory) = data_directory {
-        data_manager_builder =
-          data_manager_builder.base_data_directory(data_directory.to_string_lossy());
-      }
-
-      let data_manager = data_manager_builder.build();
-
-      if let (Some(data_directory), Some(cookie_manager)) =
-        (data_directory, data_manager.cookie_manager())
-      {
+    if let Some(data_directory) = data_directory {
+      let data_manager = WebsiteDataManager::builder()
+        .base_data_directory(data_directory.to_string_lossy())
+        .build();
+      if let Some(cookie_manager) = data_manager.cookie_manager() {
         cookie_manager.set_persistent_storage(
           &data_directory.join("cookies").to_string_lossy(),
           CookiePersistentStorage::Text,

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -40,6 +40,7 @@ impl WebContextImpl {
     let mut context_builder = WebContext::builder();
     if let Some(data_directory) = data_directory {
       let data_manager = WebsiteDataManager::builder()
+        // TODO: Consider taking a cache_directory so this can be in XDG_CACHE_HOME.
         .base_cache_directory(data_directory.to_string_lossy())
         .base_data_directory(data_directory.to_string_lossy())
         .build();


### PR DESCRIPTION
Set `WebsiteDataManagerBuilder::base_cache_directory` with the same path as `base_data_directory`.

This change allows the cache directory to be changed instead of using the default one [from WebKitGTK](https://webkitgtk.org/reference/webkit2gtk/stable/property.WebsiteDataManager.base-cache-directory.html).