### PR TITLE
unwrap handled.

### DIFF
--- a/src/wkwebview/class/wry_web_view_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_delegate.rs
@@ -58,7 +58,9 @@ define_class!(
             CStr::from_ptr(url_utf8).to_str(),
             CStr::from_ptr(js_utf8).to_str(),
           ) {
-            ipc_handler(Request::builder().uri(url).body(js.to_string()).unwrap());
+            if let Ok(r) = Request::builder().uri(url).body(js.to_string()) {
+              ipc_handler(r);
+            }
             return;
           }
         }

--- a/src/wkwebview/class/wry_web_view_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_delegate.rs
@@ -60,6 +60,9 @@ define_class!(
           ) {
             if let Ok(r) = Request::builder().uri(url).body(js.to_string()) {
               ipc_handler(r);
+            } else {
+              #[cfg(feature = "tracing")]
+              tracing::warn!("WebView received invalid IPC request: {}", js);
             }
             return;
           }


### PR DESCRIPTION
In offline mode, we encountered a crash due to an unwrap() call. Using unwrap() is bad practice, and the code was falling into it. This PR fixes the issue.