### PR TITLE
feat(ios): add support for setting the background color

### DIFF
--- a/.changes/ios-bg-color.md
+++ b/.changes/ios-bg-color.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Added iOS support for `set_background_color`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ objc2-ui-kit = { version = "0.3.0", default-features = false, features = [
   "UIWindow",
   "UIApplication",
   "UIEvent",
+  "UIColor"
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,7 +478,7 @@ pub struct WebViewAttributes<'a> {
   ///
   /// ## Platform-specific:
   ///
-  /// - **macOS / iOS**: Not implemented.
+  /// - **macOS**: Not implemented.
   /// - **Windows**:
   ///   - On Windows 7, transparency is not supported and the alpha value will be ignored.
   ///   - On Windows higher than 7: translucent colors are not supported so any alpha value other than `0` will be replaced by `255`
@@ -844,7 +844,7 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platfrom-specific:
   ///
-  /// - **macOS / iOS**: Not implemented.
+  /// - **macOS**: Not implemented.
   /// - **Windows**:
   ///   - on Windows 7, transparency is not supported and the alpha value will be ignored.
   ///   - on Windows higher than 7: translucent colors are not supported so any alpha value other than `0` will be replaced by `255`
@@ -1972,7 +1972,7 @@ impl WebView {
   ///
   /// ## Platfrom-specific:
   ///
-  /// - **macOS / iOS**: Not implemented.
+  /// - **macOS**: Not implemented.
   /// - **Windows**:
   ///   - On Windows 7, transparency is not supported and the alpha value will be ignored.
   ///   - On Windows higher than 7: translucent colors are not supported so any alpha value other than `0` will be replaced by `255`

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -370,6 +370,24 @@ impl InnerWebView {
         let frame = ns_view.frame();
         let webview: Retained<WryWebView> =
           objc2::msg_send![super(webview), initWithFrame: frame, configuration: &**config];
+        if let Some((red, green, blue, alpha)) = attributes.background_color {
+          // This is required first since the webview color is applied too late.
+          webview.setOpaque(false);
+
+          let color = objc2_ui_kit::UIColor::colorWithRed_green_blue_alpha(
+            (red / 255).into(),
+            (green / 255).into(),
+            (blue / 255).into(),
+            (alpha / 255).into(),
+          );
+
+          if !is_child {
+            ns_view.setBackgroundColor(Some(&color));
+          }
+          // This has to be monitored as it may clash with isOpaque = true.
+          // The webview background color may also applied too late so actually not that useful.
+          webview.setBackgroundColor(Some(&color));
+        }
         webview
       };
 
@@ -831,6 +849,25 @@ r#"Object.defineProperty(window, 'ipc', {
   }
 
   pub fn set_background_color(&self, _background_color: RGBA) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    unsafe {
+      let (red, green, blue, alpha) = _background_color;
+
+      let color = objc2_ui_kit::UIColor::colorWithRed_green_blue_alpha(
+        (red / 255).into(),
+        (green / 255).into(),
+        (blue / 255).into(),
+        (alpha / 255).into(),
+      );
+
+      if !self.is_child {
+        self.ns_view.setBackgroundColor(Some(&color));
+      }
+      // This has to be monitored as it may clash with isOpaque = true.
+      // The webview background color may also applied too late so actually not that useful.
+      self.webview.setBackgroundColor(Some(&color));
+    }
+
     Ok(())
   }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -375,10 +375,10 @@ impl InnerWebView {
           webview.setOpaque(false);
 
           let color = objc2_ui_kit::UIColor::colorWithRed_green_blue_alpha(
-            (red / 255).into(),
-            (green / 255).into(),
-            (blue / 255).into(),
-            (alpha / 255).into(),
+            red as f64 / 255.0,
+            green as f64 / 255.0,
+            blue as f64 / 255.0,
+            alpha as f64 / 255.0,
           );
 
           if !is_child {
@@ -854,10 +854,10 @@ r#"Object.defineProperty(window, 'ipc', {
       let (red, green, blue, alpha) = _background_color;
 
       let color = objc2_ui_kit::UIColor::colorWithRed_green_blue_alpha(
-        (red / 255).into(),
-        (green / 255).into(),
-        (blue / 255).into(),
-        (alpha / 255).into(),
+        red as f64 / 255.0,
+        green as f64 / 255.0,
+        blue as f64 / 255.0,
+        alpha as f64 / 255.0,
       );
 
       if !self.is_child {


### PR DESCRIPTION
This is _required_ to get rid of white/black flashes on app launch. ref https://github.com/tauri-apps/tauri/issues/1564