### PR TITLE
fix(linux): deadlock in WebViewUriLoader

### DIFF
--- a/.changes/fix-webkitgtk-webviewuriloader-deadlock.md
+++ b/.changes/fix-webkitgtk-webviewuriloader-deadlock.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On Linux, fix a deadlock, which could occur when destroying a WebView before loading has finished.

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -5,7 +5,10 @@
 //! Unix platform extensions for [`WebContext`](super::WebContext).
 
 use crate::{Error, RequestAsyncResponder};
-use gtk::glib::{self, MainContext, ObjectExt};
+use gtk::{
+  glib::{self, MainContext, ObjectExt},
+  traits::WidgetExt,
+};
 use http::{header::CONTENT_TYPE, HeaderName, HeaderValue, Request, Response as HttpResponse};
 use soup::{MessageHeaders, MessageHeadersType};
 use std::{
@@ -451,11 +454,18 @@ impl WebViewUriLoader {
         headers,
       }) = self.pop()
       {
+        // ensure that the lock is released when the webview is destroyed before LoadEvent::Finished is handled
+        let self_c = self.clone();
+        webview.connect_destroy(move |_| {
+          self_c.unlock();
+          self_c.clone().flush();
+        });
         // we do not need to listen to failed events because those will finish the change event anyways
+        let self_c = self.clone();
         webview.connect_load_changed(move |_, event| {
           if let LoadEvent::Finished = event {
-            self.unlock();
-            self.clone().flush();
+            self_c.unlock();
+            self_c.clone().flush();
           };
         });
 

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -478,19 +478,35 @@ impl WebViewUriLoader {
       }) = self.pop()
       {
         // ensure that the lock is released when the webview is destroyed before LoadEvent::Finished is handled
-        let self_c = self.clone();
-        webview.connect_destroy(move |_| {
-          self_c.unlock();
-          self_c.clone().flush();
+        let self_ = self.clone();
+        let destroy_id = webview.connect_destroy(move |_| {
+          self_.unlock();
+          self_.clone().flush();
         });
-        // we do not need to listen to failed events because those will finish the change event anyways
-        let self_c = self.clone();
-        webview.connect_load_changed(move |_, event| {
+        let destroy_id_guard = Mutex::new(Some(destroy_id));
+
+        let load_changed_id_guard = Rc::new(Mutex::new(None));
+        let load_changed_id_guard_ = load_changed_id_guard.clone();
+        let self_ = self.clone();
+        // noet: we do not need to listen to failed events because those will finish the change event anyways
+        let load_changed_id = webview.connect_load_changed(move |w, event| {
           if let LoadEvent::Finished = event {
-            self_c.unlock();
-            self_c.clone().flush();
+            self_.unlock();
+            self_.clone().flush();
+
+            // unregister listeners
+            if let Some(id) = destroy_id_guard.lock().unwrap().take() {
+              w.disconnect(id);
+            }
+            if let Some(id) = load_changed_id_guard_.lock().unwrap().take() {
+              w.disconnect(id);
+            }
           };
         });
+        load_changed_id_guard
+          .lock()
+          .unwrap()
+          .replace(load_changed_id);
 
         if let Some(headers) = headers {
           let req = URIRequest::builder().uri(&uri).build();


### PR DESCRIPTION
This fixes a deadlock, which could occur on Linux, when a WebView was destroyed before handling `LoadEvent::Finished`. As a consequence, no further requests could be performed.

With this fix, https://github.com/tauri-apps/tauri/issues/12589 is no longer consistently reproducible. But there still seem to be rare situations, in which a deadlock could occur, so I don't think the issue can be closed.

Note: This PR could be slightly improved by disconnecting the `connect_destroy` signal handler when `LoadEvent::Finished` is handled. But I'm not experienced in Rust development at all and have no idea how to move the `SignalHandlerId` into the closure to call `webview.disconnect(id)`.

## Additional context / long-term solution
The deadlock is caused by a workaround for a supposed bug in WebKitGTK. But the workaround introduces new bugs and negatively impacts request performance by queuing them up. Ideally, the underlying issue would be further investigated, so the workaround could be removed in the future. Currently, there doesn't seem to be an issue to track this problem and the bug has not been reported to the WebKitGTK project. As a start, it would be helpful to allow disabling the workaround. This way, it would be possible to verify if it is still needed for the latest WebKitGTK version.

Refs https://github.com/tauri-apps/wry/pull/359

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
