### PR TITLE
Make `window.close` no-op

### DIFF
--- a/.changes/window-close-no-op.md
+++ b/.changes/window-close-no-op.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Make `window.close` no-op since it would leave a broken window, and behavior is inconsistent between windows and apple platforms

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -441,8 +441,10 @@ impl InnerWebView {
     web_context: &mut WebContext,
     attributes: &mut WebViewAttributes,
   ) {
-    // window.close()
-    webview.connect_close(move |webview| unsafe { webview.destroy() });
+    // Simply destroying the webview would leave blank window which is not good.
+    // TODO: we need to add api to register callback on `window.close`
+    //   and ask user code if close the window, or just ignore `window.close`.
+    //webview.connect_close(move |webview| unsafe { webview.destroy() });
 
     // Synthetic mouse events
     synthetic_mouse_events::setup(webview);

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -576,11 +576,13 @@ impl InnerWebView {
     attributes: &mut WebViewAttributes,
     token: &mut EventRegistrationToken,
   ) -> Result<()> {
-    // Close container HWND when `window.close` is called in JS
-    webview.add_WindowCloseRequested(
-      &WindowCloseRequestedEventHandler::create(Box::new(move |_, _| DestroyWindow(hwnd))),
-      token,
-    )?;
+    // Simply destroying the hwnd would cause inconsistent window state so ignoring for now.
+    // TODO: we need to add api to register callback on `window.close`
+    //   and ask user code if close the window, or just ignore `window.close`.
+    // webview.add_WindowCloseRequested(
+    //   &WindowCloseRequestedEventHandler::create(Box::new(move |_, _| DestroyWindow(hwnd))),
+    //   token,
+    // )?;
 
     // Document title changed handler
     if let Some(document_title_changed_handler) = attributes.document_title_changed_handler.take() {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Make `window.close` no-op for several reasons:
- its behavior is not good. currently it would leave broken window without notifying library user (tauri and application)
- It should possible to ignore `window.close`
- It's inconsistent with apple platform (and possibly android?)


Fixing tauri-apps/tauri#13331