### PR TITLE
Remove potentially dangerous Send bound

### DIFF
--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -159,9 +159,9 @@ fn handle_request(
 
     let final_request = match request_builder.body(Vec::new()) {
       Ok(req) => req,
-      Err(e) => {
+      Err(_e) => {
         #[cfg(feature = "tracing")]
-        tracing::warn!("Failed to build response: {}", e);
+        tracing::warn!("Failed to build response: {_e}");
         return Ok(*JObject::null());
       }
     };
@@ -190,9 +190,9 @@ fn handle_request(
       } else {
         None
       };
-      if let Some(err) = status_err {
+      if let Some(_err) = status_err {
         #[cfg(feature = "tracing")]
-        tracing::warn!("{}", err);
+        tracing::warn!("{_err}");
         return Ok(*JObject::null());
       }
 
@@ -280,9 +280,9 @@ pub unsafe fn handleRequest(
     is_document_start_script_enabled,
   ) {
     Ok(response) => response,
-    Err(e) => {
+    Err(_e) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to handle request: {}", e);
+      tracing::warn!("Failed to handle request: {_e}");
       JObject::null().as_raw()
     }
   }
@@ -304,9 +304,9 @@ pub unsafe fn shouldOverride(mut env: JNIEnv, _: JClass, url: JString) -> jboole
         .map(|f| !(f.handler)(url))
         .unwrap_or(false)
     }
-    Err(e) => {
+    Err(_e) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to parse JString: {}", e);
+      tracing::warn!("Failed to parse JString: {_e}");
       false
     }
   }
@@ -326,9 +326,9 @@ pub unsafe fn onEval(mut env: JNIEnv, _: JClass, id: jint, result: JString) {
         cb(result.into());
       }
     }
-    Err(e) => {
+    Err(_e) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to parse JString: {}", e);
+      tracing::warn!("Failed to parse JString: {_e}");
     }
   }
 }
@@ -345,9 +345,9 @@ pub unsafe fn ipc(mut env: JNIEnv, _: JClass, url: JString, body: JString) {
         (ipc.handler)(Request::builder().uri(url).body(body).unwrap())
       }
     }
-    (Err(e), _) | (_, Err(e)) => {
+    (Err(_e), _) | (_, Err(_e)) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to parse JString: {}", e)
+      tracing::warn!("Failed to parse JString: {_e}")
     }
   }
 }
@@ -361,9 +361,9 @@ pub unsafe fn handleReceivedTitle(mut env: JNIEnv, _: JClass, _webview: JObject,
         (title_handler.handler)(title)
       }
     }
-    Err(e) => {
+    Err(_e) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to parse JString: {}", e)
+      tracing::warn!("Failed to parse JString: {_e}")
     }
   }
 }
@@ -391,9 +391,9 @@ pub unsafe fn onPageLoading(mut env: JNIEnv, _: JClass, url: JString) {
         (on_load.handler)(PageLoadEvent::Started, url)
       }
     }
-    Err(e) => {
+    Err(_e) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to parse JString: {}", e)
+      tracing::warn!("Failed to parse JString: {_e}")
     }
   }
 }
@@ -407,9 +407,9 @@ pub unsafe fn onPageLoaded(mut env: JNIEnv, _: JClass, url: JString) {
         (on_load.handler)(PageLoadEvent::Finished, url)
       }
     }
-    Err(e) => {
+    Err(_e) => {
       #[cfg(feature = "tracing")]
-      tracing::warn!("Failed to parse JString: {}", e)
+      tracing::warn!("Failed to parse JString: {_e}")
     }
   }
 }

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -226,13 +226,13 @@ impl<'a> MainPipe<'a> {
           )?;
 
           if let Some(on_webview_created) = on_webview_created {
-            if let Err(e) = on_webview_created(super::Context {
+            if let Err(_e) = on_webview_created(super::Context {
               env: &mut self.env,
               activity,
               webview: &webview,
             }) {
               #[cfg(feature = "tracing")]
-              tracing::warn!("failed to run webview created hook: {e}");
+              tracing::warn!("failed to run webview created hook: {_e}");
             }
           }
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -46,7 +46,6 @@ pub struct Context<'a, 'b> {
 
 pub(crate) struct StaticValue<T>(Mutex<T>);
 
-unsafe impl<T> Send for StaticValue<T> {}
 unsafe impl<T> Sync for StaticValue<T> {}
 
 impl<T> std::ops::Deref for StaticValue<T> {
@@ -69,9 +68,7 @@ macro_rules! define_static_handlers {
           $($fields,)*
         }
       }
-    }
-    unsafe impl Send for $type_name {}
-    unsafe impl Sync for $type_name {})*
+    })*
   };
 }
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -347,7 +347,7 @@ impl InnerWebView {
     Ok(())
   }
 
-  pub fn id(&self) -> crate::WebViewId {
+  pub fn id(&self) -> crate::WebViewId<'_> {
     &self.id
   }
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -44,7 +44,7 @@ pub struct Context<'a, 'b> {
   pub webview: &'a JObject<'b>,
 }
 
-pub(crate) struct StaticValue<T>(Mutex<T>);
+struct StaticValue<T>(Mutex<T>);
 
 unsafe impl<T> Sync for StaticValue<T> {}
 
@@ -58,12 +58,12 @@ impl<T> std::ops::Deref for StaticValue<T> {
 
 macro_rules! define_static_handlers {
   ($($var:ident = $type_name:ident { $($fields:ident:$types:ty),+ $(,)? });+ $(;)?) => {
-    $(pub static $var: StaticValue<Option<$type_name>> = StaticValue(Mutex::new(None));
-    pub struct $type_name {
+    $(static $var: StaticValue<Option<$type_name>> = StaticValue(Mutex::new(None));
+    struct $type_name {
       $($fields: $types,)*
     }
     impl $type_name {
-      pub fn new($($fields: $types,)*) -> Self {
+      fn new($($fields: $types,)*) -> Self {
         Self {
           $($fields,)*
         }
@@ -80,15 +80,15 @@ define_static_handlers! {
   ON_LOAD_HANDLER = UnsafeOnPageLoadHandler { handler: Box<dyn Fn(PageLoadEvent, String)> };
 }
 
-pub static WITH_ASSET_LOADER: StaticValue<Option<bool>> = StaticValue(Mutex::new(None));
-pub static ASSET_LOADER_DOMAIN: StaticValue<Option<String>> = StaticValue(Mutex::new(None));
+static WITH_ASSET_LOADER: Mutex<Option<bool>> = Mutex::new(None);
+static ASSET_LOADER_DOMAIN: Mutex<Option<String>> = Mutex::new(None);
 
-pub(crate) static PACKAGE: OnceCell<String> = OnceCell::new();
+static PACKAGE: OnceCell<String> = OnceCell::new();
 
 type EvalCallback = Box<dyn Fn(String) + Send + 'static>;
 
-pub static EVAL_ID_GENERATOR: Counter = Counter::new();
-pub static EVAL_CALLBACKS: OnceCell<Mutex<HashMap<i32, EvalCallback>>> = OnceCell::new();
+static EVAL_ID_GENERATOR: Counter = Counter::new();
+static EVAL_CALLBACKS: OnceCell<Mutex<HashMap<i32, EvalCallback>>> = OnceCell::new();
 
 /// Sets up the necessary logic for wry to be able to create the webviews later.
 ///

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -113,7 +113,7 @@ pub unsafe fn android_setup(
   let webchrome_client = env
     .new_object(
       &rust_webchrome_client_class,
-      &format!("(L{}/WryActivity;)V", PACKAGE.get().unwrap()),
+      format!("(L{}/WryActivity;)V", PACKAGE.get().unwrap()),
       &[activity.as_obj().into()],
     )
     .unwrap();
@@ -217,12 +217,12 @@ impl InnerWebView {
         move |webview_id: &str, mut request, is_document_start_script_enabled| {
           let uri = request.uri().to_string();
           if let Some((custom_protocol_uri, custom_protocol_closure)) = custom_protocols.iter().find(|(name, _)| {
-            uri.starts_with(&format!("{scheme}://{}.", name))
+            uri.starts_with(&format!("{scheme}://{name}."))
           }) {
             let uri_res = uri
               .replace(
-                &format!("{scheme}://{}.", custom_protocol_uri),
-                &format!("{}://", custom_protocol_uri),
+                &format!("{scheme}://{custom_protocol_uri}."),
+                &format!("{custom_protocol_uri}://"),
               )
               .parse();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1840,7 +1840,7 @@ impl WebViewBuilderExtAndroid for WebViewBuilder<'_> {
       }),
     );
     self.platform_specific.with_asset_loader = true;
-    self.platform_specific.asset_loader_domain = Some(format!("{}.assets", protocol));
+    self.platform_specific.asset_loader_domain = Some(format!("{protocol}.assets"));
     self
   }
 


### PR DESCRIPTION
`StaticValue` has `Send` and `Sync` impls with unclear soundness. `StaticValue<T>` is a wrapper around `Mutex<T>`, but `Mutex<T>` itself is only ever `Send` or `Sync` when `T: Send`. I tried to get something to crash but the `'static` lifetime on the closures seems quite restrictive.

To remove any doubts about soundness the involved closures would need an additional `Send` bound, a breaking change.

This PR removes the `Send` impl on `StaticValue` since it is never needed. The questionable `Sync` impl remains.