### PR TITLE
feat(windows): Use new webview2 background color api

### DIFF
--- a/.changes/windows-default-bg-color.md
+++ b/.changes/windows-default-bg-color.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On Windows on systems running WebView2 v137+ wry now uses a new default background color API which should reduce white flashes. The use of the `RemoveRedirectionBitmap` browser flag (v134+) was removed due to crashes on Insider builds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1487,7 +1487,7 @@ pub trait WebViewBuilderExtWindows {
   /// ## Warning
   ///
   /// - Webview instances with different browser arguments must also have different [data directories](struct.WebContext.html#method.new).
-  /// - By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --enable-features=RemoveRedirectionBitmap`
+  /// - By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   ///   `--autoplay-policy=no-user-gesture-required` if autoplay is enabled
   ///   and `--proxy-server=<scheme>://<host>:<port>` if a proxy is set.
   ///   so if you use this method, you have to add these arguments yourself if you want to keep the same behavior.


### PR DESCRIPTION
should also fix https://github.com/tauri-apps/wry/issues/1525 i guess

with these changes the transparent example does not flicker anymore.