### PR TITLE
fix(windows): `Drop::paths` returns random data

### DIFF
--- a/.changes/fix-windows-drop-path.md
+++ b/.changes/fix-windows-drop-path.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Fix `wry::DragDropEvent::Drop::paths` returns random data on Windows

--- a/src/webview2/drag_drop.rs
+++ b/src/webview2/drag_drop.rs
@@ -125,13 +125,11 @@ impl DragDropTarget {
           // Previously, this was using a fixed size array of MAX_PATH length, but the
           // Windows API allows longer paths under certain circumstances.
           let character_count = DragQueryFileW(hdrop, i, None) as usize;
-          let str_len = character_count + 1;
 
           // Fill path_buf with the null-terminated file name
-          let mut path_buf = Vec::with_capacity(str_len);
+          let str_len = character_count + 1;
+          let mut path_buf = vec![0; str_len];
           DragQueryFileW(hdrop, i, Some(&mut path_buf));
-          path_buf.set_len(str_len);
-
           callback(OsString::from_wide(&path_buf[0..character_count]).into());
         }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

A regression from #1548

Fix https://github.com/tauri-apps/tauri/issues/13698