### PR TITLE
Feat: add `WebViewBuilder::with_limit_navigations_to_app_bound_domains`

### DIFF
--- a/.changes/app-bound-domains.md
+++ b/.changes/app-bound-domains.md
@@ -1,0 +1,6 @@
+---
+"wry": "minor"
+---
+
+Add `WebViewBuilder::with_limit_navigations_to_app_bound_domains` only on iOS.
+Function is a no-op if iOS version is less than iOS 14.

--- a/.changes/app-bound-domains.md
+++ b/.changes/app-bound-domains.md
@@ -1,5 +1,5 @@
 ---
-"wry": "minor"
+"wry": "patch"
 ---
 
 Add `WebViewBuilder::with_limit_navigations_to_app_bound_domains` only on iOS.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -63,6 +63,9 @@ use once_cell::sync::Lazy;
 
 #[cfg(target_os = "ios")]
 use crate::wkwebview::ios::WKWebView::WKWebView;
+#[cfg(target_os = "ios")]
+use crate::wkwebview::util::operating_system_version;
+
 #[cfg(target_os = "macos")]
 use objc2_web_kit::WKWebView;
 
@@ -283,6 +286,12 @@ impl InnerWebView {
       let _preference = config.preferences();
       let _yes = NSNumber::numberWithBool(true);
 
+      #[cfg(target_os = "ios")]
+      {
+        if pl_attrs.limit_navigations_to_app_bound_domains && operating_system_version().0 >= 14 {
+          config.setLimitsNavigationsToAppBoundDomains(true);
+        }
+      }
       #[cfg(feature = "mac-proxy")]
       if let Some(proxy_config) = attributes.proxy_config {
         let proxy_config = match proxy_config {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
closes #1587.

In the above issue @FabianLars wrote:

> I don't think this needs a feature flag. We can check the iOS version in the function and make it do nothing on older versions.

I did this for my implementation: 
```rs
use crate::wkwebview::util::operating_system_version;

...

if pl_attrs.limit_navigations_to_app_bound_domains && operating_system_version().0 >= 14 {
  config.setLimitsNavigationsToAppBoundDomains(true);
}
```

