### PR TITLE
fix(linux): set suggested filename for download started handler

### DIFF
--- a/.changes/linux-download-handler-destination.md
+++ b/.changes/linux-download-handler-destination.md
@@ -1,0 +1,5 @@
+---
+"wry": "patch"
+---
+
+On Linux, the `download_started_handler` will now get the correct suggested destination path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2521,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -4096,6 +4134,7 @@ dependencies = [
  "block2 0.6.0",
  "cookie",
  "crossbeam-channel",
+ "dirs",
  "dpi",
  "dunce",
  "gdkx11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ soup3 = { version = "0.5", optional = true }
 x11-dl = { version = "2.21", optional = true }
 gdkx11 = { version = "0.18", optional = true }
 percent-encoding = "2.3"
+dirs = "6"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 webview2-com = "0.38"

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -329,7 +329,7 @@ impl WebContextExt for super::WebContext {
             let suggested_filename = if uri.starts_with("data:") {
               // for data: downloads webkitgtk will suggest to use the data as the filename
               // for example `"data:attachment/text," + encodeURI("some text")` will result in `text,some text`
-              "unknown"
+              "Unknown"
             } else {
               suggested_filename
             };

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -326,25 +326,32 @@ impl WebContextExt for super::WebContext {
             let mut download_location =
               dirs::download_dir().unwrap_or_else(|| current_dir().unwrap_or_default());
 
-            let suggested_filename = if uri.starts_with("data:") {
-              // for data: downloads webkitgtk will suggest to use the data as the filename
-              // for example `"data:attachment/text," + encodeURI("some text")` will result in `text,some text`
-              "Unknown"
-            } else {
-              suggested_filename
-            };
+            let (mut suggested_filename, mut ext) = suggested_filename
+              .split_once('.')
+              .map(|(base, ext)| (base, format!(".{ext}")))
+              .unwrap_or((suggested_filename, "".to_string()));
 
-            download_location.push(suggested_filename);
+            // Weird bug but webkitgtk sets the extension to `.jpe` for JPEG files in these cases:
+            // <a href="data:image/jpeg;base64,..." download="" />
+            // <a href="/some-img.jpeg" download="some-name" />
+            //
+            // Other 4 character extensions like avif,webp seem to be set correctly.
+            if ext == ".jpe" {
+              ext = ".jpeg".to_string();
+            }
+
+            // for `data:` downloads, webkitgtk will suggest to use the raw data as the filename
+            // for example `"data:attachment/text,sometext"` will result in `text,sometext`
+            if uri.starts_with("data:") {
+              suggested_filename = "Unknown";
+            }
+
+            download_location.push(format!("{suggested_filename}{ext}"));
 
             // WebView2 does not overwrite files but appends numbers
             let mut counter = 1;
             while download_location.exists() {
-              let (base, ext) = suggested_filename
-                .split_once('.')
-                .map(|(base, ext)| (base, format!(".{ext}")))
-                .unwrap_or((suggested_filename, "".to_string()));
-
-              download_location.set_file_name(format!("{base} ({counter}){ext}"));
+              download_location.set_file_name(format!("{suggested_filename} ({counter}){ext}"));
               counter += 1;
             }
 

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -12,6 +12,7 @@ use std::{
   borrow::Cow,
   cell::RefCell,
   collections::VecDeque,
+  env::current_dir,
   path::{Path, PathBuf},
   rc::Rc,
   sync::{
@@ -312,27 +313,51 @@ impl WebContextExt for super::WebContext {
   ) {
     let context = &self.os.context;
 
-    let download_started_handler = RefCell::new(download_started_handler);
+    let download_started_handler = Rc::new(RefCell::new(download_started_handler));
     let failed = Rc::new(RefCell::new(false));
 
     context.connect_download_started(move |_context, download| {
-      if let Some(uri) = download.request().and_then(|req| req.uri()) {
-        let uri = uri.to_string();
-        let mut download_location = download
-          .destination()
-          .map(PathBuf::from)
-          .unwrap_or_default();
+      let download_started_handler = download_started_handler.clone();
+      download.connect_decide_destination(move |download, suggested_filename| {
+        if let Some(uri) = download.request().and_then(|req| req.uri()) {
+          let uri = uri.to_string();
 
-        if let Some(download_started_handler) = download_started_handler.borrow_mut().as_mut() {
-          if download_started_handler(uri, &mut download_location) {
-            download.connect_response_notify(move |download| {
+          if let Some(download_started_handler) = download_started_handler.borrow_mut().as_mut() {
+            let mut download_location =
+              dirs::download_dir().unwrap_or_else(|| current_dir().unwrap_or_default());
+
+            let suggested_filename = if uri.starts_with("data:") {
+              // for data: downloads webkitgtk will suggest to use the data as the filename
+              // for example `"data:attachment/text," + encodeURI("some text")` will result in `text,some text`
+              "unknown"
+            } else {
+              suggested_filename
+            };
+
+            download_location.push(suggested_filename);
+
+            // WebView2 does not overwrite files but appends numbers
+            let mut counter = 1;
+            while download_location.exists() {
+              let (base, ext) = suggested_filename
+                .split_once('.')
+                .map(|(base, ext)| (base, format!(".{ext}")))
+                .unwrap_or((suggested_filename, "".to_string()));
+
+              download_location.set_file_name(format!("{base} ({counter}){ext}"));
+              counter += 1;
+            }
+
+            if download_started_handler(uri, &mut download_location) {
               download.set_destination(&download_location.to_string_lossy());
-            });
-          } else {
-            download.cancel();
+            } else {
+              download.cancel();
+            }
           }
         }
-      }
+        // TODO: check if we may also need `false`
+        true
+      });
 
       download.connect_failed({
         let failed = failed.clone();

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -331,15 +331,6 @@ impl WebContextExt for super::WebContext {
               .map(|(base, ext)| (base, format!(".{ext}")))
               .unwrap_or((suggested_filename, "".to_string()));
 
-            // Weird bug but webkitgtk sets the extension to `.jpe` for JPEG files in these cases:
-            // <a href="data:image/jpeg;base64,..." download="" />
-            // <a href="/some-img.jpeg" download="some-name" />
-            //
-            // Other 4 character extensions like avif,webp seem to be set correctly.
-            if ext == ".jpe" {
-              ext = ".jpeg".to_string();
-            }
-
             // for `data:` downloads, webkitgtk will suggest to use the raw data as the filename
             // for example `"data:attachment/text,sometext"` will result in `text,sometext`
             if uri.starts_with("data:") {


### PR DESCRIPTION
Opening as a draft mainly cause i didn't check how macos behaves yet. the intention here (apart from making the download handler actually work on linux) was to make it match the behavior on windows which shows the standard behavior you know from browsers.

it's ready for review, i just don't want it to be merged yet.