### PR TITLE
fix: Allow downloads by default on linux/macos to match windows behavior

### DIFF
--- a/.changes/allow-downloads-default.md
+++ b/.changes/allow-downloads-default.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Enabled all downloads by default to match WebView2 and browser behavior on all platforms. To disable this, provide a custom `download_started_handler`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,6 +585,8 @@ pub struct WebViewAttributes<'a> {
   /// second is a mutable `PathBuf` reference that (possibly) represents where the file will be downloaded to. The latter
   /// parameter can be used to set the download location by assigning a new path to it, the assigned path _must_ be
   /// absolute. The closure returns a `bool` to allow or deny the download.
+  ///
+  /// [`Self::default()`] sets a handler allowing all downloads to match browser behavior.
   pub download_started_handler: Option<Box<dyn FnMut(String, &mut PathBuf) -> bool + 'static>>,
 
   /// A download completion handler to manage downloads that have finished.
@@ -718,7 +720,7 @@ impl Default for WebViewAttributes<'_> {
       ipc_handler: None,
       drag_drop_handler: None,
       navigation_handler: None,
-      download_started_handler: None,
+      download_started_handler: Some(Box::new(|_, _| true)),
       download_completed_handler: None,
       new_window_req_handler: None,
       clipboard: false,
@@ -1159,6 +1161,8 @@ impl<'a> WebViewBuilder<'a> {
   /// second is a mutable `PathBuf` reference that (possibly) represents where the file will be downloaded to. The latter
   /// parameter can be used to set the download location by assigning a new path to it, the assigned path _must_ be
   /// absolute. The closure returns a `bool` to allow or deny the download.
+  ///
+  /// By default a handler that allows all downloads is set to match browser behavior.
   pub fn with_download_started_handler(
     mut self,
     download_started_handler: impl FnMut(String, &mut PathBuf) -> bool + 'static,


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/pull/14006#issuecomment-3190490533

If we don't want to do this then we should disable it on Windows as right now it allows downloads if no handler is set.

closes https://github.com/tauri-apps/tauri/pull/14006
closes  https://github.com/tauri-apps/tauri/pull/13734
closes https://github.com/tauri-apps/tauri/pull/4633

