### PR TITLE
fix(linux): remove harmful request loading workaround

### DIFF
--- a/.changes/remove-webkitgtk-request-workaround.md
+++ b/.changes/remove-webkitgtk-request-workaround.md
@@ -1,0 +1,8 @@
+---
+wry: patch
+---
+
+On Linux, removed a workaround which forced inital requests for multiple webviews to be handled sequentially.
+The workaround was intended to fix a concurrency bug with loading multiple URIs at the same time on WebKitGTK.
+But it prevented parallelization and could cause a deadlock in certain situations.
+It is no longer needed with newer WebKitGTK versions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1971,7 +1971,7 @@ impl WebView {
   }
 
   /// Returns the id of this webview.
-  pub fn id(&self) -> WebViewId {
+  pub fn id(&self) -> WebViewId<'_> {
     self.webview.id()
   }
 

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -669,7 +669,7 @@ impl InnerWebView {
     is_inspector_open
   }
 
-  pub fn id(&self) -> crate::WebViewId {
+  pub fn id(&self) -> crate::WebViewId<'_> {
     &self.id
   }
 

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -366,8 +366,7 @@ impl InnerWebView {
 
     // Navigation
     if let Some(url) = attributes.url {
-      web_context.queue_load_uri(w.webview.clone(), url, attributes.headers);
-      web_context.flush_queue_loader();
+      web_context.load_uri(w.webview.clone(), url, attributes.headers);
     } else if let Some(html) = attributes.html {
       w.webview.load_html(&html, None);
     }

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -5,23 +5,15 @@
 //! Unix platform extensions for [`WebContext`](super::WebContext).
 
 use crate::{Error, RequestAsyncResponder};
-use gtk::{
-  glib::{self, MainContext, ObjectExt},
-  traits::WidgetExt,
-};
+use gtk::glib::{self, MainContext, ObjectExt};
 use http::{header::CONTENT_TYPE, HeaderName, HeaderValue, Request, Response as HttpResponse};
 use soup::{MessageHeaders, MessageHeadersType};
 use std::{
   borrow::Cow,
   cell::RefCell,
-  collections::VecDeque,
   env::current_dir,
   path::{Path, PathBuf},
   rc::Rc,
-  sync::{
-    atomic::{AtomicBool, Ordering::SeqCst},
-    Mutex,
-  },
 };
 use webkit2gtk::{
   ApplicationInfo, AutomationSessionExt, CookiePersistentStorage, DownloadExt, LoadEvent,
@@ -33,7 +25,6 @@ use webkit2gtk::{
 #[derive(Debug)]
 pub struct WebContextImpl {
   context: WebContext,
-  webview_uri_loader: Rc<WebViewUriLoader>,
   automation: bool,
   app_info: Option<ApplicationInfo>,
 }
@@ -87,7 +78,6 @@ impl WebContextImpl {
     Self {
       context,
       automation,
-      webview_uri_loader: Rc::default(),
       app_info: Some(app_info),
     }
   }
@@ -114,15 +104,8 @@ pub trait WebContextExt {
   where
     F: Fn(crate::WebViewId, Request<Vec<u8>>, RequestAsyncResponder) + 'static;
 
-  /// Add a [`WebView`] to the queue waiting to be opened.
-  ///
-  /// See the [`WebViewUriLoader`] for more information.
-  fn queue_load_uri(&self, webview: WebView, url: String, headers: Option<http::HeaderMap>);
-
-  /// Flush all queued [`WebView`]s waiting to load a uri.
-  ///
-  /// See the [`WebViewUriLoader`] for more information.
-  fn flush_queue_loader(&self);
+  /// Loads a URI for a [`WebView`].
+  fn load_uri(&self, webview: WebView, url: String, headers: Option<http::HeaderMap>);
 
   /// If the context allows automation.
   ///
@@ -279,12 +262,23 @@ impl WebContextExt for super::WebContext {
     Ok(())
   }
 
-  fn queue_load_uri(&self, webview: WebView, url: String, headers: Option<http::HeaderMap>) {
-    self.os.webview_uri_loader.push(webview, url, headers)
-  }
+  fn load_uri(&self, webview: WebView, uri: String, headers: Option<http::HeaderMap>) {
+    if let Some(headers) = headers {
+      let req = URIRequest::builder().uri(&uri).build();
 
-  fn flush_queue_loader(&self) {
-    self.os.webview_uri_loader.clone().flush()
+      if let Some(ref mut req_headers) = req.http_headers() {
+        for (header, value) in headers.iter() {
+          req_headers.append(
+            header.to_string().as_str(),
+            value.to_str().unwrap_or_default(),
+          );
+        }
+      }
+
+      webview.load_request(&req);
+    } else {
+      webview.load_uri(&uri);
+    }
   }
 
   fn allows_automation(&self) -> bool {
@@ -399,134 +393,3 @@ impl MainThreadRequest {
 
 unsafe impl Send for MainThreadRequest {}
 unsafe impl Sync for MainThreadRequest {}
-
-#[derive(Debug)]
-struct WebviewUriRequest {
-  webview: WebView,
-  uri: String,
-  headers: Option<http::HeaderMap>,
-}
-
-/// Prevents an unknown concurrency bug with loading multiple URIs at the same time on webkit2gtk.
-///
-/// Using the queue prevents data race issues with loading uris for multiple [`WebView`]s in the
-/// same context at the same time. Occasionally, the one of the [`WebView`]s will be clobbered
-/// and it's content will be injected into a different [`WebView`].
-///
-/// Example of `webview-c` clobbering `webview-b` while `webview-a` is okay:
-/// ```text
-/// webview-a triggers load-change::started
-/// URISchemeRequestCallback triggered with webview-a
-/// webview-a triggers load-change::committed
-/// webview-a triggers load-change::finished
-/// webview-b triggers load-change::started
-/// webview-c triggers load-change::started
-/// URISchemeRequestCallback triggered with webview-c
-/// URISchemeRequestCallback triggered with webview-c
-/// webview-c triggers load-change::committed
-/// webview-c triggers load-change::finished
-/// ```
-///
-/// In that example, `webview-a` will load fine. `webview-b` will remain empty as the uri was
-/// never loaded. `webview-c` will contain the content of both `webview-b` and `webview-c`
-/// because it was triggered twice even through only started once. The content injected will not
-/// be sequential, and often is interjected in the middle of one of the other contents.
-///
-/// FIXME: We think this may be an underlying concurrency bug in webkit2gtk as the usual ways of
-/// fixing threading issues are not working. Ideally, the locks are not needed if we can understand
-/// the true cause of the bug.
-#[derive(Debug, Default)]
-struct WebViewUriLoader {
-  lock: AtomicBool,
-  queue: Mutex<VecDeque<WebviewUriRequest>>,
-}
-
-impl WebViewUriLoader {
-  /// Check if the lock is in use.
-  fn is_locked(&self) -> bool {
-    self.lock.swap(true, SeqCst)
-  }
-
-  /// Unlock the lock.
-  fn unlock(&self) {
-    self.lock.store(false, SeqCst)
-  }
-
-  /// Add a [`WebView`] to the queue.
-  fn push(&self, webview: WebView, uri: String, headers: Option<http::HeaderMap>) {
-    let mut queue = self.queue.lock().expect("poisoned load queue");
-    queue.push_back(WebviewUriRequest {
-      webview,
-      uri,
-      headers,
-    })
-  }
-
-  /// Remove a [`WebView`] from the queue and return it.
-  fn pop(&self) -> Option<WebviewUriRequest> {
-    let mut queue = self.queue.lock().expect("poisoned load queue");
-    queue.pop_front()
-  }
-
-  /// Load the next uri to load if the lock is not engaged.
-  fn flush(self: Rc<Self>) {
-    if !self.is_locked() {
-      if let Some(WebviewUriRequest {
-        webview,
-        uri,
-        headers,
-      }) = self.pop()
-      {
-        // ensure that the lock is released when the webview is destroyed before LoadEvent::Finished is handled
-        let self_ = self.clone();
-        let destroy_id = webview.connect_destroy(move |_| {
-          self_.unlock();
-          self_.clone().flush();
-        });
-        let destroy_id_guard = Mutex::new(Some(destroy_id));
-
-        let load_changed_id_guard = Rc::new(Mutex::new(None));
-        let load_changed_id_guard_ = load_changed_id_guard.clone();
-        let self_ = self.clone();
-        // noet: we do not need to listen to failed events because those will finish the change event anyways
-        let load_changed_id = webview.connect_load_changed(move |w, event| {
-          if let LoadEvent::Finished = event {
-            self_.unlock();
-            self_.clone().flush();
-
-            // unregister listeners
-            if let Some(id) = destroy_id_guard.lock().unwrap().take() {
-              w.disconnect(id);
-            }
-            if let Some(id) = load_changed_id_guard_.lock().unwrap().take() {
-              w.disconnect(id);
-            }
-          };
-        });
-        load_changed_id_guard
-          .lock()
-          .unwrap()
-          .replace(load_changed_id);
-
-        if let Some(headers) = headers {
-          let req = URIRequest::builder().uri(&uri).build();
-
-          if let Some(ref mut req_headers) = req.http_headers() {
-            for (header, value) in headers.iter() {
-              req_headers.append(
-                header.to_string().as_str(),
-                value.to_str().unwrap_or_default(),
-              );
-            }
-          }
-
-          webview.load_request(&req);
-        } else {
-          webview.load_uri(&uri);
-        }
-      } else {
-        self.unlock();
-      }
-    }
-  }
-}

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -16,10 +16,9 @@ use std::{
   rc::Rc,
 };
 use webkit2gtk::{
-  ApplicationInfo, AutomationSessionExt, CookiePersistentStorage, DownloadExt, LoadEvent,
-  SecurityManagerExt, URIRequest, URIRequestExt, URISchemeRequest, URISchemeRequestExt,
-  URISchemeResponse, URISchemeResponseExt, WebContext, WebContextExt as Webkit2gtkContextExt,
-  WebView, WebViewExt,
+  ApplicationInfo, AutomationSessionExt, CookiePersistentStorage, DownloadExt, SecurityManagerExt,
+  URIRequest, URIRequestExt, URISchemeRequest, URISchemeRequestExt, URISchemeResponse,
+  URISchemeResponseExt, WebContext, WebContextExt as Webkit2gtkContextExt, WebView, WebViewExt,
 };
 
 #[derive(Debug)]


### PR DESCRIPTION
With the introduction of the multi webview unstable feature in #359, a workaround for request loading during webview initialization was added for an unknown concurrency bug in WebKitGTK. This PR now removes it because it has negative side effects and does not seem to be needed anymore:
* it introduces a deadlock situation (partially mitigated by #1561),
* it disables parallel loading when initializing multiple webviews, and
* the bug can no longer be reproduced using current WebKitGTK versions.

The workaround does not seem to have ever been intended to be a long term solution (FIXME comment). Unfortunately, there is no issue linked for the underlying issue and no reproduction was provided, which makes it hard to tell if the bug still exists with newer versions of WebKitGTK. But I have not been able to reproduce the issue on Ubuntu 24.04 using `libwebkit2gtk-4.1-0@2.48.3-0ubuntu0.24.04.1`. In the worst case scenario, this would cause a regression on an unstable feature while still fixing and improving webview loading in general on Linux.

This PR provides an alternate solution for #1562, which instead introduces a feature flag to opt out of the workaround.

Original description of the workaround:
> Prevents an unknown concurrency bug with loading multiple URIs at the same time on webkit2gtk.
>
> Using the queue prevents data race issues with loading uris for multiple [`WebView`]s in the
> same context at the same time. Occasionally, the one of the [`WebView`]s will be clobbered
> and it's content will be injected into a different [`WebView`].
>
> Example of `webview-c` clobbering `webview-b` while `webview-a` is okay:
> ```text
> webview-a triggers load-change::started
> URISchemeRequestCallback triggered with webview-a
> webview-a triggers load-change::committed
> webview-a triggers load-change::finished
> webview-b triggers load-change::started
> webview-c triggers load-change::started
> URISchemeRequestCallback triggered with webview-c
> URISchemeRequestCallback triggered with webview-c
> webview-c triggers load-change::committed
> webview-c triggers load-change::finished
> ```
>
> In that example, `webview-a` will load fine. `webview-b` will remain empty as the uri was
> never loaded. `webview-c` will contain the content of both `webview-b` and `webview-c`
> because it was triggered twice even through only started once. The content injected will not
> be sequential, and often is interjected in the middle of one of the other contents.
>
> FIXME: We think this may be an underlying concurrency bug in webkit2gtk as the usual ways of
> fixing threading issues are not working. Ideally, the locks are not needed if we can understand
> the true cause of the bug.

Closes https://github.com/tauri-apps/tauri/issues/12589
Refs https://github.com/tauri-apps/wry/pull/359

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
