### PR TITLE
Handle wkwebview web content process termination

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,6 +792,13 @@ pub struct WebViewAttributes<'a> {
 
   /// Whether JavaScript should be disabled.
   pub javascript_disabled: bool,
+
+  /// Set a handler closure to respond to web content process termination.
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Linux / Windows / Android**: Unsupported.
+  pub on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
 }
 
 impl Default for WebViewAttributes<'_> {
@@ -834,6 +841,7 @@ impl Default for WebViewAttributes<'_> {
       }),
       background_throttling: None,
       javascript_disabled: false,
+      on_web_content_process_terminate_handler: None,
     }
   }
 }
@@ -1402,6 +1410,15 @@ impl<'a> WebViewBuilder<'a> {
   /// Whether JavaScript should be disabled.
   pub fn with_javascript_disabled(mut self) -> Self {
     self.attrs.javascript_disabled = true;
+    self
+  }
+
+  /// Set a handler to respond to web content process termination.
+  pub fn with_on_web_content_process_terminate_handler(
+    mut self,
+    handler: impl Fn() + 'static,
+  ) -> Self {
+    self.attrs.on_web_content_process_terminate_handler = Some(Box::new(handler));
     self
   }
 

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -36,6 +36,7 @@ pub struct WryNavigationDelegateIvars {
   pub navigation_policy_function: Box<dyn Fn(String) -> bool>,
   pub download_delegate: Option<Retained<WryDownloadDelegate>>,
   pub on_page_load_handler: Option<Box<dyn Fn(PageLoadEvent)>>,
+  pub on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
 }
 
 define_class!(
@@ -114,6 +115,7 @@ impl WryNavigationDelegate {
     navigation_handler: Option<Box<dyn Fn(String) -> bool>>,
     download_delegate: Option<Retained<WryDownloadDelegate>>,
     on_page_load_handler: Option<Box<dyn Fn(PageLoadEvent, String)>>,
+    on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
     mtm: MainThreadMarker,
   ) -> Retained<Self> {
     let navigation_policy_function = Box::new(move |url: String| -> bool {
@@ -131,6 +133,15 @@ impl WryNavigationDelegate {
       None
     };
 
+    let on_web_content_process_terminate_handler = if let Some(handler) = on_web_content_process_terminate_handler {
+      let custom_handler = Box::new(move || {
+        handler();
+      }) as Box<dyn Fn()>;
+      Some(custom_handler)
+    } else {
+      None
+    };
+
     let delegate = mtm
       .alloc::<WryNavigationDelegate>()
       .set_ivars(WryNavigationDelegateIvars {
@@ -139,6 +150,7 @@ impl WryNavigationDelegate {
         has_download_handler,
         download_delegate,
         on_page_load_handler,
+        on_web_content_process_terminate_handler,
       });
 
     unsafe { msg_send![super(delegate), init] }

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -22,7 +22,7 @@ use crate::{
     download::{navigation_download_action, navigation_download_response},
     navigation::{
       did_commit_navigation, did_finish_navigation, navigation_policy, navigation_policy_response,
-      web_content_process_termination,
+      web_content_process_did_terminate,
     },
   },
   PageLoadEvent, WryWebView,
@@ -99,8 +99,8 @@ define_class!(
     }
 
     #[unsafe(method(webViewWebContentProcessDidTerminate:))]
-    fn web_content_process_termination(&self, webview: &WKWebView) {
-      web_content_process_termination(webview);
+    fn web_content_process_did_terminate(&self, webview: &WKWebView) {
+      web_content_process_did_terminate(self, webview);
     }
   }
 );

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -22,6 +22,7 @@ use crate::{
     download::{navigation_download_action, navigation_download_response},
     navigation::{
       did_commit_navigation, did_finish_navigation, navigation_policy, navigation_policy_response,
+      web_content_process_termination,
     },
   },
   PageLoadEvent, WryWebView,
@@ -95,6 +96,11 @@ define_class!(
       download: &WKDownload,
     ) {
       navigation_download_response(self, webview, response, download);
+    }
+
+    #[unsafe(method(webViewWebContentProcessDidTerminate:))]
+    fn web_content_process_termination(&self, webview: &WKWebView) {
+      web_content_process_termination(self, webview);
     }
   }
 );

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -100,7 +100,7 @@ define_class!(
 
     #[unsafe(method(webViewWebContentProcessDidTerminate:))]
     fn web_content_process_termination(&self, webview: &WKWebView) {
-      web_content_process_termination(self, webview);
+      web_content_process_termination(webview);
     }
   }
 );

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -542,6 +542,7 @@ impl InnerWebView {
         attributes.navigation_handler,
         download_delegate.clone(),
         attributes.on_page_load_handler,
+        attributes.on_web_content_process_terminate_handler,
         mtm,
       );
 

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -103,6 +103,9 @@ pub(crate) fn navigation_policy_response(
   }
 }
 
-pub(crate) fn web_content_process_termination(webview: &WKWebView) {
+pub(crate) fn web_content_process_did_terminate(
+  _this: &WryNavigationDelegate,
+  webview: &WKWebView,
+) {
   unsafe { webview.reload() };
 }

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -102,3 +102,10 @@ pub(crate) fn navigation_policy_response(
     (*handler).call((WKNavigationResponsePolicy::Allow,));
   }
 }
+
+pub(crate) fn web_content_process_termination(
+  this: &WryNavigationDelegate,
+  webview: &WKWebView,
+) {
+  unsafe { webview.reload() };
+}

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -103,9 +103,6 @@ pub(crate) fn navigation_policy_response(
   }
 }
 
-pub(crate) fn web_content_process_termination(
-  this: &WryNavigationDelegate,
-  webview: &WKWebView,
-) {
+pub(crate) fn web_content_process_termination(webview: &WKWebView) {
   unsafe { webview.reload() };
 }

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -104,8 +104,10 @@ pub(crate) fn navigation_policy_response(
 }
 
 pub(crate) fn web_content_process_did_terminate(
-  _this: &WryNavigationDelegate,
-  webview: &WKWebView,
+  this: &WryNavigationDelegate,
+  _webview: &WKWebView,
 ) {
-  unsafe { webview.reload() };
+  if let Some(on_web_content_process_terminate) = &this.ivars().on_web_content_process_terminate_handler {
+    on_web_content_process_terminate();
+  }
 }


### PR DESCRIPTION
For WKWebView, the webview's content process can get terminated, especially when the app is backgrounded. This results in a blank screen when you resume the app. To fix this, the webview can be reloaded in the webViewWebContentProcessDidTerminate method in WKNavigationDelegate.