### PR TITLE
feat(ios/macos): Add handler for web content process termination

### DIFF
--- a/.changes/web-content-process-termination.md
+++ b/.changes/web-content-process-termination.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add handler for web content process termination.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1533,7 +1533,9 @@ impl WebViewBuilderExtDarwin for WebViewBuilder<'_> {
   }
 
   fn with_on_web_content_process_terminate_handler(mut self, handler: impl Fn() + 'static) -> Self {
-    self.platform_specific.on_web_content_process_terminate_handler = Some(Box::new(handler));
+    self
+      .platform_specific
+      .on_web_content_process_terminate_handler = Some(Box::new(handler));
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,14 +792,6 @@ pub struct WebViewAttributes<'a> {
 
   /// Whether JavaScript should be disabled.
   pub javascript_disabled: bool,
-
-
-  /// Set a handler closure to respond to web content process termination.
-  ///
-  /// ## Platform-specific:
-  ///
-  /// - **Linux / Windows / Android**: Unsupported.
-  pub on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
 }
 
 impl Default for WebViewAttributes<'_> {
@@ -842,7 +834,6 @@ impl Default for WebViewAttributes<'_> {
       }),
       background_throttling: None,
       javascript_disabled: false,
-      on_web_content_process_terminate_handler: None,
     }
   }
 }
@@ -1414,15 +1405,6 @@ impl<'a> WebViewBuilder<'a> {
     self
   }
 
-  /// Set a handler to respond to web content process termination.
-  pub fn with_on_web_content_process_terminate_handler(
-    mut self,
-    handler: impl Fn() + 'static,
-  ) -> Self {
-    self.attrs.on_web_content_process_terminate_handler = Some(Box::new(handler));
-    self
-  }
-
   /// Consume the builder and create the [`WebView`] from a type that implements [`HasWindowHandle`].
   ///
   /// # Platform-specific:
@@ -1480,6 +1462,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   data_store_identifier: Option<[u8; 16]>,
   traffic_light_inset: Option<dpi::Position>,
   allow_link_preview: bool,
+  on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
   #[cfg(target_os = "ios")]
   input_accessory_view_builder: Option<Box<InputAccessoryViewBuilder>>,
   #[cfg(target_os = "ios")]
@@ -1496,6 +1479,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       traffic_light_inset: None,
       // platform default for this is true
       allow_link_preview: true,
+      on_web_content_process_terminate_handler: None,
       #[cfg(target_os = "ios")]
       input_accessory_view_builder: None,
       #[cfg(target_os = "ios")]
@@ -1527,6 +1511,8 @@ pub trait WebViewBuilderExtDarwin {
   ///
   /// See https://developer.apple.com/documentation/webkit/wkwebview/allowslinkpreview
   fn with_allow_link_preview(self, allow_link_preview: bool) -> Self;
+  /// Set a handler closure to respond to web content process termination. Available on macOS and iOS only.
+  fn with_on_web_content_process_terminate_handler(self, handler: impl Fn() + 'static) -> Self;
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -1543,6 +1529,11 @@ impl WebViewBuilderExtDarwin for WebViewBuilder<'_> {
 
   fn with_allow_link_preview(mut self, allow_link_preview: bool) -> Self {
     self.platform_specific.allow_link_preview = allow_link_preview;
+    self
+  }
+
+  fn with_on_web_content_process_terminate_handler(mut self, handler: impl Fn() + 'static) -> Self {
+    self.platform_specific.on_web_content_process_terminate_handler = Some(Box::new(handler));
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,6 +792,14 @@ pub struct WebViewAttributes<'a> {
 
   /// Whether JavaScript should be disabled.
   pub javascript_disabled: bool,
+
+
+  /// Set a handler closure to respond to web content process termination.
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Linux / Windows / Android**: Unsupported.
+  pub on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
 }
 
 impl Default for WebViewAttributes<'_> {
@@ -834,6 +842,7 @@ impl Default for WebViewAttributes<'_> {
       }),
       background_throttling: None,
       javascript_disabled: false,
+      on_web_content_process_terminate_handler: None,
     }
   }
 }
@@ -1402,6 +1411,15 @@ impl<'a> WebViewBuilder<'a> {
   /// Whether JavaScript should be disabled.
   pub fn with_javascript_disabled(mut self) -> Self {
     self.attrs.javascript_disabled = true;
+    self
+  }
+
+  /// Set a handler to respond to web content process termination.
+  pub fn with_on_web_content_process_terminate_handler(
+    mut self,
+    handler: impl Fn() + 'static,
+  ) -> Self {
+    self.attrs.on_web_content_process_terminate_handler = Some(Box::new(handler));
     self
   }
 

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -22,6 +22,7 @@ use crate::{
     download::{navigation_download_action, navigation_download_response},
     navigation::{
       did_commit_navigation, did_finish_navigation, navigation_policy, navigation_policy_response,
+      web_content_process_did_terminate,
     },
   },
   PageLoadEvent, WryWebView,
@@ -35,6 +36,7 @@ pub struct WryNavigationDelegateIvars {
   pub navigation_policy_function: Box<dyn Fn(String) -> bool>,
   pub download_delegate: Option<Retained<WryDownloadDelegate>>,
   pub on_page_load_handler: Option<Box<dyn Fn(PageLoadEvent)>>,
+  pub on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
 }
 
 define_class!(
@@ -96,6 +98,11 @@ define_class!(
     ) {
       navigation_download_response(self, webview, response, download);
     }
+
+    #[unsafe(method(webViewWebContentProcessDidTerminate:))]
+    fn web_content_process_did_terminate(&self, webview: &WKWebView) {
+      web_content_process_did_terminate(self, webview);
+    }
   }
 );
 
@@ -108,6 +115,7 @@ impl WryNavigationDelegate {
     navigation_handler: Option<Box<dyn Fn(String) -> bool>>,
     download_delegate: Option<Retained<WryDownloadDelegate>>,
     on_page_load_handler: Option<Box<dyn Fn(PageLoadEvent, String)>>,
+    on_web_content_process_terminate_handler: Option<Box<dyn Fn()>>,
     mtm: MainThreadMarker,
   ) -> Retained<Self> {
     let navigation_policy_function = Box::new(move |url: String| -> bool {
@@ -125,6 +133,15 @@ impl WryNavigationDelegate {
       None
     };
 
+    let on_web_content_process_terminate_handler = if let Some(handler) = on_web_content_process_terminate_handler {
+      let custom_handler = Box::new(move || {
+        handler();
+      }) as Box<dyn Fn()>;
+      Some(custom_handler)
+    } else {
+      None
+    };
+
     let delegate = mtm
       .alloc::<WryNavigationDelegate>()
       .set_ivars(WryNavigationDelegateIvars {
@@ -133,6 +150,7 @@ impl WryNavigationDelegate {
         has_download_handler,
         download_delegate,
         on_page_load_handler,
+        on_web_content_process_terminate_handler,
       });
 
     unsafe { msg_send![super(delegate), init] }

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -133,14 +133,15 @@ impl WryNavigationDelegate {
       None
     };
 
-    let on_web_content_process_terminate_handler = if let Some(handler) = on_web_content_process_terminate_handler {
-      let custom_handler = Box::new(move || {
-        handler();
-      }) as Box<dyn Fn()>;
-      Some(custom_handler)
-    } else {
-      None
-    };
+    let on_web_content_process_terminate_handler =
+      if let Some(handler) = on_web_content_process_terminate_handler {
+        let custom_handler = Box::new(move || {
+          handler();
+        }) as Box<dyn Fn()>;
+        Some(custom_handler)
+      } else {
+        None
+      };
 
     let delegate = mtm
       .alloc::<WryNavigationDelegate>()

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -542,6 +542,7 @@ impl InnerWebView {
         attributes.navigation_handler,
         download_delegate.clone(),
         attributes.on_page_load_handler,
+        attributes.on_web_content_process_terminate_handler,
         mtm,
       );
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -542,7 +542,7 @@ impl InnerWebView {
         attributes.navigation_handler,
         download_delegate.clone(),
         attributes.on_page_load_handler,
-        attributes.on_web_content_process_terminate_handler,
+        pl_attrs.on_web_content_process_terminate_handler,
         mtm,
       );
 

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -102,3 +102,12 @@ pub(crate) fn navigation_policy_response(
     (*handler).call((WKNavigationResponsePolicy::Allow,));
   }
 }
+
+pub(crate) fn web_content_process_did_terminate(
+  this: &WryNavigationDelegate,
+  _webview: &WKWebView,
+) {
+  if let Some(on_web_content_process_terminate) = &this.ivars().on_web_content_process_terminate_handler {
+    on_web_content_process_terminate();
+  }
+}

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -107,7 +107,9 @@ pub(crate) fn web_content_process_did_terminate(
   this: &WryNavigationDelegate,
   _webview: &WKWebView,
 ) {
-  if let Some(on_web_content_process_terminate) = &this.ivars().on_web_content_process_terminate_handler {
+  if let Some(on_web_content_process_terminate) =
+    &this.ivars().on_web_content_process_terminate_handler
+  {
     on_web_content_process_terminate();
   }
 }


### PR DESCRIPTION
As it turns out, it's still important to handle the termination of the web content process.