### PR TITLE
chore: remove rustc/rustdoc args for docsrs cfg to fix docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ targets = [
   "x86_64-pc-windows-msvc",
   "x86_64-apple-darwin",
 ]
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["drag-drop", "protocol", "os-webview", "x11"]


### PR DESCRIPTION
seen in https://github.com/winnow-rs/winnow/issues/834#issuecomment-3403140625 and at least in my local docs.rs environment it works, also couldn't spot any differences in the generated docs.