### PR TITLE
fix: add missing backtick which breaks formatting in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,7 +629,7 @@ pub struct WebViewAttributes<'a> {
   /// different Origin headers across platforms:
   ///
   /// - macOS, iOS and Linux: `<scheme_name>://<path>` (so it will be `wry://path/to/page/`).
-  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://wry.path/to/page). To use `https` instead of `http`, use [`WebViewBuilderExtWindows::with_https_scheme`] and [`WebViewBuilderExtAndroid::with_https_scheme`].
+  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://wry.path/to/page`). To use `https` instead of `http`, use [`WebViewBuilderExtWindows::with_https_scheme`] and [`WebViewBuilderExtAndroid::with_https_scheme`].
   ///
   /// # Reading assets on mobile
   ///


### PR DESCRIPTION
Hi there,

this is just a small doc fix, there was a backtick (`\``) missing which broke the rendered HTML:

Broken:

<img width="1046" height="260" alt="Screenshot 2025-11-29 at 08 55 44" src="https://github.com/user-attachments/assets/a96d2e23-3049-4ef5-a101-f79258cfc72e" />

Fixed:
<img width="956" height="135" alt="Screenshot 2025-11-29 at 08 57 40" src="https://github.com/user-attachments/assets/0f521bf5-af4b-4166-9928-e4d74b9834f6" />
