### PR TITLE
fix: clippy io_other_error errors

### DIFF
--- a/.changes/fix-clippy-io_other_error.md
+++ b/.changes/fix-clippy-io_other_error.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix clippy io_other_error. No user facing changes.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1263,28 +1263,24 @@ pub fn platform_webview_version() -> Result<String> {
   unsafe {
     let Some(bundle) = NSBundle::bundleWithIdentifier(&NSString::from_str("com.apple.WebKit"))
     else {
-      return Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
+      return Err(Error::Io(std::io::Error::other(
         "failed to locate com.apple.WebKit bundle",
       )));
     };
     let Some(dict) = bundle.infoDictionary() else {
-      return Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
+      return Err(Error::Io(std::io::Error::other(
         "failed to get WebKit info dictionary",
       )));
     };
 
     let Some(webkit_version) = dict.objectForKey(&NSString::from_str("CFBundleVersion")) else {
-      return Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
+      return Err(Error::Io(std::io::Error::other(
         "failed to get WebKit version",
       )));
     };
 
     let Ok(webkit_version) = webkit_version.downcast::<NSString>() else {
-      return Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
+      return Err(Error::Io(std::io::Error::other(
         "failed to parse WebKit version",
       )));
     };


### PR DESCRIPTION
Fix clippy errors
```
warning: this can be `std::io::Error::other(_)`
    --> src/wkwebview/mod.rs:1266:28
     |
1266 |         return Err(Error::Io(std::io::Error::new(
     |  ____________________________^
1267 | |         std::io::ErrorKind::Other,
1268 | |         "failed to locate com.apple.WebKit bundle",
1269 | |       )));
     | |_______^
     |
```