### PR TITLE
enhance: Add an option to control browser-level autofill behavior on Windows

### DIFF
--- a/.changes/general-autofill.md
+++ b/.changes/general-autofill.md
@@ -1,0 +1,5 @@
+---
+'wry': 'patch:enhance'
+---
+
+Add an option to control browser-level autofill behavior on Windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -804,10 +804,10 @@ pub struct WebViewAttributes<'a> {
   ///
   /// - **Windows**: Supported. On Windows, WebView2's autofill feature (called
   ///   "Suggestions") may not honor `autocomplete="off"` attributes on input
-  ///   elements in some cases. When this option is `Some(false)`, that autofill
+  ///   elements in some cases. When this option is `false`, that autofill
   ///   behavior will be disabled.
   /// - **macOS / Linux / Android / iOS**: Unsupported and ignored.
-  pub general_autofill_enabled: Option<bool>,
+  pub general_autofill_enabled: bool,
 }
 
 impl Default for WebViewAttributes<'_> {
@@ -850,7 +850,7 @@ impl Default for WebViewAttributes<'_> {
       }),
       background_throttling: None,
       javascript_disabled: false,
-      general_autofill_enabled: None,
+      general_autofill_enabled: true,
     }
   }
 }
@@ -1433,11 +1433,11 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// - **Windows**: Supported. On Windows, WebView2's autofill feature (called
   ///   "Suggestions") may not honor `autocomplete="off"` attributes on input
-  ///   elements in some cases. When this option is `Some(false)`, that autofill
+  ///   elements in some cases. When this option is `false`, that autofill
   ///   behavior will be disabled.
   /// - **macOS / Linux / Android / iOS**: Unsupported and ignored.
   pub fn with_general_autofill_enabled(mut self, enabled: bool) -> Self {
-    self.attrs.general_autofill_enabled = Some(enabled);
+    self.attrs.general_autofill_enabled = enabled;
     self
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,10 +795,13 @@ pub struct WebViewAttributes<'a> {
 
   /// Controls the WebView's browser-level general autofill behavior.
   ///
+  /// **This option does not disable password or credit card autofill.**
+  ///
   /// When enabled, the WebView may automatically populate form fields using
   /// previously stored data such as addresses or contact information.
   ///
-  /// If set to `None`, the default platform behavior is preserved.
+  /// If not specified, this is `true` by default.
+  /// Setting this to `false` preserves the default platform behavior.
   ///
   /// ## Platform-specific
   ///
@@ -1424,10 +1427,13 @@ impl<'a> WebViewBuilder<'a> {
 
   /// Controls the WebView's browser-level general autofill behavior.
   ///
+  /// **This option does not disable password or credit card autofill.**
+  ///
   /// When enabled, the WebView may automatically populate form fields using
   /// previously stored data such as addresses or contact information.
   ///
-  /// If set to `None`, the default platform behavior is preserved.
+  /// If not specified, this is `true` by default.
+  /// Setting this to `false` preserves the default platform behavior.
   ///
   /// ## Platform-specific
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,6 +792,22 @@ pub struct WebViewAttributes<'a> {
 
   /// Whether JavaScript should be disabled.
   pub javascript_disabled: bool,
+
+  /// Controls the WebView's browser-level general autofill behavior.
+  ///
+  /// When enabled, the WebView may automatically populate form fields using
+  /// previously stored data such as addresses or contact information.
+  ///
+  /// If set to `None`, the default platform behavior is preserved.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows**: Supported. On Windows, WebView2's autofill feature (called
+  ///   "Suggestions") may not honor `autocomplete="off"` attributes on input
+  ///   elements in some cases. When this option is `Some(false)`, that autofill
+  ///   behavior will be disabled.
+  /// - **macOS / Linux / Android / iOS**: Unsupported and ignored.
+  pub general_autofill_enabled: Option<bool>,
 }
 
 impl Default for WebViewAttributes<'_> {
@@ -834,6 +850,7 @@ impl Default for WebViewAttributes<'_> {
       }),
       background_throttling: None,
       javascript_disabled: false,
+      general_autofill_enabled: None,
     }
   }
 }
@@ -1402,6 +1419,25 @@ impl<'a> WebViewBuilder<'a> {
   /// Whether JavaScript should be disabled.
   pub fn with_javascript_disabled(mut self) -> Self {
     self.attrs.javascript_disabled = true;
+    self
+  }
+
+  /// Controls the WebView's browser-level general autofill behavior.
+  ///
+  /// When enabled, the WebView may automatically populate form fields using
+  /// previously stored data such as addresses or contact information.
+  ///
+  /// If set to `None`, the default platform behavior is preserved.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows**: Supported. On Windows, WebView2's autofill feature (called
+  ///   "Suggestions") may not honor `autocomplete="off"` attributes on input
+  ///   elements in some cases. When this option is `Some(false)`, that autofill
+  ///   behavior will be disabled.
+  /// - **macOS / Linux / Android / iOS**: Unsupported and ignored.
+  pub fn with_general_autofill_enabled(mut self, enabled: bool) -> Self {
+    self.attrs.general_autofill_enabled = Some(enabled);
     self
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,7 +801,6 @@ pub struct WebViewAttributes<'a> {
   /// previously stored data such as addresses or contact information.
   ///
   /// If not specified, this is `true` by default.
-  /// Setting this to `false` preserves the default platform behavior.
   ///
   /// ## Platform-specific
   ///
@@ -1433,7 +1432,6 @@ impl<'a> WebViewBuilder<'a> {
   /// previously stored data such as addresses or contact information.
   ///
   /// If not specified, this is `true` by default.
-  /// Setting this to `false` preserves the default platform behavior.
   ///
   /// ## Platform-specific
   ///

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -582,9 +582,7 @@ impl InnerWebView {
     }
 
     if let Ok(settings4) = settings.cast::<ICoreWebView2Settings4>() {
-      settings4.SetIsGeneralAutofillEnabled(
-      attributes.general_autofill_enabled,
-      )?;
+      settings4.SetIsGeneralAutofillEnabled(attributes.general_autofill_enabled)?;
     }
 
     if let Ok(settings5) = settings.cast::<ICoreWebView2Settings5>() {

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -581,10 +581,10 @@ impl InnerWebView {
       }
     }
 
-    if let Some(enabled) = attributes.general_autofill_enabled {
-      if let Ok(settings4) = settings.cast::<ICoreWebView2Settings4>() {
-        settings4.SetIsGeneralAutofillEnabled(enabled)?;
-     }
+    if let Ok(settings4) = settings.cast::<ICoreWebView2Settings4>() {
+      settings4.SetIsGeneralAutofillEnabled(
+      attributes.general_autofill_enabled,
+      )?;
     }
 
     if let Ok(settings5) = settings.cast::<ICoreWebView2Settings5>() {

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -581,6 +581,12 @@ impl InnerWebView {
       }
     }
 
+    if let Some(enabled) = attributes.general_autofill_enabled {
+      if let Ok(settings4) = settings.cast::<ICoreWebView2Settings4>() {
+        settings4.SetIsGeneralAutofillEnabled(enabled)?;
+     }
+    }
+
     if let Ok(settings5) = settings.cast::<ICoreWebView2Settings5>() {
       settings5.SetIsPinchZoomEnabled(attributes.zoom_hotkeys_enabled)?;
     }


### PR DESCRIPTION
close tauri-apps/wry#1535

This PR adds an optional WebView attribute to control browser-level autofill behavior on Windows.

The motivation for exposing this option is that browser-level autofill behavior in WebView2
is controlled by the underlying runtime and cannot always be influenced through standard
HTML attributes alone. In some scenarios, applications need a way to explicitly opt out of
browser-managed autofill at the WebView level.

The default behavior is preserved unless the option is explicitly set.  
The change is limited to the WebView2 implementation and does not affect other platforms.

### Related issues
- https://github.com/tauri-apps/wry/issues/1535
- https://github.com/clash-verge-rev/clash-verge-rev/issues/5944

### Follow-up
I will submit a separate PR to `tauri` to expose this API at the application level.