### PR TITLE
fix!: remove Send, Sync bounds from closure to fix tauri issue 14801

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,8 +700,7 @@ pub struct WebViewAttributes<'a> {
   /// - **Windows**: The closure is executed on a separate thread to prevent a deadlock.
   ///
   /// [window.open]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
-  pub new_window_req_handler:
-    Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse + Send + Sync>>,
+  pub new_window_req_handler: Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse>>,
 
   /// Enables clipboard access for the page rendered on **Linux** and **Windows**.
   ///
@@ -1319,7 +1318,7 @@ impl<'a> WebViewBuilder<'a> {
   /// [window.open]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
   pub fn with_new_window_req_handler(
     mut self,
-    callback: impl Fn(String, NewWindowFeatures) -> NewWindowResponse + Send + Sync + 'static,
+    callback: impl Fn(String, NewWindowFeatures) -> NewWindowResponse + 'static,
   ) -> Self {
     self.attrs.new_window_req_handler = Some(Box::new(callback));
     self


### PR DESCRIPTION
The Send and Sync bounds on the closure are not used and prevent the most straightforward fix to [tauri issue 14801](https://github.com/tauri-apps/tauri/issues/14801) that I can come up with.

I'm basing my PR on heuristics, and have no idea if the removal of these bounds is going to affect some changes down the line.