### PR TITLE
fix(windows): run `new_window_req_handler` on main thread

### DIFF
--- a/.changes/new-window-handler-no-send.md
+++ b/.changes/new-window-handler-no-send.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Run `new_window_req_handler` on main thread and remove the `Send + Sync` restriction on it

--- a/.changes/new-window-handler-no-send.md
+++ b/.changes/new-window-handler-no-send.md
@@ -1,5 +1,5 @@
 ---
-wry: patch
+wry: minor
 ---
 
 Run `new_window_req_handler` on main thread and remove the `Send + Sync` restriction on it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,13 +695,8 @@ pub struct WebViewAttributes<'a> {
   ///
   /// The closure take the URL to open and the window features object and returns [`NewWindowResponse`] to determine whether the window should open.
   ///
-  /// ## Platform-specific:
-  ///
-  /// - **Windows**: The closure is executed on a separate thread to prevent a deadlock.
-  ///
   /// [window.open]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
-  pub new_window_req_handler:
-    Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse + Send + Sync>>,
+  pub new_window_req_handler: Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse>>,
 
   /// Enables clipboard access for the page rendered on **Linux** and **Windows**.
   ///
@@ -1319,7 +1314,7 @@ impl<'a> WebViewBuilder<'a> {
   /// [window.open]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
   pub fn with_new_window_req_handler(
     mut self,
-    callback: impl Fn(String, NewWindowFeatures) -> NewWindowResponse + Send + Sync + 'static,
+    callback: impl Fn(String, NewWindowFeatures) -> NewWindowResponse + 'static,
   ) -> Self {
     self.attrs.new_window_req_handler = Some(Box::new(callback));
     self

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -689,7 +689,7 @@ impl InnerWebView {
     let new_window_req_handler = attributes
       .new_window_req_handler
       .take()
-      .map(std::sync::Arc::new);
+      .map(std::rc::Rc::new);
     let env_ = env.clone();
     // New window handler
     webview.add_NewWindowRequested(
@@ -753,25 +753,19 @@ impl InnerWebView {
 
           let new_window_req_handler = new_window_req_handler.clone();
           let deferral = args.GetDeferral()?;
-          let deferral = UnsafeSend(deferral);
-          let args = UnsafeSend(args);
-          let hwnd = UnsafeSend(hwnd);
-          std::thread::spawn(move || match new_window_req_handler(uri, features) {
+          Self::dispatch_handler(hwnd, move || match new_window_req_handler(uri, features) {
             NewWindowResponse::Allow => {
-              let _ = args.take().SetHandled(false);
-              let _ = deferral.take().Complete();
+              let _ = args.SetHandled(false);
+              let _ = deferral.Complete();
             }
             NewWindowResponse::Create { webview } => {
-              Self::dispatch_handler(hwnd.take(), move || {
-                let args = args.take();
-                let _ = args.SetHandled(true);
-                let _ = args.SetNewWindow(&webview);
-                let _ = deferral.take().Complete();
-              });
+              let _ = args.SetHandled(true);
+              let _ = args.SetNewWindow(&webview);
+              let _ = deferral.Complete();
             }
             NewWindowResponse::Deny => {
-              let _ = args.take().SetHandled(true);
-              let _ = deferral.take().Complete();
+              let _ = args.SetHandled(true);
+              let _ = deferral.Complete();
             }
           });
         } else {
@@ -782,6 +776,7 @@ impl InnerWebView {
       })),
       token,
     )?;
+    Self::attach_main_thread_dispatcher(hwnd);
 
     // Download handler
     if attributes.download_started_handler.is_some()
@@ -1158,9 +1153,9 @@ impl InnerWebView {
         err.message()
       );
       #[cfg(feature = "tracing")]
-      tracing::error!("{}", &msg);
+      tracing::error!("{msg}");
       #[cfg(debug_assertions)]
-      eprintln!("{}", msg);
+      eprintln!("{msg}");
     }
   }
 
@@ -1836,13 +1831,4 @@ fn is_windows_7() -> bool {
   let v = windows_version::OsVersion::current();
   // windows 7 is 6.1
   v.major == 6 && v.minor == 1
-}
-
-struct UnsafeSend<T>(T);
-unsafe impl<T> Send for UnsafeSend<T> {}
-
-impl<T> UnsafeSend<T> {
-  fn take(self) -> T {
-    self.0
-  }
 }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -753,6 +753,9 @@ impl InnerWebView {
 
           let new_window_req_handler = new_window_req_handler.clone();
           let deferral = args.GetDeferral()?;
+          // Use `dispatch_handler` to schedule the run on the message loop after this callback completes,
+          // this is needed for `new_window_req_handler` to create new webviews for `NewWindowResponse::Create`
+          // or it will deadlock, see https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/threading-model#reentrancy
           Self::dispatch_handler(hwnd, move || match new_window_req_handler(uri, features) {
             NewWindowResponse::Allow => {
               let _ = args.SetHandled(false);
@@ -1132,6 +1135,13 @@ impl InnerWebView {
     env.CreateWebResourceResponse(None, status_code as i32, &status, &error)
   }
 
+  /// Send `function` to run on `hwnd`'s thread
+  ///
+  /// ## SAFETY:
+  ///
+  /// This function doesn't force a `Send` to make it easier to use,
+  /// the caller must call this function on the same thread as `hwnd`
+  /// or ensure the function is can be `Send`
   #[inline]
   unsafe fn dispatch_handler<F>(hwnd: HWND, function: F)
   where

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1141,7 +1141,7 @@ impl InnerWebView {
   ///
   /// This function doesn't force a `Send` to make it easier to use,
   /// the caller must call this function on the same thread as `hwnd`
-  /// or ensure the function is safe to `Send`
+  /// or ensure the function is safe to send to and called on `hwnd`'s thread
   #[inline]
   unsafe fn dispatch_handler<F>(hwnd: HWND, function: F)
   where

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1141,7 +1141,7 @@ impl InnerWebView {
   ///
   /// This function doesn't force a `Send` to make it easier to use,
   /// the caller must call this function on the same thread as `hwnd`
-  /// or ensure the function is can be `Send`
+  /// or ensure the function is safe to `Send`
   #[inline]
   unsafe fn dispatch_handler<F>(hwnd: HWND, function: F)
   where

--- a/src/wkwebview/class/wry_web_view_ui_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_ui_delegate.rs
@@ -82,8 +82,7 @@ impl WryNSWindowDelegate {
 
 pub struct WryWebViewUIDelegateIvars {
   #[cfg(target_os = "macos")]
-  new_window_req_handler:
-    Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse + Send + Sync>>,
+  new_window_req_handler: Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse>>,
   #[cfg(target_os = "macos")]
   new_windows: Rc<RefCell<Vec<NewWindow>>>,
 }
@@ -267,9 +266,7 @@ define_class!(
 impl WryWebViewUIDelegate {
   pub fn new(
     mtm: MainThreadMarker,
-    new_window_req_handler: Option<
-      Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse + Send + Sync>,
-    >,
+    new_window_req_handler: Option<Box<dyn Fn(String, NewWindowFeatures) -> NewWindowResponse>>,
   ) -> Retained<Self> {
     #[cfg(target_os = "ios")]
     let _new_window_req_handler = new_window_req_handler;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Implement the solution in https://github.com/tauri-apps/wry/pull/1657#issuecomment-3823336202, closes #1657

Run `new_window_req_handler` on main thread and remove the `Send + Sync` restriction on it

Also fixed:

- `NewWindowResponse::Create` not working if no custom protocol's registered
- `tauri-runtime-wry`'s usage of `RefCell` on another thread pointed out by @sftse in https://github.com/tauri-apps/tauri/pull/14805