### PR TITLE
feat(macos): implement background_color for WKWebView

### DIFF
--- a/.changes/fix-macos-background-color.md
+++ b/.changes/fix-macos-background-color.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, implement `background_color` support for WKWebView behind the `transparent` feature. Disables the default white background via the `drawsBackground` KVC key at init and applies `underPageBackgroundColor` on macOS 12+ for both initial creation and runtime `set_background_color` calls.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,7 +564,8 @@ pub struct WebViewAttributes<'a> {
   ///
   /// ## Platform-specific:
   ///
-  /// - **macOS**: Not implemented.
+  /// - **macOS**: Disables the default white WKWebView background via the `drawsBackground` KVC key
+  ///   (same as the `transparent` feature) and sets `underPageBackgroundColor` (macOS 12+) for overscroll areas.
   /// - **Windows**:
   ///   - On Windows 7, transparency is not supported and the alpha value will be ignored.
   ///   - On Windows higher than 7: translucent colors are not supported so any alpha value other than `0` will be replaced by `255`
@@ -920,7 +921,8 @@ impl<'a> WebViewBuilder<'a> {
   ///
   /// ## Platfrom-specific:
   ///
-  /// - **macOS**: Not implemented.
+  /// - **macOS**: Disables the default white WKWebView background via the `drawsBackground` KVC key
+  ///   (same as the `transparent` feature) and sets `underPageBackgroundColor` (macOS 12+) for overscroll areas.
   /// - **Windows**:
   ///   - on Windows 7, transparency is not supported and the alpha value will be ignored.
   ///   - on Windows higher than 7: translucent colors are not supported so any alpha value other than `0` will be replaced by `255`
@@ -2110,7 +2112,8 @@ impl WebView {
   ///
   /// ## Platfrom-specific:
   ///
-  /// - **macOS**: Not implemented.
+  /// - **macOS**: Disables the default white WKWebView background via the `drawsBackground` KVC key
+  ///   (same as the `transparent` feature) and sets `underPageBackgroundColor` (macOS 12+) for overscroll areas.
   /// - **Windows**:
   ///   - On Windows 7, transparency is not supported and the alpha value will be ignored.
   ///   - On Windows higher than 7: translucent colors are not supported so any alpha value other than `0` will be replaced by `255`

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -352,19 +352,9 @@ impl InnerWebView {
       }
 
       #[cfg(feature = "transparent")]
-      if attributes.transparent {
+      if attributes.transparent || attributes.background_color.is_some() {
         let no = NSNumber::numberWithBool(false);
         // Equivalent Obj-C:
-        config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
-      }
-
-      // On macOS, disable the default white WKWebView background when a custom
-      // background color is specified. Applied to the config before initWithFrame
-      // so the WKWebView never renders a white frame.
-      // Uses the same `drawsBackground` KVC key as the `transparent` feature above.
-      #[cfg(target_os = "macos")]
-      if attributes.background_color.is_some() {
-        let no = NSNumber::numberWithBool(false);
         config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
       }
 
@@ -929,7 +919,7 @@ r#"Object.defineProperty(window, 'ipc', {
       self.webview.setBackgroundColor(Some(&color));
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos", feature = "transparent"))]
     unsafe {
       let (red, green, blue, alpha) = _background_color;
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -358,6 +358,16 @@ impl InnerWebView {
         config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
       }
 
+      // On macOS, disable the default white WKWebView background when a custom
+      // background color is specified. Applied to the config before initWithFrame
+      // so the WKWebView never renders a white frame.
+      // Uses the same `drawsBackground` KVC key as the `transparent` feature above.
+      #[cfg(target_os = "macos")]
+      if attributes.background_color.is_some() {
+        let no = NSNumber::numberWithBool(false);
+        config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
+      }
+
       #[cfg(feature = "fullscreen")]
       // Equivalent Obj-C:
       _preference.setValue_forKey(Some(&_yes), ns_string!("fullScreenEnabled"));
@@ -399,6 +409,20 @@ impl InnerWebView {
         };
         let webview: Retained<WryWebView> =
           objc2::msg_send![super(webview), initWithFrame: frame, configuration: &**config];
+
+        // Set the under-page background color for overscroll areas (public API, macOS 12+).
+        // drawsBackground is already disabled on the config above, so the window background
+        // shows through. This handles the color visible when scrolling past page bounds.
+        if let Some((red, green, blue, alpha)) = attributes.background_color {
+          let color = objc2_app_kit::NSColor::colorWithSRGBRed_green_blue_alpha(
+            red as f64 / 255.0,
+            green as f64 / 255.0,
+            blue as f64 / 255.0,
+            alpha as f64 / 255.0,
+          );
+          webview.setUnderPageBackgroundColor(Some(&color));
+        }
+
         webview
       };
       #[cfg(target_os = "ios")]
@@ -903,6 +927,26 @@ r#"Object.defineProperty(window, 'ipc', {
       // This has to be monitored as it may clash with isOpaque = true.
       // The webview background color may also applied too late so actually not that useful.
       self.webview.setBackgroundColor(Some(&color));
+    }
+
+    #[cfg(target_os = "macos")]
+    unsafe {
+      let (red, green, blue, alpha) = _background_color;
+
+      // Disable the default white background using the same drawsBackground KVC key
+      // as the `transparent` feature. On the webview instance (vs config) for runtime changes.
+      let no = NSNumber::numberWithBool(false);
+      self
+        .webview
+        .setValue_forKey(Some(&no), ns_string!("drawsBackground"));
+
+      let color = objc2_app_kit::NSColor::colorWithSRGBRed_green_blue_alpha(
+        red as f64 / 255.0,
+        green as f64 / 255.0,
+        blue as f64 / 255.0,
+        alpha as f64 / 255.0,
+      );
+      self.webview.setUnderPageBackgroundColor(Some(&color));
     }
 
     Ok(())

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -403,14 +403,16 @@ impl InnerWebView {
         // Set the under-page background color for overscroll areas (public API, macOS 12+).
         // drawsBackground is already disabled on the config above, so the window background
         // shows through. This handles the color visible when scrolling past page bounds.
-        if let Some((red, green, blue, alpha)) = attributes.background_color {
-          let color = objc2_app_kit::NSColor::colorWithSRGBRed_green_blue_alpha(
-            red as f64 / 255.0,
-            green as f64 / 255.0,
-            blue as f64 / 255.0,
-            alpha as f64 / 255.0,
-          );
-          webview.setUnderPageBackgroundColor(Some(&color));
+        if os_major_version >= 12 {
+          if let Some((red, green, blue, alpha)) = attributes.background_color {
+            let color = objc2_app_kit::NSColor::colorWithSRGBRed_green_blue_alpha(
+              red as f64 / 255.0,
+              green as f64 / 255.0,
+              blue as f64 / 255.0,
+              alpha as f64 / 255.0,
+            );
+            webview.setUnderPageBackgroundColor(Some(&color));
+          }
         }
 
         webview
@@ -930,13 +932,16 @@ r#"Object.defineProperty(window, 'ipc', {
         .webview
         .setValue_forKey(Some(&no), ns_string!("drawsBackground"));
 
-      let color = objc2_app_kit::NSColor::colorWithSRGBRed_green_blue_alpha(
-        red as f64 / 255.0,
-        green as f64 / 255.0,
-        blue as f64 / 255.0,
-        alpha as f64 / 255.0,
-      );
-      self.webview.setUnderPageBackgroundColor(Some(&color));
+      let (os_major_version, _, _) = util::operating_system_version();
+      if os_major_version >= 12 {
+        let color = objc2_app_kit::NSColor::colorWithSRGBRed_green_blue_alpha(
+          red as f64 / 255.0,
+          green as f64 / 255.0,
+          blue as f64 / 255.0,
+          alpha as f64 / 255.0,
+        );
+        self.webview.setUnderPageBackgroundColor(Some(&color));
+      }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Implements `background_color` / `with_background_color` / `set_background_color` on **macOS** — the only remaining platform where this was documented as "Not implemented".

- Disables the default white WKWebView background via the `drawsBackground` KVC key on `WKWebViewConfiguration` (pre-init), the same key already used by the `transparent` feature
- Sets `underPageBackgroundColor` (public API, macOS 12+) on the `WKWebView` instance for overscroll/loading areas
- Updates all three doc comments to reflect macOS support

## Context

The `backgroundColor` config in Tauri's `tauri.conf.json` correctly sets the **NSWindow** background on macOS, and the **webview** background on Windows (WebView2), Linux (WebKitGTK), iOS, and Android. However, wry's macOS codepath was a no-op — the WKWebView layer on top of the window retained its default white background, causing a visible white flash before HTML/CSS paints.

This has been a long-standing issue affecting dark-themed apps that use a hidden-then-shown window pattern to prevent flash on startup. The fix was deferred in the original PR #682 because no maintainer had macOS hardware to test on. The [Vector Privacy](https://github.com/VectorPrivacy/Vector) team would like to change that — we're committed to assisting fully with the review and merging of this PR, for the benefit of Vector as well as all other Tauri v2 apps on macOS that deserve a standardised way of preventing "the unholy flashbang".

## Real-World Tests (on a [real Tauri v2 app](https://github.com/VectorPrivacy/Vector))

**Before (With Flashbang!)**:
<video src="https://github.com/user-attachments/assets/77f9e15f-30d1-4ee8-8150-c6deac8a4e50" autoplay loop muted></video>

**After (No Flashbang!)**:
<video src="https://github.com/user-attachments/assets/e6b28580-6de8-4c23-b559-3580a91dcf8c" autoplay loop muted></video>

## Approach: `drawsBackground` KVC key

There is **no public Apple API** to disable WKWebView's default white background on macOS (`NSView` doesn't have a writable `opaque` property like iOS's `UIView`). The `drawsBackground` KVC key on `WKWebViewConfiguration` is the standard approach — and is already used by wry's own [`transparent` feature](https://github.com/tauri-apps/wry/blob/dev/src/wkwebview/mod.rs#L354-L359).

We investigated alternatives:
- `setUnderPageBackgroundColor` alone — does not prevent the initial white flash (only affects overscroll areas)
- `setOpaque(false)` — not available on macOS `NSView` (iOS-only setter)
- JS-side `setTimeout` delays before `.show()` — device-dependent, unreliable across hardware

### Feature-gating

If the maintainers prefer extra caution, this could be gated behind the existing `transparent` or `macos-private-api` feature flag — though we'd argue it should be ungated since `background_color` is a standard webview configuration, and the same KVC key is already used by the `transparent` feature on macOS.

## Research: safety of the `drawsBackground` KVC key

We conducted extensive research into the App Store safety of this key. Findings:

**Zero documented App Store rejections.** After searching Apple Developer Forums ([thread/121139](https://developer.apple.com/forums/thread/121139), [thread/65553](https://developer.apple.com/forums/thread/65553), [thread/87474](https://developer.apple.com/forums/thread/87474)), GitHub issues across wry, Tauri, WebKit, react-native-webview, Sparkle, and the WebKit bug tracker ([bug 200528](https://bugs.webkit.org/show_bug.cgi?id=200528)) — not a single report documents an actual Mac App Store rejection caused by `drawsBackground`.

**KVC string keys vs private selectors.** Apple's App Store scanner works by extracting Objective-C selectors from the binary's `__objc_selrefs` section and matching them against a private API database. When `drawsBackground` is accessed via `setValue:forKey:` (a public KVC API), the binary only contains the public selector `setValue:forKey:` and a string literal — **not** the private selector `_setDrawsBackground:`. Documented App Store rejections ([Electron #20027](https://github.com/electron/electron/issues/20027), [react-native-webview #2527](https://github.com/react-native-webview/react-native-webview/issues/2527), [cordova-plugin-ionic-webview #286](https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/286)) all flagged direct private selectors or class names in `__objc_selrefs`/`__objc_classrefs`, never KVC string keys.

**~9 years of stability.** The `drawsBackground` property has been present in WebKit since at least macOS 10.12 Sierra (2016) through macOS 15 Sequoia (2025), declared in `WKWebViewPrivate.h` and `WKWebViewConfigurationPrivate.h`. It has never been removed or broken across releases.

**Apple is aware of the gap.** Feedback [FB7539179](https://github.com/feedback-assistant/reports/issues/81) (filed January 2020) explicitly requested Apple make transparent WKWebView backgrounds a public API on macOS, noting developers are forced to use a "semi-private property." Apple has not made it public, but has also not broken or flagged it.

**No public alternative exists.** Apple added `underPageBackgroundColor` (macOS 12+) as a public API, but it only controls the color visible when scrolling past page bounds — it does not replace `drawsBackground` for preventing the white background from rendering.

**wry's existing warnings are precautionary.** The documentation at `src/lib.rs` lines 309-312 warns to "avoid this in release build if your app needs to publish to App Store" for the `transparent` feature. This warning cites no actual rejection event and is precautionary in nature ([tauri-docs #463](https://github.com/tauri-apps/tauri-docs/issues/463) likewise contains no evidence of rejections).

## Test plan

- [x] Tested on macOS (Apple Silicon) with [a Tauri v2 app](https://github.com/VectorPrivacy/Vector) using `backgroundColor: "#030303"` + `visible: false` + show-on-content-ready pattern
- [x] Verified **zero white flash** on startup in release builds — no JS-side delays needed
- [x] Verified overscroll areas show the correct dark color via `underPageBackgroundColor`
- [x] Confirmed the fix works with both init-time (`with_background_color`) and runtime (`set_background_color`) paths
- [ ] Windows/Linux builds should be unaffected (no changes to those codepaths)