### PR TITLE
fix(macOS）：Fix the crash issue on macOS 10.13 caused by the missing NSHTTPCookie symbol and the invocation of drawsBackground in WKWebViewConfiguration.

### DIFF
--- a/.changes/macos-cookie-symbol-not-found.md
+++ b/.changes/macos-cookie-symbol-not-found.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixed an issue that caused "Symbol not found: \_NSHTTPCookieSameSite..." panics on macOS `10.13` & `10.14`.

--- a/.changes/macos-set-draws-background-crash.md
+++ b/.changes/macos-set-draws-background-crash.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fixed an issue that caused "[<WKWebViewConfiguration 0x6000003f4d00> setValue:forUndefinedKey:]: this class is not key value coding-compliant for the key drawsBackground." panics on macOS `10.13`

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -354,7 +354,20 @@ impl InnerWebView {
       if attributes.transparent || attributes.background_color.is_some() {
         let no = NSNumber::numberWithBool(false);
         // Equivalent Obj-C:
-        config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
+        // drawsBackground is only available on macOS 10.14+
+        #[cfg(target_os = "macos")]
+        {
+          let version = util::operating_system_version();
+          if version.0 > 10 || (version.0 == 10 && version.1 >= 14) {
+            // Equivalent Obj-C:
+            config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
+          }
+        }
+        #[cfg(target_os = "ios")]
+        {
+          // Equivalent Obj-C:
+          config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
+        }
       }
 
       #[cfg(feature = "fullscreen")]

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -45,9 +45,8 @@ use objc2_core_foundation::{CGPoint, CGRect};
 use objc2_foundation::{
   ns_string, MainThreadMarker, NSArray, NSBundle, NSDate, NSError, NSHTTPCookie,
   NSHTTPCookieDomain, NSHTTPCookieExpires, NSHTTPCookieMaximumAge, NSHTTPCookieName,
-  NSHTTPCookiePath, NSHTTPCookiePropertyKey, NSHTTPCookieSameSiteLax, NSHTTPCookieSameSitePolicy,
-  NSHTTPCookieSameSiteStrict, NSHTTPCookieSecure, NSHTTPCookieValue, NSHTTPCookieVersion,
-  NSJSONSerialization, NSMutableDictionary, NSMutableURLRequest, NSNumber,
+  NSHTTPCookiePath, NSHTTPCookiePropertyKey, NSHTTPCookieSecure, NSHTTPCookieValue,
+  NSHTTPCookieVersion, NSJSONSerialization, NSMutableDictionary, NSMutableURLRequest, NSNumber,
   NSObjectNSKeyValueCoding, NSObjectProtocol, NSString, NSUTF8StringEncoding, NSURL, NSUUID,
 };
 #[cfg(target_os = "ios")]
@@ -1031,13 +1030,17 @@ r#"Object.defineProperty(window, 'ipc', {
     let secure = cookie.isSecure();
     cookie_builder = cookie_builder.secure(secure);
 
-    let same_site = cookie.sameSitePolicy();
-    let same_site = match same_site {
-      Some(policy) if &*policy == NSHTTPCookieSameSiteLax => cookie::SameSite::Lax,
-      Some(policy) if &*policy == NSHTTPCookieSameSiteStrict => cookie::SameSite::Strict,
-      _ => cookie::SameSite::None,
-    };
-    cookie_builder = cookie_builder.same_site(same_site);
+    // Using string comparison because of https://github.com/tauri-apps/wry/issues/1616
+    let (major, minor, _) = util::operating_system_version();
+    if major > 10 || (major == 10 && minor >= 15) {
+      let same_site = cookie.sameSitePolicy();
+      let same_site = match same_site {
+        Some(policy) if policy.to_string() == "lax" => cookie::SameSite::Lax,
+        Some(policy) if policy.to_string() == "strict" => cookie::SameSite::Strict,
+        _ => cookie::SameSite::None,
+      };
+      cookie_builder = cookie_builder.same_site(same_site);
+    }
 
     let expires = cookie.expiresDate();
     let expires = match expires {
@@ -1106,13 +1109,17 @@ r#"Object.defineProperty(window, 'ipc', {
       properties.insert(ns_string!("HttpOnly"), http_only);
     }
 
+    // Using strings because of https://github.com/tauri-apps/wry/issues/1616
     if let Some(same_site) = cookie.same_site() {
+      let key = ns_string!("SameSite");
+      let lax = ns_string!("lax");
+      let strict = ns_string!("strict");
       match same_site {
         cookie::SameSite::Lax => {
-          properties.insert(NSHTTPCookieSameSitePolicy, NSHTTPCookieSameSiteLax);
+          properties.insert(key, lax);
         }
         cookie::SameSite::Strict => {
-          properties.insert(NSHTTPCookieSameSitePolicy, NSHTTPCookieSameSiteStrict);
+          properties.insert(key, strict);
         }
         cookie::SameSite::None => {}
       };


### PR DESCRIPTION
related issue：https://github.com/tauri-apps/tauri/issues/14201

The branch pending for merge previously: https://github.com/tauri-apps/wry/tree/fix/macos/symbol-not-found-1013
As this branch dates back too long, I have re-implemented the corresponding modifications on a new branch, and also fixed additional new issues that were identified subsequently.
To date, all changes have passed testing on my macOS 10.13.6 environment.

closes #1618