### PR TITLE
feat: add Rust-side webview screenshot API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,7 @@ dependencies = [
  "bitflags 2.8.0",
  "objc2 0.6.0",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.0",
 ]
 
@@ -1850,6 +1851,18 @@ checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
  "bitflags 2.8.0",
  "objc2 0.6.0",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -1909,6 +1922,17 @@ name = "objc2-foundation"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
 dependencies = [
  "bitflags 2.8.0",
  "objc2 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,9 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = [
   "NSImage",
   "NSImageRep",
   "NSBitmapImageRep",
+  "NSGraphicsContext",
   "NSScreen",
+  "objc2-core-graphics",
 ] }
 
 [target."cfg(target_os = \"android\")".dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ objc2-web-kit = { version = "0.3.0", default-features = false, features = [
   "WKWebpagePreferences",
   "WKNavigationResponse",
   "WKUserScript",
+  "WKSnapshotConfiguration",
   "WKHTTPCookieStore",
   "WKWindowFeatures",
 ] }
@@ -190,6 +191,9 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = [
   "NSSavePanel",
   "NSMenu",
   "NSGraphics",
+  "NSImage",
+  "NSImageRep",
+  "NSBitmapImageRep",
   "NSScreen",
 ] }
 

--- a/examples/screenshot_smoke.rs
+++ b/examples/screenshot_smoke.rs
@@ -1,0 +1,139 @@
+// Copyright 2020-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::sync::{
+  atomic::{AtomicBool, Ordering},
+  Arc,
+};
+use std::time::Duration;
+
+use tao::{
+  event::{Event, WindowEvent},
+  event_loop::{ControlFlow, EventLoopBuilder},
+  window::WindowBuilder,
+};
+use wry::{PageLoadEvent, WebViewBuilder};
+
+#[derive(Debug, Clone, Copy)]
+enum UserEvent {
+  Capture,
+  Exit,
+}
+
+fn main() -> wry::Result<()> {
+  let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
+  let proxy = event_loop.create_proxy();
+  let window = WindowBuilder::new()
+    .with_title("wry screenshot smoke")
+    .build(&event_loop)
+    .unwrap();
+
+  let already_requested = Arc::new(AtomicBool::new(false));
+  let already_requested_ = already_requested.clone();
+  let proxy_for_load = proxy.clone();
+
+  let builder = WebViewBuilder::new()
+    .with_html(
+      r#"<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>WRY Screenshot Smoke</title>
+    <style>
+      html, body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        font-family: sans-serif;
+      }
+      body {
+        display: grid;
+        place-items: center;
+        background: #1f2937;
+        color: white;
+      }
+      .card {
+        padding: 24px 28px;
+        border-radius: 16px;
+        background: rgba(255,255,255,0.12);
+        border: 1px solid rgba(255,255,255,0.18);
+        box-shadow: 0 20px 50px rgba(0,0,0,0.35);
+        backdrop-filter: blur(8px);
+      }
+      h1 { margin: 0 0 8px; font-size: 28px; }
+      p { margin: 0; opacity: 0.9; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Screenshot Smoke Test</h1>
+      <p>If you can read this in screenshot.png, capture worked.</p>
+    </div>
+  </body>
+</html>"#,
+    )
+    .with_on_page_load_handler(move |event, _url| {
+      if matches!(event, PageLoadEvent::Finished)
+        && !already_requested_.swap(true, Ordering::SeqCst)
+      {
+        let proxy = proxy_for_load.clone();
+        std::thread::spawn(move || {
+          std::thread::sleep(Duration::from_millis(1000));
+          let _ = proxy.send_event(UserEvent::Capture);
+        });
+      }
+    });
+
+  #[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+  ))]
+  let webview = builder.build(&window)?;
+  #[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+  )))]
+  let webview = {
+    use tao::platform::unix::WindowExtUnix;
+    use wry::WebViewBuilderExtUnix;
+    let vbox = window.default_vbox().unwrap();
+    builder.build_gtk(vbox)?
+  };
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        ..
+      } => *control_flow = ControlFlow::Exit,
+      Event::UserEvent(UserEvent::Capture) => {
+        let proxy = proxy.clone();
+        webview
+          .screenshot(move |result| {
+            match result {
+              Ok(bytes) => {
+                if let Err(err) = std::fs::write("screenshot.png", bytes) {
+                  eprintln!("failed to write screenshot.png: {err}");
+                } else {
+                  println!("wrote screenshot.png");
+                }
+              }
+              Err(err) => eprintln!("screenshot failed: {err}"),
+            }
+            let _ = proxy.send_event(UserEvent::Exit);
+          })
+          .expect("failed to request screenshot");
+      }
+      Event::UserEvent(UserEvent::Exit) => *control_flow = ControlFlow::Exit,
+      _ => {}
+    }
+  });
+}

--- a/examples/screenshot_smoke.rs
+++ b/examples/screenshot_smoke.rs
@@ -115,22 +115,33 @@ fn main() -> wry::Result<()> {
         ..
       } => *control_flow = ControlFlow::Exit,
       Event::UserEvent(UserEvent::Capture) => {
-        let proxy = proxy.clone();
-        webview
-          .screenshot(move |result| {
-            match result {
-              Ok(bytes) => {
-                if let Err(err) = std::fs::write("screenshot.png", bytes) {
-                  eprintln!("failed to write screenshot.png: {err}");
-                } else {
-                  println!("wrote screenshot.png");
+        // screenshot is not supported on Android or iOS; the handler would
+        // never be called, so we exit immediately on those platforms.
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        {
+          let _ = proxy.send_event(UserEvent::Exit);
+          return;
+        }
+
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        {
+          let proxy = proxy.clone();
+          webview
+            .screenshot(move |result| {
+              match result {
+                Ok(bytes) => {
+                  if let Err(err) = std::fs::write("screenshot.png", bytes) {
+                    eprintln!("failed to write screenshot.png: {err}");
+                  } else {
+                    println!("wrote screenshot.png");
+                  }
                 }
+                Err(err) => eprintln!("screenshot failed: {err}"),
               }
-              Err(err) => eprintln!("screenshot failed: {err}"),
-            }
-            let _ = proxy.send_event(UserEvent::Exit);
-          })
-          .expect("failed to request screenshot");
+              let _ = proxy.send_event(UserEvent::Exit);
+            })
+            .expect("failed to request screenshot");
+        }
       }
       Event::UserEvent(UserEvent::Exit) => *control_flow = ControlFlow::Exit,
       _ => {}

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -346,6 +346,14 @@ impl InnerWebView {
     Ok(())
   }
 
+  pub fn screenshot<F>(&self, _handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
+  {
+    // Unsupported
+    Ok(())
+  }
+
   pub fn id(&self) -> crate::WebViewId<'_> {
     &self.id
   }

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,4 +83,11 @@ pub enum Error {
   #[cfg(target_os = "macos")]
   #[error("Could not obtain screenshot from webview")]
   NilScreenshot,
+  #[cfg(target_os = "macos")]
+  #[error("Screenshot failed ({domain}:{code}): {description}")]
+  MacOsScreenshotError {
+    domain: String,
+    code: isize,
+    description: String,
+  },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
   #[cfg(gtk)]
   #[error(transparent)]
   CairoError(#[from] gtk::cairo::Error),
+  #[cfg(gtk)]
+  #[error("Failed to convert WebView snapshot to a Pixbuf")]
+  PixbufConversionFailed,
   #[cfg(all(gtk, feature = "x11"))]
   #[error(transparent)]
   XlibError(#[from] x11_dl::error::OpenError),
@@ -77,7 +80,7 @@ pub enum Error {
   #[cfg(any(target_os = "macos", target_os = "ios"))]
   #[error("data store is currently opened")]
   DataStoreInUse,
-  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  #[cfg(target_os = "macos")]
   #[error("Could not obtain screenshot from webview")]
   NilScreenshot,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
   #[cfg(gtk)]
   #[error("Couldn't find X11 Display")]
   X11DisplayNotFound,
+  #[cfg(gtk)]
+  #[error(transparent)]
+  CairoError(#[from] gtk::cairo::Error),
   #[cfg(all(gtk, feature = "x11"))]
   #[error(transparent)]
   XlibError(#[from] x11_dl::error::OpenError),
@@ -74,4 +77,7 @@ pub enum Error {
   #[cfg(any(target_os = "macos", target_os = "ios"))]
   #[error("data store is currently opened")]
   DataStoreInUse,
+  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  #[error("Could not obtain screenshot from webview")]
+  NilScreenshot,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2033,6 +2033,21 @@ impl WebView {
     self.webview.print()
   }
 
+  /// Capture a PNG screenshot of the currently visible webview contents.
+  ///
+  /// The screenshot is returned asynchronously via `handler`.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / macOS / Windows**: Implemented (visible region only).
+  /// - **Android / iOS**: Unsupported.
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
+  {
+    self.webview.screenshot(handler)
+  }
+
   /// Get a list of cookies for specific url.
   pub fn cookies_for_url(&self, url: &str) -> Result<Vec<cookie::Cookie<'static>>> {
     self.webview.cookies_for_url(url)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2040,7 +2040,7 @@ impl WebView {
   /// ## Platform-specific
   ///
   /// - **Linux / macOS / Windows**: Implemented (visible region only).
-  /// - **Android / iOS**: Unsupported.
+  /// - **Android / iOS**: Not supported; `handler` will never be called.
   pub fn screenshot<F>(&self, handler: F) -> Result<()>
   where
     F: Fn(Result<Vec<u8>>) + 'static + Send,

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -29,7 +29,6 @@ use std::ffi::c_ulong;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
   collections::HashMap,
-  convert::TryFrom,
   rc::Rc,
   sync::{Arc, Mutex},
 };
@@ -696,9 +695,7 @@ impl InnerWebView {
               Ok(bytes) => handler(Ok(bytes)),
               Err(err) => handler(Err(Error::GlibError(err))),
             },
-            None => handler(Err(Error::CairoError(
-              gtk::cairo::Error::SurfaceTypeMismatch,
-            ))),
+            None => handler(Err(Error::PixbufConversionFailed)),
           }
         }
         Err(_) => handler(Err(Error::CairoError(

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -29,6 +29,7 @@ use std::ffi::c_ulong;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
   collections::HashMap,
+  convert::TryFrom,
   rc::Rc,
   sync::{Arc, Mutex},
 };
@@ -37,10 +38,10 @@ use webkit2gtk::WebInspectorExt;
 use webkit2gtk::{
   AutoplayPolicy, CookieManagerExt, InputMethodContextExt, LoadEvent, NavigationPolicyDecision,
   NavigationPolicyDecisionExt, NetworkProxyMode, NetworkProxySettings, PolicyDecisionType,
-  PrintOperationExt, SettingsExt, URIRequest, URIRequestExt, UserContentInjectedFrames,
-  UserContentManager, UserContentManagerExt, UserScript, UserScriptInjectionTime,
-  WebContextExt as Webkit2gtkWeContextExt, WebView, WebViewExt, WebsiteDataManagerExt,
-  WebsiteDataManagerExtManual, WebsitePolicies,
+  PrintOperationExt, SettingsExt, SnapshotOptions, SnapshotRegion, URIRequest, URIRequestExt,
+  UserContentInjectedFrames, UserContentManager, UserContentManagerExt, UserScript,
+  UserScriptInjectionTime, WebContextExt as Webkit2gtkWeContextExt, WebView, WebViewExt,
+  WebsiteDataManagerExt, WebsiteDataManagerExtManual, WebsitePolicies,
 };
 use webkit2gtk_sys::{
   webkit_get_major_version, webkit_get_micro_version, webkit_get_minor_version,
@@ -676,6 +677,44 @@ impl InnerWebView {
   pub fn print(&self) -> Result<()> {
     let print = webkit2gtk::PrintOperation::new(&self.webview);
     print.run_dialog(None::<&gtk::Window>);
+    Ok(())
+  }
+
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
+  {
+    let cancellable: Option<&Cancellable> = None;
+    let cb = move |result: std::result::Result<gtk::cairo::Surface, gtk::glib::Error>| match result
+    {
+      Ok(surface) => match gtk::cairo::ImageSurface::try_from(surface) {
+        Ok(image) => {
+          let width = image.width();
+          let height = image.height();
+          match gdk::pixbuf_get_from_surface(&image, 0, 0, width, height) {
+            Some(pixbuf) => match pixbuf.save_to_bufferv("png", &[]) {
+              Ok(bytes) => handler(Ok(bytes)),
+              Err(err) => handler(Err(Error::GlibError(err))),
+            },
+            None => handler(Err(Error::CairoError(
+              gtk::cairo::Error::SurfaceTypeMismatch,
+            ))),
+          }
+        }
+        Err(_) => handler(Err(Error::CairoError(
+          gtk::cairo::Error::SurfaceTypeMismatch,
+        ))),
+      },
+      Err(err) => handler(Err(Error::GlibError(err))),
+    };
+
+    self.webview.snapshot(
+      SnapshotRegion::Visible,
+      SnapshotOptions::NONE,
+      cancellable,
+      cb,
+    );
+
     Ok(())
   }
 

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1709,6 +1709,7 @@ impl InnerWebView {
       let Some(stream) = SHCreateMemStream(None) else {
         return Err(Error::from(windows::core::Error::from(E_POINTER)));
       };
+      let stream_for_handler = stream.clone();
 
       self.webview.CapturePreview(
         COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG,
@@ -1718,12 +1719,12 @@ impl InnerWebView {
             res?;
 
             let mut bytes = Vec::new();
-            stream.Seek(0, STREAM_SEEK_SET, None)?;
+            stream_for_handler.Seek(0, STREAM_SEEK_SET, None)?;
 
             let mut buffer = [0u8; 4096];
             loop {
               let mut cb_read = 0;
-              stream
+              stream_for_handler
                 .Read(
                   buffer.as_mut_ptr() as *mut _,
                   buffer.len() as u32,

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1701,6 +1701,59 @@ impl InnerWebView {
     )
   }
 
+  pub fn screenshot<F>(&self, handler: F) -> Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
+  {
+    unsafe {
+      let Some(stream) = SHCreateMemStream(None) else {
+        return Err(Error::from(windows::core::Error::from(E_POINTER)));
+      };
+
+      self.webview.CapturePreview(
+        COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG,
+        &stream,
+        &CapturePreviewCompletedHandler::create(Box::new(move |res| {
+          let result = (|| -> windows::core::Result<Vec<u8>> {
+            res?;
+
+            let mut bytes = Vec::new();
+            stream.Seek(0, STREAM_SEEK_SET, None)?;
+
+            let mut buffer = [0u8; 4096];
+            loop {
+              let mut cb_read = 0;
+              stream
+                .Read(
+                  buffer.as_mut_ptr() as *mut _,
+                  buffer.len() as u32,
+                  Some(&mut cb_read),
+                )
+                .ok()?;
+
+              if cb_read == 0 {
+                break;
+              }
+
+              bytes.extend_from_slice(&buffer[..cb_read as usize]);
+            }
+
+            Ok(bytes)
+          })();
+
+          match result {
+            Ok(bytes) => handler(Ok(bytes)),
+            Err(err) => handler(Err(err.into())),
+          }
+
+          Ok(())
+        })),
+      )?;
+    }
+
+    Ok(())
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     unsafe {
       self

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -72,7 +72,7 @@ use crate::wkwebview::util::operating_system_version;
 use objc2_web_kit::WKWebView;
 
 use objc2_web_kit::{
-  WKAudiovisualMediaTypes, WKInactiveSchedulingPolicy, WKSnapshotConfiguration, WKURLSchemeHandler,
+  WKAudiovisualMediaTypes, WKInactiveSchedulingPolicy, WKURLSchemeHandler,
   WKUserContentController, WKUserScript, WKUserScriptInjectionTime, WKWebViewConfiguration,
   WKWebsiteDataStore,
 };
@@ -847,24 +847,32 @@ r#"Object.defineProperty(window, 'ipc', {
     // Safety: objc runtime calls are unsafe
     #[cfg(target_os = "macos")]
     unsafe {
-      let config = WKSnapshotConfiguration::new(self.mtm);
-      config.setAfterScreenUpdates(true);
+      let callback = block2::RcBlock::new(move |image: *mut NSImage, err: *mut NSError| {
+        if let Some(err) = err.as_ref() {
+          handler(Err(Error::MacOsScreenshotError {
+            domain: err.domain().to_string(),
+            code: err.code(),
+            description: err.localizedDescription().to_string(),
+          }));
+          return;
+        }
 
-      let callback = block2::RcBlock::new(move |image: *mut NSImage, _err: *mut NSError| {
         let Some(image) = image.as_ref() else {
           handler(Err(Error::NilScreenshot));
           return;
         };
 
-        let Some(tiff) = image.TIFFRepresentation() else {
+        let Some(cg_image) = image.CGImageForProposedRect_context_hints(
+          std::ptr::null_mut(),
+          None,
+          None,
+        ) else {
           handler(Err(Error::NilScreenshot));
           return;
         };
 
-        let Some(bitmap) = NSBitmapImageRep::imageRepWithData(&tiff) else {
-          handler(Err(Error::NilScreenshot));
-          return;
-        };
+        let bitmap = NSBitmapImageRep::initWithCGImage(NSBitmapImageRep::alloc(), &cg_image);
+        bitmap.setSize(image.size());
 
         let props: Retained<NSDictionary<NSBitmapImageRepPropertyKey, AnyObject>> =
           NSDictionary::new();
@@ -877,7 +885,7 @@ r#"Object.defineProperty(window, 'ipc', {
 
       self
         .webview
-        .takeSnapshotWithConfiguration_completionHandler(Some(&config), &callback);
+        .takeSnapshotWithConfiguration_completionHandler(None, &callback);
     }
 
     #[cfg(target_os = "ios")]

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -844,6 +844,7 @@ r#"Object.defineProperty(window, 'ipc', {
   where
     F: Fn(Result<Vec<u8>>) + 'static + Send,
   {
+    // Safety: objc runtime calls are unsafe
     #[cfg(target_os = "macos")]
     unsafe {
       let config = WKSnapshotConfiguration::new(self.mtm);
@@ -880,7 +881,10 @@ r#"Object.defineProperty(window, 'ipc', {
     }
 
     #[cfg(target_os = "ios")]
-    let _ = handler;
+    {
+      // Unsupported
+      let _ = handler;
+    }
 
     Ok(())
   }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -38,12 +38,15 @@ use objc2::{
   AllocAnyThread, DeclaredClass, MainThreadOnly, Message,
 };
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSAutoresizingMaskOptions, NSTitlebarSeparatorStyle, NSView};
+use objc2_app_kit::{
+  NSApplication, NSAutoresizingMaskOptions, NSBitmapImageFileType, NSBitmapImageRep,
+  NSBitmapImageRepPropertyKey, NSImage, NSTitlebarSeparatorStyle, NSView,
+};
 #[cfg(target_os = "macos")]
 use objc2_core_foundation::CGSize;
 use objc2_core_foundation::{CGPoint, CGRect};
 use objc2_foundation::{
-  ns_string, MainThreadMarker, NSArray, NSBundle, NSDate, NSError, NSHTTPCookie,
+  ns_string, MainThreadMarker, NSArray, NSBundle, NSDate, NSDictionary, NSError, NSHTTPCookie,
   NSHTTPCookieDomain, NSHTTPCookieExpires, NSHTTPCookieMaximumAge, NSHTTPCookieName,
   NSHTTPCookiePath, NSHTTPCookiePropertyKey, NSHTTPCookieSecure, NSHTTPCookieValue,
   NSHTTPCookieVersion, NSJSONSerialization, NSMutableDictionary, NSMutableURLRequest, NSNumber,
@@ -69,8 +72,9 @@ use crate::wkwebview::util::operating_system_version;
 use objc2_web_kit::WKWebView;
 
 use objc2_web_kit::{
-  WKAudiovisualMediaTypes, WKInactiveSchedulingPolicy, WKURLSchemeHandler, WKUserContentController,
-  WKUserScript, WKUserScriptInjectionTime, WKWebViewConfiguration, WKWebsiteDataStore,
+  WKAudiovisualMediaTypes, WKInactiveSchedulingPolicy, WKSnapshotConfiguration, WKURLSchemeHandler,
+  WKUserContentController, WKUserScript, WKUserScriptInjectionTime, WKWebViewConfiguration,
+  WKWebsiteDataStore,
 };
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
@@ -834,6 +838,51 @@ r#"Object.defineProperty(window, 'ipc', {
 
   pub fn print(&self) -> crate::Result<()> {
     self.print_with_options(&PrintOptions::default())
+  }
+
+  pub fn screenshot<F>(&self, handler: F) -> crate::Result<()>
+  where
+    F: Fn(Result<Vec<u8>>) + 'static + Send,
+  {
+    #[cfg(target_os = "macos")]
+    unsafe {
+      let config = WKSnapshotConfiguration::new(self.mtm);
+      config.setAfterScreenUpdates(true);
+
+      let callback = block2::RcBlock::new(move |image: *mut NSImage, _err: *mut NSError| {
+        let Some(image) = image.as_ref() else {
+          handler(Err(Error::NilScreenshot));
+          return;
+        };
+
+        let Some(tiff) = image.TIFFRepresentation() else {
+          handler(Err(Error::NilScreenshot));
+          return;
+        };
+
+        let Some(bitmap) = NSBitmapImageRep::imageRepWithData(&tiff) else {
+          handler(Err(Error::NilScreenshot));
+          return;
+        };
+
+        let props: Retained<NSDictionary<NSBitmapImageRepPropertyKey, AnyObject>> =
+          NSDictionary::new();
+        let png = bitmap.representationUsingType_properties(NSBitmapImageFileType::PNG, &props);
+        match png {
+          Some(data) => handler(Ok(data.to_vec())),
+          None => handler(Err(Error::NilScreenshot)),
+        }
+      });
+
+      self
+        .webview
+        .takeSnapshotWithConfiguration_completionHandler(Some(&config), &callback);
+    }
+
+    #[cfg(target_os = "ios")]
+    let _ = handler;
+
+    Ok(())
   }
 
   pub fn print_with_options(&self, _options: &PrintOptions) -> crate::Result<()> {


### PR DESCRIPTION
Related to #1358. Prior art: #266, #1258. I'd really like to be able to take screenshots of my webviews in my Wry app.

Adds a Rust-side screenshot API for `WebView`: `WebView::screenshot(handler)` which returns visible-region screenshots as PNG bytes. Implemented for and tested on:
- Windows 11 Pro 25H2 26200.7840
- Arch Linux (6.6.119-1-MANJARO, Gnome 49.2, Wayland (had to run with `WEBKIT_DISABLE_DMABUF_RENDERER=1`))
- macOS Sequoia 15.6
- Unsupported and stubbed on iOS and Android.

I've also added  `examples/screenshot_smoke.rs` (inline HTML, waits for page load + 1s, writes `screenshot.png`). I suspect this should probably be removed before this is merged, I just wanted an easy way of testing cross platform.

Scope is intentionally limited to visible-region screenshots only (no full-document capture, afaict APIs to do this cross platform are not mature / well standardized yet). 

On Linux I'm using webkit2gtk snapshot API and encodes PNGs via GTK/GDK Pixbuf, so it does not introduce a cairo dependency. On macOS, it uses WKWebView’s native snapshot API rather than OS/screen capture APIs, which avoids the screen-recording permission requirement that affected the older approach.
