### PR TITLE
fix(macOS): panic when loading multiple dylibs (fix #1675)

### DIFF
--- a/.changes/mac-dylib.md
+++ b/.changes/mac-dylib.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix bug where wry would crash when loaded by multiple dylibs in the same process on macOS.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
 dependencies = [
- "objc2 0.6.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1770,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -1801,7 +1801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
 ]
@@ -1849,7 +1849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1911,7 +1911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -1990,7 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777a571be14a42a3990d4ebedaeb8b54cd17377ec21b92e8200ac03797b3bee1"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
 ]
@@ -2027,7 +2027,7 @@ checksum = "b717127e4014b0f9f3e8bba3d3f2acec81f1bde01f656823036e823ed2c94dce"
 dependencies = [
  "bitflags 2.8.0",
  "block2 0.6.0",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
@@ -2905,7 +2905,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.0",
  "objc2-foundation 0.3.0",
  "once_cell",
@@ -4148,7 +4148,7 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ features = [
 url = "2.5"
 dirs = "6"
 block2 = "0.6"
-objc2 = { version = "0.6", features = [
+objc2 = { version = "0.6.4", features = [
   "exception",
   # because `NSUUID::from_bytes` needs it,
   # and `WebViewBuilderExtDarwin.with_data_store_identifier` crashes otherwise,

--- a/src/wkwebview/class/document_title_changed_observer.rs
+++ b/src/wkwebview/class/document_title_changed_observer.rs
@@ -23,7 +23,6 @@ pub struct DocumentTitleChangedObserverIvars {
 
 define_class!(
   #[unsafe(super(NSObject))]
-  #[name = "DocumentTitleChangedObserver"]
   #[ivars = DocumentTitleChangedObserverIvars]
   pub struct DocumentTitleChangedObserver;
 

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -28,7 +28,10 @@ use crate::{wkwebview::WEBVIEW_STATE, RequestAsyncResponder, WryWebView};
 
 pub fn create(name: &str) -> &AnyClass {
   unsafe {
-    let scheme_name = format!("{name}URLSchemeHandler\0");
+    // Include the address of WEBVIEW_STATE in the class name so that each dylib in the process
+    // gets its own ObjC class with method pointers into its own code and data segments.
+    let unique_id = std::ptr::addr_of!(WEBVIEW_STATE) as usize;
+    let scheme_name = format!("{name}URLSchemeHandler_{unique_id:x}\0");
     let scheme_name = CStr::from_bytes_with_nul(scheme_name.as_bytes()).unwrap();
     let cls = ClassBuilder::new(scheme_name, NSObject::class());
     match cls {

--- a/src/wkwebview/class/wry_download_delegate.rs
+++ b/src/wkwebview/class/wry_download_delegate.rs
@@ -19,7 +19,6 @@ pub struct WryDownloadDelegateIvars {
 
 define_class!(
   #[unsafe(super(NSObject))]
-  #[name = "WryDownloadDelegate"]
   #[thread_kind = MainThreadOnly]
   #[ivars = WryDownloadDelegateIvars]
   pub struct WryDownloadDelegate;

--- a/src/wkwebview/class/wry_navigation_delegate.rs
+++ b/src/wkwebview/class/wry_navigation_delegate.rs
@@ -41,7 +41,6 @@ pub struct WryNavigationDelegateIvars {
 
 define_class!(
   #[unsafe(super(NSObject))]
-  #[name = "WryNavigationDelegate"]
   #[thread_kind = MainThreadOnly]
   #[ivars = WryNavigationDelegateIvars]
   pub struct WryNavigationDelegate;

--- a/src/wkwebview/class/wry_web_view.rs
+++ b/src/wkwebview/class/wry_web_view.rs
@@ -36,7 +36,6 @@ pub struct WryWebViewIvars {
 
 define_class!(
   #[unsafe(super(WKWebView))]
-  #[name = "WryWebView"]
   #[ivars = WryWebViewIvars]
   pub struct WryWebView;
 

--- a/src/wkwebview/class/wry_web_view_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_delegate.rs
@@ -23,7 +23,6 @@ pub struct WryWebViewDelegateIvars {
 
 define_class!(
   #[unsafe(super(NSObject))]
-  #[name = "WryWebViewDelegate"]
   #[thread_kind = MainThreadOnly]
   #[ivars = WryWebViewDelegateIvars]
   pub struct WryWebViewDelegate;

--- a/src/wkwebview/class/wry_web_view_parent.rs
+++ b/src/wkwebview/class/wry_web_view_parent.rs
@@ -20,7 +20,6 @@ pub struct WryWebViewParentIvars {
 
 define_class!(
   #[unsafe(super(NSView))]
-  #[name = "WryWebViewParent"]
   #[ivars = WryWebViewParentIvars]
   pub struct WryWebViewParent;
 

--- a/src/wkwebview/class/wry_web_view_ui_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_ui_delegate.rs
@@ -54,7 +54,6 @@ struct WryNSWindowDelegateIvars {
 #[cfg(target_os = "macos")]
 define_class!(
   #[unsafe(super(NSObject))]
-  #[name = "WryNSWindowDelegate"]
   #[thread_kind = MainThreadOnly]
   #[ivars = WryNSWindowDelegateIvars]
   struct WryNSWindowDelegate;
@@ -90,7 +89,6 @@ pub struct WryWebViewUIDelegateIvars {
 
 define_class!(
   #[unsafe(super(NSObject))]
-  #[name = "WryWebViewUIDelegate"]
   #[thread_kind = MainThreadOnly]
   #[ivars = WryWebViewUIDelegateIvars]
   pub struct WryWebViewUIDelegate;


### PR DESCRIPTION
closes #1675 

This fixes the panic by using the new "auto-generating" name feature of `define_class!` `objc2` - the name of the objective C class for the delegates will include the wry version number so will not be unsound to have multiple in the process.

I also added a unique name to the custom protocol handler, as this was causing issues even after the fix above.

I tested this with a local build of a few audio plug-ins using wry loaded into the same process