### PR TITLE
docs: add gtk opengl triangle example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glutin_wgl_sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,12 +1518,12 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3593,7 +3605,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases 0.1.1",
  "core-graphics-types 0.1.3",
- "glow",
+ "glow 0.14.2",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
@@ -3684,7 +3696,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.0",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-numerics",
 ]
 
@@ -3718,7 +3730,7 @@ checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
 ]
@@ -3730,7 +3742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
 dependencies = [
  "windows-core 0.61.0",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -3784,13 +3796,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.0",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -3808,7 +3826,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -3827,7 +3845,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -3909,7 +3927,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -4139,6 +4157,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "getrandom 0.3.1",
+ "glow 0.16.0",
  "gtk",
  "html5ever",
  "http",
@@ -4147,6 +4166,7 @@ dependencies = [
  "jni",
  "kuchikiki",
  "libc",
+ "libloading",
  "ndk",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,8 @@ winit = "0.30"
 getrandom = "0.3"
 http-range = "0.1"
 percent-encoding = "2.3"
+glow = "0.16.0"
+libloading = "0.8.9"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/examples/gtk_opengl.rs
+++ b/examples/gtk_opengl.rs
@@ -1,0 +1,236 @@
+// Copyright 2020-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::cell::RefCell;
+use std::ffi::CString;
+use std::rc::Rc;
+use tao::{
+  event::{Event, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  window::WindowBuilder,
+};
+use wry::{
+  dpi::{LogicalPosition, LogicalSize},
+  Rect, WebViewBuilder,
+};
+
+fn main() -> wry::Result<()> {
+  let event_loop = EventLoop::new();
+  let window = WindowBuilder::new()
+    .with_title("GTK OpenGL with Webview")
+    .with_inner_size(LogicalSize::new(800, 600))
+    .build(&event_loop)
+    .unwrap();
+
+  #[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+  )))]
+  let (fixed, gl_area) = {
+    use gtk::prelude::*;
+    use tao::platform::unix::WindowExtUnix;
+    let fixed = gtk::Fixed::new();
+    let vbox = window.default_vbox().unwrap();
+    vbox.pack_start(&fixed, true, true, 0);
+
+    let gl_area = gtk::GLArea::new();
+    gl_area.set_has_alpha(true);
+    gl_area.set_auto_render(true);
+
+    struct AppState {
+      gl: glow::Context,
+      program: glow::Program,
+      vertex_array: glow::VertexArray,
+    }
+
+    let state: Rc<RefCell<Option<AppState>>> = Rc::new(RefCell::new(None));
+    let state_realize = state.clone();
+
+    gl_area.connect_realize(move |gl_area| {
+      gl_area.make_current();
+      if gl_area.error().is_some() {
+        println!("Error creating GLArea context");
+        return;
+      }
+
+      let gl = unsafe {
+        let lib = Box::leak(Box::new(
+          libloading::Library::new("libepoxy.so.0").expect("Failed to load libepoxy"),
+        ));
+        glow::Context::from_loader_function_unsafe(|s| {
+          let name = CString::new(s).unwrap();
+          let get_proc_address: libloading::Symbol<
+            unsafe extern "C" fn(*const i8) -> *const std::ffi::c_void,
+          > = lib.get(b"epoxy_get_proc_address\0").unwrap();
+          get_proc_address(name.as_ptr())
+        })
+      };
+
+      unsafe {
+        use glow::HasContext as _;
+
+        let vertex_array = gl.create_vertex_array().unwrap();
+        gl.bind_vertex_array(Some(vertex_array));
+
+        let program = gl.create_program().expect("Cannot create program");
+
+        let vertex_shader_source = r#"
+        #version 330 core
+        void main() {
+            if (gl_VertexID == 0) gl_Position = vec4(-0.5, -0.5, 0.0, 1.0);
+            else if (gl_VertexID == 1) gl_Position = vec4(0.5, -0.5, 0.0, 1.0);
+            else gl_Position = vec4(0.0, 0.5, 0.0, 1.0);
+        }
+        "#;
+
+        let fragment_shader_source = r#"
+        #version 330 core
+        out vec4 FragColor;
+        void main() {
+            FragColor = vec4(1.0, 0.5, 0.2, 1.0);
+        }
+        "#;
+
+        let vs = gl.create_shader(glow::VERTEX_SHADER).unwrap();
+        gl.shader_source(vs, vertex_shader_source);
+        gl.compile_shader(vs);
+        if !gl.get_shader_compile_status(vs) {
+          panic!("{}", gl.get_shader_info_log(vs));
+        }
+
+        let fs = gl.create_shader(glow::FRAGMENT_SHADER).unwrap();
+        gl.shader_source(fs, fragment_shader_source);
+        gl.compile_shader(fs);
+        if !gl.get_shader_compile_status(fs) {
+          panic!("{}", gl.get_shader_info_log(fs));
+        }
+
+        gl.attach_shader(program, vs);
+        gl.attach_shader(program, fs);
+        gl.link_program(program);
+        if !gl.get_program_link_status(program) {
+          panic!("{}", gl.get_program_info_log(program));
+        }
+
+        gl.detach_shader(program, vs);
+        gl.delete_shader(vs);
+        gl.detach_shader(program, fs);
+        gl.delete_shader(fs);
+
+        *state_realize.borrow_mut() = Some(AppState {
+          gl,
+          program,
+          vertex_array,
+        });
+      }
+    });
+
+    let state_render = state.clone();
+    gl_area.connect_render(move |gl_area, _gl_context| {
+      if let Some(state) = state_render.borrow().as_ref() {
+        unsafe {
+          use glow::HasContext as _;
+          state.gl.clear_color(0.1, 0.2, 0.3, 1.0);
+          state.gl.clear(glow::COLOR_BUFFER_BIT);
+
+          state.gl.use_program(Some(state.program));
+          state.gl.bind_vertex_array(Some(state.vertex_array));
+          state.gl.draw_arrays(glow::TRIANGLES, 0, 3);
+        }
+      }
+      gtk::Inhibit(false)
+    });
+
+    gl_area.connect_unrealize(move |gl_area| {
+      gl_area.make_current();
+      if let Some(state) = state.borrow_mut().take() {
+        unsafe {
+          use glow::HasContext as _;
+          state.gl.delete_program(state.program);
+          state.gl.delete_vertex_array(state.vertex_array);
+        }
+      }
+    });
+
+    gl_area.set_size_request(800, 600);
+    fixed.put(&gl_area, 0, 0);
+
+    fixed.show_all();
+    (fixed, gl_area)
+  };
+
+  let builder = WebViewBuilder::new()
+    .with_bounds(Rect {
+      position: LogicalPosition::new(100, 100).into(),
+      size: LogicalSize::new(400, 300).into(),
+    })
+    .with_transparent(true)
+    .with_html(
+      r#"<html>
+          <body style="background-color:rgba(87,87,87,0.5); color: white; display: flex; justify-content: center; align-items: center;">
+            <h1>Webview Overlay Layer</h1>
+          </body>
+      </html>"#,
+    );
+
+  #[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+  ))]
+  let webview = builder.build(&window)?;
+
+  #[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+  )))]
+  let webview = {
+    use wry::WebViewBuilderExtUnix;
+    builder.build_gtk(&fixed)?
+  };
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::Resized(size),
+        ..
+      } => {
+        let size = size.to_logical::<u32>(window.scale_factor());
+        webview
+          .set_bounds(Rect {
+            position: LogicalPosition::new(100, 100).into(),
+            size: LogicalSize::new(
+              size.width.saturating_sub(200).max(100),
+              size.height.saturating_sub(200).max(100),
+            )
+            .into(),
+          })
+          .unwrap();
+
+        #[cfg(not(any(
+          target_os = "windows",
+          target_os = "macos",
+          target_os = "ios",
+          target_os = "android"
+        )))]
+        {
+          use gtk::prelude::*;
+          gl_area.set_size_request(size.width as i32, size.height as i32);
+        }
+      }
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        ..
+      } => *control_flow = ControlFlow::Exit,
+      _ => {}
+    }
+  });
+}

--- a/examples/gtk_opengl.rs
+++ b/examples/gtk_opengl.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 use std::cell::RefCell;
-use std::ffi::CString;
 use std::rc::Rc;
 use tao::{
   event::{Event, WindowEvent},
@@ -57,15 +56,29 @@ fn main() -> wry::Result<()> {
       }
 
       let gl = unsafe {
-        let lib = Box::leak(Box::new(
-          libloading::Library::new("libepoxy.so.0").expect("Failed to load libepoxy"),
-        ));
-        glow::Context::from_loader_function_unsafe(|s| {
-          let name = CString::new(s).unwrap();
-          let get_proc_address: libloading::Symbol<
-            unsafe extern "C" fn(*const i8) -> *const std::ffi::c_void,
-          > = lib.get(b"epoxy_get_proc_address\0").unwrap();
-          get_proc_address(name.as_ptr())
+        glow::Context::from_loader_function(|s| {
+          let mut ptr = std::ptr::null();
+          let name = std::ffi::CString::new(s).unwrap();
+
+          if let Ok(lib) = libloading::Library::new("libGL.so.1") {
+            if let Ok(sym) = lib.get::<unsafe extern "C" fn(*const i8) -> *const std::ffi::c_void>(
+              b"glXGetProcAddress\0",
+            ) {
+              ptr = sym(name.as_ptr());
+            }
+          }
+          if ptr.is_null() {
+            if let Ok(lib) = libloading::Library::new("libEGL.so.1") {
+              if let Ok(sym) = lib
+                .get::<unsafe extern "C" fn(*const i8) -> *const std::ffi::c_void>(
+                  b"eglGetProcAddress\0",
+                )
+              {
+                ptr = sym(name.as_ptr());
+              }
+            }
+          }
+          ptr
         })
       };
 
@@ -129,7 +142,7 @@ fn main() -> wry::Result<()> {
     });
 
     let state_render = state.clone();
-    gl_area.connect_render(move |gl_area, _gl_context| {
+    gl_area.connect_render(move |_gl_area, _gl_context| {
       if let Some(state) = state_render.borrow().as_ref() {
         unsafe {
           use glow::HasContext as _;
@@ -141,7 +154,7 @@ fn main() -> wry::Result<()> {
           state.gl.draw_arrays(glow::TRIANGLES, 0, 3);
         }
       }
-      gtk::Inhibit(false)
+      gtk::glib::Propagation::Proceed
     });
 
     gl_area.connect_unrealize(move |gl_area| {
@@ -170,7 +183,7 @@ fn main() -> wry::Result<()> {
     .with_transparent(true)
     .with_html(
       r#"<html>
-          <body style="background-color:rgba(87,87,87,0.5); color: white; display: flex; justify-content: center; align-items: center;">
+          <body>
             <h1>Webview Overlay Layer</h1>
           </body>
       </html>"#,

--- a/examples/gtk_opengl.rs
+++ b/examples/gtk_opengl.rs
@@ -28,12 +28,13 @@ fn main() -> wry::Result<()> {
     target_os = "ios",
     target_os = "android"
   )))]
-  let (fixed, gl_area) = {
+  let (fixed, _) = {
     use gtk::prelude::*;
     use tao::platform::unix::WindowExtUnix;
-    let fixed = gtk::Fixed::new();
+
+    let overlay = gtk::Overlay::new();
     let vbox = window.default_vbox().unwrap();
-    vbox.pack_start(&fixed, true, true, 0);
+    vbox.pack_start(&overlay, true, true, 0);
 
     let gl_area = gtk::GLArea::new();
     gl_area.set_has_alpha(true);
@@ -168,10 +169,12 @@ fn main() -> wry::Result<()> {
       }
     });
 
-    gl_area.set_size_request(800, 600);
-    fixed.put(&gl_area, 0, 0);
+    overlay.add(&gl_area);
 
-    fixed.show_all();
+    let fixed = gtk::Fixed::new();
+    overlay.add_overlay(&fixed);
+
+    overlay.show_all();
     (fixed, gl_area)
   };
 
@@ -184,7 +187,7 @@ fn main() -> wry::Result<()> {
     .with_html(
       r#"<html>
           <body>
-            <h1>Webview Overlay Layer</h1>
+            <h1 style="color: white;">Hello World!</h1>
           </body>
       </html>"#,
     );
@@ -227,17 +230,6 @@ fn main() -> wry::Result<()> {
             .into(),
           })
           .unwrap();
-
-        #[cfg(not(any(
-          target_os = "windows",
-          target_os = "macos",
-          target_os = "ios",
-          target_os = "android"
-        )))]
-        {
-          use gtk::prelude::*;
-          gl_area.set_size_request(size.width as i32, size.height as i32);
-        }
       }
       Event::WindowEvent {
         event: WindowEvent::CloseRequested,


### PR DESCRIPTION
Since wgpu doesn't support or conflict on GTK, I added GTK OpenGL with glow example implementation as an alternative.