### PR TITLE
docs: `WebViewAttributes` stability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,11 +549,13 @@ pub type WebViewId<'a> = &'a str;
 /// and create the struct with the [Struct Update Syntax] (`..Default::default()`), which may need a
 /// `#[allow(clippy::needless_update)]` attribute if you are declaring all fields.
 ///
-/// ```no_run
+/// ```
+/// # use wry::WebViewAttributes;
+///
 /// let attributes = WebViewAttributes {
 ///   visible: false,
 ///   ..Default::default()
-/// }
+/// };
 ///
 /// let WebViewAttributes {
 ///   visible,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,6 +540,29 @@ pub struct NewWindowFeatures {
 /// An id for a webview
 pub type WebViewId<'a> = &'a str;
 
+/// # Stability
+///
+/// We might add new fields in patch versions, so prefer [`WebViewBuilder`] when possible
+///
+/// If you do decide to use this, to avoid breakage,
+/// [ignore unknown fields when destructuring] with the `{ id, context, .. }` pattern,
+/// and create the struct with the [Struct Update Syntax] (`..Default::default()`), which may need a
+/// `#[allow(clippy::needless_update)]` attribute if you are declaring all fields.
+///
+/// ```no_run
+/// let attributes = WebViewAttributes {
+///   visible: false,
+///   ..Default::default()
+/// }
+///
+/// let WebViewAttributes {
+///   visible,
+///   ..
+/// } = attributes;
+/// ```
+///
+/// [ignore unknown fields when destructuring]: https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#ignoring-remaining-parts-of-a-value-with-
+/// [Struct Update Syntax]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax
 pub struct WebViewAttributes<'a> {
   /// An id that will be passed when this webview makes requests in certain callbacks.
   pub id: Option<WebViewId<'a>>,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Mainly copied in the one we had for tauri config

Looking at the patch version we just released, #1649 is technically breaking since we added a field to `WebViewAttributes` with all `pub` fields