### PR TITLE
fix(webkitgtk): normalize background color values to 0.0–1.0

### DIFF
--- a/.changes/fix-webkitgtk-background-color.md
+++ b/.changes/fix-webkitgtk-background-color.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+fix(webkitgtk): normalize background color values to 0.0–1.0

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -292,7 +292,10 @@ impl InnerWebView {
       // background color
       if let Some((red, green, blue, alpha)) = attributes.background_color {
         webview.set_background_color(&gtk::gdk::RGBA::new(
-          red as _, green as _, blue as _, alpha as _,
+          red as f64 / 255.0,
+          green as f64 / 255.0,
+          blue as f64 / 255.0,
+          alpha as f64 / 255.0,
         ));
       }
     }
@@ -763,7 +766,10 @@ impl InnerWebView {
 
   pub fn set_background_color(&self, (red, green, blue, alpha): RGBA) -> Result<()> {
     self.webview.set_background_color(&gtk::gdk::RGBA::new(
-      red as _, green as _, blue as _, alpha as _,
+      red as f64 / 255.0,
+      green as f64 / 255.0,
+      blue as f64 / 255.0,
+      alpha as f64 / 255.0,
     ));
     Ok(())
   }


### PR DESCRIPTION
## Summary

`gdk::RGBA::new()` expects color values in the 0.0–1.0 range, but the `u8` components (0–255) from `background_color` were cast directly to `f64` without normalizing. GDK clamps anything >1.0 to 1.0, so any non-zero background color ended up as white on Linux.

This PR divides each component by 255.0, fixing both the init path and the runtime setter.

Fixes #1690