### PR TITLE
fix: scripts wrongly escaped by `dom_query`

### DIFF
--- a/.changes/dom-query-0.26.md
+++ b/.changes/dom-query-0.26.md
@@ -1,5 +1,0 @@
----
-wry: patch
----
-
-Updated dependency dom_query to 0.26.0

--- a/.changes/dom-query-0.27.md
+++ b/.changes/dom-query-0.27.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Updated dependency dom_query to 0.27.0, this fixed a bug where initialization scripts were escaped incorrectly on Android

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,8 +605,9 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.26.0"
-source = "git+https://github.com/niklak/dom_query.git#e86123456b05a315157b15dbcd8f9821ca96a269"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,8 +606,7 @@ dependencies = [
 [[package]]
 name = "dom_query"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e4c03f2421dab1870544d171d3db22bdab0da4015995ff0b2f23125bbda9fb"
+source = "git+https://github.com/niklak/dom_query.git#e86123456b05a315157b15dbcd8f9821ca96a269"
 dependencies = [
  "bit-set",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,3 +219,6 @@ dom_query = { version = "0.26.0", default-features = false }
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ["cfg(linux)", "cfg(gtk)"]
+
+[patch.crates-io]
+dom_query = { git = "https://github.com/niklak/dom_query.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ jni = "0.21"
 ndk = "0.9"
 tao-macros = "0.1"
 libc = "0.2"
-dom_query = { version = "0.26.0", default-features = false }
+dom_query = { version = "0.27.0", default-features = false }
 
 [dev-dependencies]
 pollster = "0.4.0"
@@ -214,11 +214,8 @@ percent-encoding = "2.3"
 # For unit testing `inject_initialization_scripts` since we can't do it easily on Android
 sha2 = "0.10"
 base64 = "0.22"
-dom_query = { version = "0.26.0", default-features = false }
+dom_query = { version = "0.27.0", default-features = false }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ["cfg(linux)", "cfg(gtk)"]
-
-[patch.crates-io]
-dom_query = { git = "https://github.com/niklak/dom_query.git" }

--- a/src/inject_initialization_scripts.rs
+++ b/src/inject_initialization_scripts.rs
@@ -5,7 +5,7 @@
 //! This is an internal implementation detail used by the Android backend to inject
 //! initialization scripts when `addDocumentStartJavaScript` is not supported.
 
-use base64::{engine::general_purpose, Engine};
+use base64::{prelude::BASE64_STANDARD, Engine};
 use dom_query::Document;
 use http::{
   header::{HeaderValue, CONTENT_SECURITY_POLICY, CONTENT_TYPE},
@@ -79,7 +79,7 @@ fn hash_script(script: &str) -> String {
   let mut hasher = Sha256::new();
   hasher.update(script);
   let hash = hasher.finalize();
-  format!("'sha256-{}'", general_purpose::STANDARD.encode(hash))
+  format!("'sha256-{}'", BASE64_STANDARD.encode(hash))
 }
 
 #[cfg(test)]
@@ -123,16 +123,17 @@ mod tests {
   fn test_inject_multiple_scripts() {
     let body = "<html><head></head><body>Content</body></html>";
     let scripts = vec![
-      "var first = 1;".to_string(),
-      "var second = 2;".to_string(),
-      "var third = 3;".to_string(),
+      "var first = 1;".to_owned(),
+      "let second = 2;".to_owned(),
+      "const third = 3;".to_owned(),
+      "window.test = () => console.log('test');".to_owned(),
     ];
 
     let result = run(body, "text/html", scripts);
 
     assert_eq!(
       result,
-      "<html><head><script>var first = 1;</script><script>var second = 2;</script><script>var third = 3;</script></head><body>Content</body></html>"
+      "<html><head><script>var first = 1;</script><script>let second = 2;</script><script>const third = 3;</script><script>window.test = () => console.log('test');</script></head><body>Content</body></html>"
     );
   }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Fix #1689
Fix https://github.com/tauri-apps/tauri/issues/15067