### PR TITLE
docs: remove outdated Android note for evaluate_script_with_callback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2012,8 +2012,6 @@ impl WebView {
   /// serialized into a JSON string and passed to the callback function.
   ///
   /// Exception is ignored because of the limitation on windows. You can catch it yourself and return as string as a workaround.
-  ///
-  /// - ** Android:** Not implemented yet.
   pub fn evaluate_script_with_callback(
     &self,
     js: &str,


### PR DESCRIPTION
This is implemented for Android in #1133

Reference https://github.com/tauri-apps/tauri/pull/14925#discussion_r2998781773