### PR TITLE
fix(macos): forward unhandled keyDown events to WebView content

### DIFF
--- a/src/wkwebview/class/wry_web_view_parent.rs
+++ b/src/wkwebview/class/wry_web_view_parent.rs
@@ -6,10 +6,12 @@
 use objc2::DefinedClass;
 use objc2::{define_class, msg_send, rc::Retained, MainThreadOnly};
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSEvent, NSView, NSWindow, NSWindowButton};
+use objc2_app_kit::{
+  NSApplication, NSEvent, NSEventModifierFlags, NSView, NSWindow, NSWindowButton,
+};
 use objc2_foundation::MainThreadMarker;
 #[cfg(target_os = "macos")]
-use objc2_foundation::NSRect;
+use objc2_foundation::{NSArray, NSRect};
 #[cfg(target_os = "ios")]
 use objc2_ui_kit::UIView as NSView;
 
@@ -28,12 +30,42 @@ define_class!(
     #[cfg(target_os = "macos")]
     #[unsafe(method(keyDown:))]
     fn key_down(&self, event: &NSEvent) {
-      let mtm = MainThreadMarker::new().unwrap();
-      let app = NSApplication::sharedApplication(mtm);
-      unsafe {
-        if let Some(menu) = app.mainMenu() {
-          menu.performKeyEquivalent(event);
+      let flags = unsafe { event.modifierFlags() };
+
+      // Only attempt menu key equivalents when Command or Control modifiers
+      // are held. Without this guard, ALL keyDown events (including bare
+      // number keys, symbols, and arrow keys) are sent to
+      // `performKeyEquivalent` which silently swallows them when no menu
+      // item matches, preventing the events from ever reaching the
+      // WKWebView content — especially problematic for iframe-based apps.
+      //
+      // Note: Option (Alt) is intentionally excluded — Option+key
+      // combinations are used for special character input (e.g.,
+      // Option+e for accent marks) and routing them to
+      // performKeyEquivalent would break dead-key / compose input.
+      //
+      // Refs: https://github.com/tauri-apps/wry/issues/1175
+      //       https://github.com/tauri-apps/wry/issues/1177
+      if flags.intersects(NSEventModifierFlags::Command | NSEventModifierFlags::Control) {
+        let mtm = MainThreadMarker::new().unwrap();
+        let app = NSApplication::sharedApplication(mtm);
+        unsafe {
+          if let Some(menu) = app.mainMenu() {
+            if menu.performKeyEquivalent(event) {
+              return;
+            }
+          }
         }
+      }
+
+      // Events reaching here were not handled by the WKWebView (first
+      // responder) or matched a menu shortcut. We call interpretKeyEvents
+      // on self (the parent NSView) purely to suppress the NSBeep that
+      // super.keyDown would produce (see PR #742). The parent has no
+      // NSTextInputClient, so this is effectively a no-op sink for
+      // unhandled keys.
+      unsafe {
+        self.interpretKeyEvents(&NSArray::from_slice(&[event]));
       }
     }
 


### PR DESCRIPTION
## Summary

On macOS, `WryWebViewParent::keyDown:` unconditionally sends **all** key events to `menu.performKeyEquivalent()` without checking the return value or forwarding unhandled events. This causes bare key presses (numbers, symbols, arrow keys) to be silently swallowed — they never reach the WKWebView content, especially in iframe-based applications.

## Changes

- Only route key events to `performKeyEquivalent` when **Command** or **Control** modifiers are held
- Check `performKeyEquivalent` return value — if the menu handled it, stop; otherwise fall through
- For unhandled keys, call `interpretKeyEvents` (not `super.keyDown`) to avoid re-introducing the NSBeep sound fixed in PR #742
- Option (Alt) is intentionally excluded from the modifier check — Option+key is used for special character / dead-key input

## Background

| PR | What happened |
|---|---|
| #742 | Added `interpretKeyEvents` to suppress beep |
| #760 | Added `performKeyEquivalent` for menu shortcuts |
| #798 | Removed all keyDown overrides (clean slate) |
| #801 | Re-added `performKeyEquivalent` **without** return value check — current buggy state |

## Known limitation

This does not fix Cmd+key JavaScript listeners in child webviews (the existing FIXME in `wry_web_view.rs:47-50`). That is a separate issue tracked in #1177.

Fixes #1175
Refs #1177, #801