### PR TITLE
feat: Implements `WebViewExtWindows::hwnd` and `InnerWebView::hwnd` handler

### DIFF
--- a/.changes/forward-hwnd-handler.md
+++ b/.changes/forward-hwnd-handler.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-Add getter for HWND property for **WebViewExtWindows** and **InnerWebView** Structs
+On Windows, Add `WebViewExtWindows::hwnd` getter to access the child HWND containing the webview.

--- a/.changes/forward-hwnd-handler.md
+++ b/.changes/forward-hwnd-handler.md
@@ -1,5 +1,5 @@
 ---
-"wry": patch
+"wry": minor
 ---
 
 On Windows, Add `WebViewExtWindows::hwnd` getter to access the child HWND containing the webview.

--- a/.changes/forward-hwnd-handler.md
+++ b/.changes/forward-hwnd-handler.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-Add getter for HWND property for WebViewExtWindows and WebView Structs
+Add getter for HWND property for **WebViewExtWindows** and **InnerWebView** Structs

--- a/.changes/forward-hwnd-handler.md
+++ b/.changes/forward-hwnd-handler.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Add getter for HWND property for WebViewExtWindows and WebView Structs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2168,11 +2168,6 @@ impl WebView {
   pub fn focus_parent(&self) -> Result<()> {
     self.webview.focus_parent()
   }
-
-  /// Returns the HWND of this webview.
-  pub fn webview_hwnd(&self) -> windows::Win32::Foundation::HWND {
-    self.webview.hwnd()
-  }
 }
 
 /// An event describing drag and drop operations on the webview.
@@ -2260,6 +2255,8 @@ pub trait WebViewExtWindows {
 
   /// Attaches this webview to the given HWND and removes it from the current one.
   fn reparent(&self, hwnd: isize) -> Result<()>;
+
+  fn webview_hwnd(&self) -> windows::Win32::Foundation::HWND;
 }
 
 #[cfg(target_os = "windows")]
@@ -2286,6 +2283,11 @@ impl WebViewExtWindows for WebView {
 
   fn reparent(&self, hwnd: isize) -> Result<()> {
     self.webview.reparent(hwnd)
+  }
+
+  /// Returns the child HWND hosting this webview.
+  fn webview_hwnd(&self) -> windows::Win32::Foundation::HWND {
+    self.webview.hwnd()
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2168,6 +2168,11 @@ impl WebView {
   pub fn focus_parent(&self) -> Result<()> {
     self.webview.focus_parent()
   }
+
+  /// Returns the HWND of this webview.
+  pub fn webview_hwnd(&self) -> windows::Win32::Foundation::HWND {
+    self.webview.hwnd()
+  }
 }
 
 /// An event describing drag and drop operations on the webview.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2256,7 +2256,8 @@ pub trait WebViewExtWindows {
   /// Attaches this webview to the given HWND and removes it from the current one.
   fn reparent(&self, hwnd: isize) -> Result<()>;
 
-  fn webview_hwnd(&self) -> windows::Win32::Foundation::HWND;
+  /// Returns the child HWND hosting this webview.
+  fn hwnd(&self) -> windows::Win32::Foundation::HWND;
 }
 
 #[cfg(target_os = "windows")]
@@ -2286,7 +2287,7 @@ impl WebViewExtWindows for WebView {
   }
 
   /// Returns the child HWND hosting this webview.
-  fn webview_hwnd(&self) -> windows::Win32::Foundation::HWND {
+  fn hwnd(&self) -> windows::Win32::Foundation::HWND {
     self.webview.hwnd()
   }
 }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1372,6 +1372,11 @@ impl InnerWebView {
     &self.id
   }
 
+  #[inline]
+  pub fn hwnd(&self) -> HWND {
+    self.hwnd
+  }
+
   pub fn eval(
     &self,
     js: &str,


### PR DESCRIPTION
## Summary
Working on a personal project I found the need to handle the `HWND` own my application side for personal features implementations. 

## Changes
- On Windows, Add `WebViewExtWindows::hwnd` getter to access the child HWND containing the webview.
