### PR TITLE
perf(macOS): avoid copying large protocol bodies

### DIFF
--- a/.changes/macos-protocol-body-nocopy.md
+++ b/.changes/macos-protocol-body-nocopy.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, avoid an extra copy for owned custom protocol response bodies of 128KB or larger by transferring the body buffer into `NSData`.

--- a/.changes/macos-protocol-body-nocopy.md
+++ b/.changes/macos-protocol-body-nocopy.md
@@ -2,4 +2,4 @@
 "wry": patch
 ---
 
-On macOS, avoid an extra copy for owned custom protocol response bodies of 128KB or larger by transferring the body buffer into `NSData`.
+On macOS, avoid an extra copy for owned custom protocol response bodies by transferring the body buffer into `NSData`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
  "bitflags 2.8.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ objc2-core-foundation = { version = "0.3.0", default-features = false, features 
 ] }
 objc2-foundation = { version = "0.3.0", default-features = false, features = [
   "std",
+  "block2",
   "objc2-core-foundation",
   "NSURLRequest",
   "NSURL",

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -26,8 +26,6 @@ use objc2_web_kit::{WKURLSchemeHandler, WKURLSchemeTask};
 
 use crate::{wkwebview::WEBVIEW_STATE, RequestAsyncResponder, WryWebView};
 
-const NO_COPY_DATA_THRESHOLD: usize = 128 * 1024;
-
 pub fn create(name: &str) -> &AnyClass {
   unsafe {
     // Include the address of WEBVIEW_STATE in the class name so that each dylib in the process

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -267,8 +267,8 @@ extern "C" fn start_task(
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
                 let data = match sent_response.into_body() {
-                    Cow::Owned(content) => NSData::from_vec(content),
-                    Cow::Borrowed(content) => NSData::with_bytes(content),
+                  Cow::Owned(content) => NSData::from_vec(content),
+                  Cow::Borrowed(content) => NSData::with_bytes(content),
                 };
 
                 // Check validity again

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -4,7 +4,7 @@
 
 use std::{
   borrow::Cow,
-  ffi::{c_char, c_void, CStr},
+  ffi::{c_char, CStr},
   panic::AssertUnwindSafe,
   ptr::NonNull,
 };
@@ -268,20 +268,14 @@ extern "C" fn start_task(
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
                 let data = if content_len < NO_COPY_DATA_THRESHOLD {
-                  let data = NSData::alloc();
                   // Keep small responses on the original copy path; no-copy deallocation costs more.
-                  NSData::initWithBytes_length(data, content.as_ptr() as *mut c_void, content.len())
+                  NSData::with_bytes(content)
                 } else {
                   match sent_response.into_body() {
                     Cow::Owned(content) => NSData::from_vec(content),
                     Cow::Borrowed(content) => {
-                      let data = NSData::alloc();
                       // Copy borrowed responses because NSData cannot take ownership.
-                      NSData::initWithBytes_length(
-                        data,
-                        content.as_ptr() as *mut c_void,
-                        content.len(),
-                      )
+                      NSData::with_bytes(content)
                     }
                   }
                 };

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -266,21 +266,9 @@ extern "C" fn start_task(
                 }))
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
-                let content = sent_response.into_body();
-                // It yields benefits by eliminating buffer copying starting from 128 KB.
-                // However, sizes below 64 bytes cause regressions(or noise). 128 KB as
-                // it aligns better with engineering standards and is more human-readable.
-                let data = if content_len < NO_COPY_DATA_THRESHOLD {
-                  // Keep small responses on the original copy path; no-copy deallocation costs more.
-                  NSData::with_bytes(content.as_ref())
-                } else {
-                  match content {
+                let data = match sent_response.into_body() {
                     Cow::Owned(content) => NSData::from_vec(content),
-                    Cow::Borrowed(content) => {
-                      // Copy borrowed responses because NSData cannot take ownership.
-                      NSData::with_bytes(content)
-                    }
-                  }
+                    Cow::Borrowed(content) => NSData::with_bytes(content),
                 };
 
                 // Check validity again

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -216,8 +216,7 @@ extern "C" fn start_task(
                 check_webview_id_valid(webview_id)?;
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
 
-                let content = sent_response.body();
-                let content_len = content.len();
+                let content_len = sent_response.body().len();
                 // default: application/octet-stream, but should be provided by the client
                 let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
                 // default to 200
@@ -267,11 +266,12 @@ extern "C" fn start_task(
                 }))
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
+                let content = sent_response.into_body();
                 let data = if content_len < NO_COPY_DATA_THRESHOLD {
                   // Keep small responses on the original copy path; no-copy deallocation costs more.
-                  NSData::with_bytes(content)
+                  NSData::with_bytes(content.as_ref())
                 } else {
-                  match sent_response.into_body() {
+                  match content {
                     Cow::Owned(content) => NSData::from_vec(content),
                     Cow::Borrowed(content) => {
                       // Copy borrowed responses because NSData cannot take ownership.

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -267,6 +267,9 @@ extern "C" fn start_task(
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
                 let content = sent_response.into_body();
+                // It yields benefits by eliminating buffer copying starting from 88 bytes.
+                // However, sizes below 88 bytes cause regressions. 128 bytes as
+                // it aligns better with engineering standards and is more human-readable.
                 let data = if content_len < NO_COPY_DATA_THRESHOLD {
                   // Keep small responses on the original copy path; no-copy deallocation costs more.
                   NSData::with_bytes(content.as_ref())

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -26,7 +26,7 @@ use objc2_web_kit::{WKURLSchemeHandler, WKURLSchemeTask};
 
 use crate::{wkwebview::WEBVIEW_STATE, RequestAsyncResponder, WryWebView};
 
-const NO_COPY_DATA_THRESHOLD: usize = 64 * 1024;
+const NO_COPY_DATA_THRESHOLD: usize = 128 * 1024;
 
 pub fn create(name: &str) -> &AnyClass {
   unsafe {
@@ -267,8 +267,8 @@ extern "C" fn start_task(
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
                 let content = sent_response.into_body();
-                // It yields benefits by eliminating buffer copying starting from 64 KB.
-                // However, sizes below 64 bytes cause regressions(or noise). 64 KB as
+                // It yields benefits by eliminating buffer copying starting from 128 KB.
+                // However, sizes below 64 bytes cause regressions(or noise). 128 KB as
                 // it aligns better with engineering standards and is more human-readable.
                 let data = if content_len < NO_COPY_DATA_THRESHOLD {
                   // Keep small responses on the original copy path; no-copy deallocation costs more.

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -26,7 +26,7 @@ use objc2_web_kit::{WKURLSchemeHandler, WKURLSchemeTask};
 
 use crate::{wkwebview::WEBVIEW_STATE, RequestAsyncResponder, WryWebView};
 
-const NO_COPY_DATA_THRESHOLD: usize = 128 * 1024;
+const NO_COPY_DATA_THRESHOLD: usize = 64 * 1024;
 
 pub fn create(name: &str) -> &AnyClass {
   unsafe {
@@ -267,8 +267,8 @@ extern "C" fn start_task(
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
                 let content = sent_response.into_body();
-                // It yields benefits by eliminating buffer copying starting from 88 bytes.
-                // However, sizes below 88 bytes cause regressions. 128 bytes as
+                // It yields benefits by eliminating buffer copying starting from 64 KB.
+                // However, sizes below 64 bytes cause regressions(or noise). 64 KB as
                 // it aligns better with engineering standards and is more human-readable.
                 let data = if content_len < NO_COPY_DATA_THRESHOLD {
                   // Keep small responses on the original copy path; no-copy deallocation costs more.

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -26,6 +26,8 @@ use objc2_web_kit::{WKURLSchemeHandler, WKURLSchemeTask};
 
 use crate::{wkwebview::WEBVIEW_STATE, RequestAsyncResponder, WryWebView};
 
+const NO_COPY_DATA_THRESHOLD: usize = 128 * 1024;
+
 pub fn create(name: &str) -> &AnyClass {
   unsafe {
     // Include the address of WEBVIEW_STATE in the class name so that each dylib in the process
@@ -215,6 +217,7 @@ extern "C" fn start_task(
                 check_task_is_valid(&webview, task_key, task_uuid.clone())?;
 
                 let content = sent_response.body();
+                let content_len = content.len();
                 // default: application/octet-stream, but should be provided by the client
                 let wanted_mime = sent_response.headers().get(CONTENT_TYPE);
                 // default to 200
@@ -231,7 +234,7 @@ extern "C" fn start_task(
                 }
                 headers.insert(
                   &*NSString::from_str(CONTENT_LENGTH.as_str()),
-                  &*NSString::from_str(&content.len().to_string()),
+                  &*NSString::from_str(&content_len.to_string()),
                 );
 
                 // add headers
@@ -264,15 +267,24 @@ extern "C" fn start_task(
                 }))
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
-                // Send data
-                let data = NSData::alloc();
-                // MIGRATE NOTE: we copied the content to the NSData because content will be freed
-                // when out of scope but NSData will also free the content when it's done and cause doube free.
-                let data = NSData::initWithBytes_length(
-                  data,
-                  content.as_ptr() as *mut c_void,
-                  content.len(),
-                );
+                let data = if content_len < NO_COPY_DATA_THRESHOLD {
+                  let data = NSData::alloc();
+                  // Keep small responses on the original copy path; no-copy deallocation costs more.
+                  NSData::initWithBytes_length(data, content.as_ptr() as *mut c_void, content.len())
+                } else {
+                  match sent_response.into_body() {
+                    Cow::Owned(content) => NSData::from_vec(content),
+                    Cow::Borrowed(content) => {
+                      let data = NSData::alloc();
+                      // Copy borrowed responses because NSData cannot take ownership.
+                      NSData::initWithBytes_length(
+                        data,
+                        content.as_ptr() as *mut c_void,
+                        content.len(),
+                      )
+                    }
+                  }
+                };
 
                 // Check validity again
                 check_webview_id_valid(webview_id)?;


### PR DESCRIPTION
On macOS, Wry now avoids an extra copy for owned custom protocol
response bodies of 128KB or larger by transferring the Vec<u8> directly into NSData.