### PR TITLE
fix(macos): use modern pasteboard API for drag-drop file collection

### DIFF
--- a/.changes/macos-drag-drop-modern-pasteboard.md
+++ b/.changes/macos-drag-drop-modern-pasteboard.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS, use the modern `readObjectsForClasses:options:` pasteboard API to collect dragged file paths. This fixes a panic when the drag source publishes only the modern per-item `public.file-url` type (as `NSDraggingItem.initWithPasteboardWriter:` does) instead of the legacy `NSFilenamesPboardType`, and removes the deprecated API as the primary path. The legacy type is kept as a defensive fallback.

--- a/src/wkwebview/drag_drop.rs
+++ b/src/wkwebview/drag_drop.rs
@@ -6,27 +6,58 @@ use std::{ffi::CStr, path::PathBuf};
 
 use objc2::{
   runtime::{Bool, ProtocolObject},
-  DeclaredClass,
+  ClassType, DeclaredClass,
 };
 use objc2_app_kit::{NSDragOperation, NSDraggingInfo, NSFilenamesPboardType};
-use objc2_foundation::{NSArray, NSPoint, NSRect, NSString};
+use objc2_foundation::{NSArray, NSPoint, NSRect, NSString, NSURL};
 
 use crate::DragDropEvent;
 
 use super::WryWebView;
 
 pub(crate) unsafe fn collect_paths(drag_info: &ProtocolObject<dyn NSDraggingInfo>) -> Vec<PathBuf> {
+  // Prefer the modern `readObjectsForClasses:options:` API with `NSURL`. It works
+  // for sources that publish per-item `public.file-url` types (the standard for
+  // `NSDraggingItem.initWithPasteboardWriter:` with `NSPasteboardItem`) as well
+  // as the legacy `NSFilenamesPboardType` payload, so it covers both paths in
+  // one call.
+  //
+  // The legacy `NSFilenamesPboardType` branch below is kept as a defensive
+  // fallback in case `readObjectsForClasses:options:` returns nothing on some
+  // configuration; it should not normally be reached.
+  //
+  // No `unwrap` calls: every conversion that can fail skips the entry, so a
+  // malformed pasteboard never panics the webview process.
   let pb = drag_info.draggingPasteboard();
   let mut drag_drop_paths = Vec::new();
-  let types = NSArray::arrayWithObject(NSFilenamesPboardType);
 
+  let url_classes = NSArray::from_slice(&[NSURL::class()]);
+  if let Some(items) = pb.readObjectsForClasses_options(&url_classes, None) {
+    for item in &items {
+      if let Some(url) = item.downcast_ref::<NSURL>() {
+        if let Some(path) = url.path() {
+          let path = CStr::from_ptr(path.UTF8String()).to_string_lossy();
+          drag_drop_paths.push(PathBuf::from(path.into_owned()));
+        }
+      }
+    }
+    if !drag_drop_paths.is_empty() {
+      return drag_drop_paths;
+    }
+  }
+
+  // Legacy fallback: read `NSFilenamesPboardType` directly.
+  let types = NSArray::arrayWithObject(NSFilenamesPboardType);
   if pb.availableTypeFromArray(&types).is_some() {
-    let paths = pb.propertyListForType(NSFilenamesPboardType).unwrap();
-    let paths = paths.downcast::<NSArray>().unwrap();
-    for path in paths {
-      let path = path.downcast::<NSString>().unwrap();
-      let path = CStr::from_ptr(path.UTF8String()).to_string_lossy();
-      drag_drop_paths.push(PathBuf::from(path.into_owned()));
+    if let Some(paths) = pb.propertyListForType(NSFilenamesPboardType) {
+      if let Ok(paths) = paths.downcast::<NSArray>() {
+        for path in paths {
+          if let Ok(path) = path.downcast::<NSString>() {
+            let path = CStr::from_ptr(path.UTF8String()).to_string_lossy();
+            drag_drop_paths.push(PathBuf::from(path.into_owned()));
+          }
+        }
+      }
     }
   }
   drag_drop_paths


### PR DESCRIPTION
On macOS, `collect_paths` reads dragged file paths from the deprecated `NSFilenamesPboardType` only. When the drag source publishes only the modern per-item `public.file-url` type (the standard for `NSDraggingItem.initWithPasteboardWriter:` with `NSPasteboardItem`), `availableTypeFromArray:` reports the legacy type as derivable but `propertyListForType:` returns nil, hitting an `unwrap` and panicking the whole webview process.

This switches `collect_paths` to the modern `NSPasteboard.readObjectsForClasses:options:` API with `NSURL`, which covers both legacy and modern sources in one call. The legacy `NSFilenamesPboardType` branch is kept as a defensive fallback in case `readObjectsForClasses:options:` returns nothing on some configuration. No `unwrap` calls anywhere in the new code — every fallible conversion skips the entry instead of panicking.

## Test plan

I did these:

- Ran `cargo build` and `cargo test` on `aarch64-apple-darwin` and `x86_64-apple-darwin`, with default features, `--all-features`, and `--no-default-features --features os-webview`. All combinations: 8 unit tests + 6–7 doc tests passed, 0 failed.
- Ran `cargo clippy --all-targets --all-features`, it's clean (existing unrelated `examples/gtk_opengl.rs` unused-import warnings only, present on `dev` since #1682).
- Ran `cargo fmt --all -- --check` clean.
- End-to-end validated against [Cmdr](https://getcmdr.com) (my file manager), which is the real-world drag source that triggered this bug. With Cmdr publishing only modern per-item `public.file-url` types (no `NSFilenamesPboardType`), self-drag re-entry into the wry webview no longer panics — the `readObjectsForClasses:` path returns the URLs and `collect_paths` yields the expected `Vec<PathBuf>`.