### PR TITLE
feat(webkitgtk): make input method preedit configurable

### DIFF
--- a/.changes/configurable-input-method-preedit.md
+++ b/.changes/configurable-input-method-preedit.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+On Linux, add `WebViewBuilderExtUnix::with_input_method_preedit(bool)` to make the input method preedit configurable. Defaults to `false`, preserving the behavior introduced in wry 0.29.0 (see tauri-apps/tauri#5986). Apps targeting modern webkit2gtk (≥ 2.50) can opt in to inline preedit, which CJK IMEs use to render composition state inside editable elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1920,6 +1920,7 @@ impl WebViewBuilderExtAndroid for WebViewBuilder<'_> {
 pub(crate) struct PlatformSpecificWebViewAttributes {
   extension_path: Option<PathBuf>,
   related_view: Option<webkit2gtk::WebView>,
+  input_method_preedit: bool,
 }
 
 #[cfg(any(
@@ -1950,6 +1951,26 @@ pub trait WebViewBuilderExtUnix<'a> {
   /// Creates a new webview sharing the same web process with the provided webview.
   /// Useful if you need to link a webview to another, for instance when using the [`WebViewBuilder::with_new_window_req_handler`].
   fn with_related_view(self, webview: webkit2gtk::WebView) -> Self;
+
+  /// Set whether the WebView's input method context should report
+  /// preedit text to the application during composition.
+  ///
+  /// When `true`, IME composition events (`compositionstart`,
+  /// `compositionupdate`, `compositionend`) fire in the DOM and
+  /// CJK input methods can render their preedit inline in editable
+  /// elements. When `false` (the default), preedit is suppressed
+  /// and the IM falls back to its own popup UI; this matches the
+  /// behavior introduced in wry 0.29.0 to mitigate
+  /// popup-positioning issues on older webkit2gtk versions (see
+  /// [tauri-apps/tauri#5986]).
+  ///
+  /// On modern webkit2gtk-4.1 (≥ 2.50) inline preedit works
+  /// correctly with major IMEs (fcitx5, ibus, etc.); apps targeting
+  /// those environments can opt in here to match the IME UX of
+  /// native GTK / Firefox / Chromium-based apps.
+  ///
+  /// [tauri-apps/tauri#5986]: https://github.com/tauri-apps/tauri/issues/5986
+  fn with_input_method_preedit(self, enabled: bool) -> Self;
 }
 
 #[cfg(any(
@@ -1977,6 +1998,11 @@ impl<'a> WebViewBuilderExtUnix<'a> for WebViewBuilder<'a> {
 
   fn with_related_view(mut self, webview: webkit2gtk::WebView) -> Self {
     self.platform_specific.related_view.replace(webview);
+    self
+  }
+
+  fn with_input_method_preedit(mut self, enabled: bool) -> Self {
+    self.platform_specific.input_method_preedit = enabled;
     self
   }
 }

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -301,7 +301,7 @@ impl InnerWebView {
     }
 
     // Webview Settings
-    Self::set_webview_settings(&webview, &attributes);
+    Self::set_webview_settings(&webview, &attributes, &pl_attrs);
 
     // Webview handlers
     Self::attach_handlers(&webview, web_context, &mut attributes);
@@ -411,10 +411,19 @@ impl InnerWebView {
     builder.build()
   }
 
-  fn set_webview_settings(webview: &WebView, attributes: &WebViewAttributes) {
-    // Disable input preedit,fcitx input editor can anchor at edit cursor position
+  fn set_webview_settings(
+    webview: &WebView,
+    attributes: &WebViewAttributes,
+    pl_attrs: &super::PlatformSpecificWebViewAttributes,
+  ) {
+    // Configure input method preedit per the platform-specific
+    // attribute. Default is `false` (disabled) — fcitx-style IMEs
+    // anchor their popup at the edit cursor (see
+    // tauri-apps/tauri#5986 for the original motivation). When
+    // `true`, WebKit reports composition events to the DOM and
+    // CJK IMEs render preedit inline.
     if let Some(input_context) = webview.input_method_context() {
-      input_context.set_enable_preedit(false);
+      input_context.set_enable_preedit(pl_attrs.input_method_preedit);
     }
 
     // use system scrollbars


### PR DESCRIPTION
## Background

I ran into this while experimenting with a Linux desktop app on **wry 0.53.5** against **webkit2gtk-4.1 2.50.x** on Ubuntu 24.04, and trying to use a plain `<input>` for Korean text. With a default wry build, typing Hangul felt broken — each keystroke either dropped the in-progress composition or briefly flickered into a detached fcitx popup that didn't track the cursor.

**The root cause is that wry currently disables IME preedit unconditionally on Linux, so there is no way for any wry-based app to display preedit text inline.** `webkitgtk::InnerWebView::set_webview_settings` calls `set_enable_preedit(false)` with no opt-out, which means CJK users never see what they're composing inside `<input>` / `<textarea>` / `contenteditable` elements — they only see characters appear after the IME commits, with no underlined preedit in between.

That call landed in wry 0.29.0 to work around fcitx popup positioning on older webkit2gtk (tauri-apps/tauri#5986). On modern webkit2gtk-4.1 (≥ 2.50) the popup positioning issue is gone, but the unconditional `false` is now actively preventing the standard IME UX that GTK, Firefox, and Chromium-based apps all render correctly on the same systems.

## What this PR does

Adds `WebViewBuilderExtUnix::with_input_method_preedit(bool)` so apps can opt in to inline preedit:

```rust
let builder = WebViewBuilder::new()
    .with_input_method_preedit(true);
```

The default stays false, so this is non-breaking — existing apps that rely on the popup behavior keep getting it.

When enabled, webkit's GtkIMContext reports compositionstart / compositionupdate / compositionend to the DOM, and the IME renders its preedit string (with the standard underline) inline at the cursor.

## Testing

Manually tested on Ubuntu 24.04 (X11) + webkit2gtk-4.1 2.50.x with two IMEs:

- fcitx5-hangul (Korean): typing 안녕 shows inline preedit underlined at the cursor; commit lands cleanly; repeated send-and-clear works in a loop.
- fcitx5-anthy (Japanese): typing romaji like nihongo shows にほんご inline; Space opens the candidate window; Enter commits.

I haven't tested Wayland or ibus — happy to add those data points if a maintainer wants them before merging.

## Related

- tauri-apps/tauri#5986 — original report behind unconditional set_enable_preedit(false)
- tauri-apps/tauri#11412 — recent user request for inline preedit
- tauri-apps/tauri#8264 — related IME report
- tauri-apps/wry#955 — earlier discussion


<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in navigation handler
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/wry/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
