### PR TITLE
fix(webkitgtk): mark custom URI schemes as CORS-enabled

### DIFF
--- a/.changes/webkit-cors-enable-scheme.md
+++ b/.changes/webkit-cors-enable-scheme.md
@@ -1,0 +1,16 @@
+---
+"wry": patch
+---
+
+On Linux, mark custom URI schemes as CORS-enabled (in addition to
+secure) when registering them with webkit2gtk. webkit2gtk 2.46+ added a
+requirement that the scheme be in the CORS allow-list for the host's
+custom-scheme handler to be invoked for top-level navigations; without
+it webkit silently bypasses the handler and routes the request through
+the default network loader. Symptom for Tauri apps on Ubuntu 26.04 /
+Fedora 40+ / Arch rolling: the bundled UI fails to load and webview
+shows "Could not connect to localhost: Connection refused" because
+`tauri://localhost/` gets interpreted as `http://localhost:80/`.
+
+The new call is a no-op on webkit2gtk ≤ 2.44 so the patch is safe on
+Ubuntu 22.04 / 24.04.

--- a/src/webkitgtk/web_context.rs
+++ b/src/webkitgtk/web_context.rs
@@ -133,13 +133,23 @@ impl WebContextExt for super::WebContext {
   {
     self.register_custom_protocol(name.to_owned())?;
 
-    // Enable secure context
-    self
+    // Enable secure context + CORS for the scheme. webkit2gtk 2.46+
+    // requires the scheme to be CORS-enabled or webkit silently bypasses
+    // the registered handler and routes the request through the default
+    // network loader. Symptom for callers using a custom scheme like
+    // `tauri://localhost/`: the load lands as `http://localhost:80/` and
+    // shows "Could not connect to localhost: Connection refused" instead
+    // of the embedded asset.
+    //
+    // The CORS-enable call is a no-op on webkit2gtk ≤ 2.44 (Ubuntu 22.04
+    // / 24.04) so it's safe to add unconditionally.
+    let security_manager = self
       .os
       .context
       .security_manager()
-      .ok_or(Error::MissingManager)?
-      .register_uri_scheme_as_secure(name);
+      .ok_or(Error::MissingManager)?;
+    security_manager.register_uri_scheme_as_secure(name);
+    security_manager.register_uri_scheme_as_cors_enabled(name);
 
     self.os.context.register_uri_scheme(name, move |request| {
       #[cfg(feature = "tracing")]


### PR DESCRIPTION
## Summary

On Linux, the registered handler for a custom URI scheme is silently bypassed by webkit2gtk 2.46+ for top-level navigations unless the scheme is also marked CORS-enabled. Adds the missing \`register_uri_scheme_as_cors_enabled()\` call alongside the existing \`register_uri_scheme_as_secure()\`.

## Why

webkit2gtk 2.46 tightened security around custom URI schemes. The scheme registration via \`webkit_web_context_register_uri_scheme()\` no longer dispatches the handler for top-level navigations unless the scheme is also in the CORS allow-list. Without it, webkit silently routes the request through the default network loader.

For a Tauri app loading the bundled UI via \`tauri://localhost/index.html\`, this means the request lands at \`http://localhost:80/\` (with nothing listening) and the webview shows webkit's standard \"Could not connect to localhost: Connection refused\" error page — the entire app appears broken to the user.

The new call is a no-op on webkit2gtk ≤ 2.44 (Ubuntu 22.04 / 24.04) so the fix is safe to ship across versions.

## Validation

- **Reproduced**: Ubuntu 26.04 LTS aarch64, webkit2gtk 2.52.0, Tauri 2.10.3 release build → webview shows the connection-error page
- **Patched**: same setup → embedded UI loads correctly
- The same Tauri app's dev mode (vite serving real HTTP on :5173) was always working, isolating the bug to the custom-scheme path on Linux release builds
- Mac (WKWebView) / Windows (WebView2) untouched

## Test plan

- [ ] CI: existing wry tests pass
- [ ] Reviewer (Ubuntu 22.04 / 24.04): confirm the extra CORS-enable call is harmless on webkit2gtk ≤ 2.44 (the underlying C function is a no-op there per the webkit2gtk source)
- [ ] Reviewer (any Linux with webkit2gtk ≥ 2.46): confirm a sample Tauri app's release build that previously failed with the localhost error now loads
- [ ] Reviewer (Mac / Windows): no regression — the patch only touches \`src/webkitgtk/\`

## Notes

- The CORS-enable call comes from the existing \`webkit2gtk = \"=2.0.2\"\` Rust binding. No new dependency, no feature flag.
- The full integration that proved this out is at https://github.com/Sozenta-Inc/veya/pull/17 (vendored wry + workspace patch + repro doc) so we can drop the local fork once a wry release with this patch lands.

Draft until reviewers confirm + I respond to feedback.