### PR TITLE
fix(macos): avoid panicking on missing webview URL

### DIFF
--- a/.changes/macos-webview-url-error.md
+++ b/.changes/macos-webview-url-error.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Return an error instead of panicking when `WebView::url` cannot read a URL from `WKWebView` on macOS and iOS.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1346,8 +1346,16 @@ r#"Object.defineProperty(window, 'ipc', {
 }
 
 pub fn url_from_webview(webview: &WKWebView) -> Result<String> {
-  let url_obj = unsafe { webview.URL().unwrap() };
-  let absolute_url = unsafe { url_obj.absoluteString().unwrap() };
+  let Some(url_obj) = (unsafe { webview.URL() }) else {
+    return Err(Error::Io(std::io::Error::other(
+      "failed to get WebView URL",
+    )));
+  };
+  let Some(absolute_url) = (unsafe { url_obj.absoluteString() }) else {
+    return Err(Error::Io(std::io::Error::other(
+      "failed to get absolute WebView URL",
+    )));
+  };
 
   let bytes = {
     let bytes: *const c_char = absolute_url.UTF8String();


### PR DESCRIPTION
🤖 Sent by my AI agent on behalf of @gilgtm.

## Why
On macOS and iOS, `WKWebView.URL()` can be nil. Wry currently unwraps that optional value in `WebView::url`, which can panic the host process instead of returning an error to the caller.

## What
- Return an `Error::Io` when `WKWebView.URL()` is unavailable
- Return an `Error::Io` when the URL cannot produce an absolute string
- Add a patch changeset for the Darwin WebView URL getter fix

## Risk Assessment
Low — this only changes the failure path for the Darwin URL getter. The existing successful URL conversion path is unchanged.

## References
Validated locally on macOS:
- `cargo fmt --check`
- `cargo check`
- `cargo test`

Generated with Codex