### PR TITLE
fix(macos): prevent use-after-free in stop_task on macOS 11 during WKWebView dealloc

### DIFF
--- a/.changes/fix-macos11-stop-task-uaf.md
+++ b/.changes/fix-macos11-stop-task-uaf.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On macOS 11, fix use-after-free crash in custom protocol `stop_task` during WKWebView dealloc by using raw pointers instead of objc2 references and enforcing correct drop ordering in the async response handler.

--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -286,12 +286,18 @@ extern "C" fn start_task(
                 }))
                 .map_err(|_e| crate::Error::CustomProtocolTaskInvalid)?;
 
-                if WEBVIEW_STATE.read().unwrap().contains_key(webview_id) {
+                let result = if WEBVIEW_STATE.read().unwrap().contains_key(webview_id) {
                   webview.remove_custom_task_key(task_key);
                   Ok(())
                 } else {
                   Err(crate::Error::CustomProtocolTaskInvalid)
-                }
+                };
+
+                // webview must drop before task: if webview drop triggers dealloc →
+                // stopAllTasksForPage → platformStopTask, the task must still be alive.
+                drop(webview);
+                drop(task);
+                result
               }
 
               #[cfg(feature = "tracing")]
@@ -334,8 +340,8 @@ extern "C" fn start_task(
 extern "C" fn stop_task(
   _this: &ProtocolObject<dyn WKURLSchemeHandler>,
   _sel: objc2::runtime::Sel,
-  webview: &WryWebView,
-  task: &ProtocolObject<dyn WKURLSchemeTask>,
+  _webview: *mut AnyObject,
+  _task: *mut AnyObject,
 ) {
-  webview.remove_custom_task_key(task.hash());
+  // no-op: avoid accessing task/webview — macOS 11 may pass freed pointers here
 }


### PR DESCRIPTION
macOS 11 WebKit bug: during WKWebView dealloc, `stopAllTasksForPage` calls `stop_task` with already-freed task pointers. Any access (including the implicit `objc_release` from objc2 reference types) causes SIGSEGV.

Fix:
- `stop_task`: use raw pointers (`*mut AnyObject`) instead of objc2 references to skip automatic retain/release. Body is no-op since task is invalid.
- `start_task` response handler: explicit `drop(webview)` before `drop(task)` to ensure correct deallocation order.

closes #1733

## Details

On macOS 11, WebKit's internal `stopAllTasksForPage` (triggered during `[WKWebView dealloc]`) passes already-freed `WKURLSchemeTask` pointers to the `webView:stopURLSchemeTask:` callback. Using objc2 reference types (`&WryWebView`, `&ProtocolObject<dyn WKURLSchemeTask>`) triggers implicit `objc_retain` on entry, which crashes on the freed pointer.

The explicit drop ordering (`drop(webview)` before `drop(task)`) prevents a scenario where dropping `Retained<WryWebView>` on a worker thread triggers dealloc → `stopAllTasksForPage` → `stop_task`, while the task reference is still alive in the closure.

This is the same class of race condition reported in https://github.com/tauri-apps/tauri/issues/11516 (macOS 15) and https://github.com/tauri-apps/wry/issues/1730.