### PR TITLE
refactor!: remove unsafe impl Send and Sync on `NewWindowOpener`

### DIFF
--- a/.changes/change-pr-1736.md
+++ b/.changes/change-pr-1736.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Remove Send, Sync bounds from NewWindowOpener.

--- a/examples/gtk_opengl.rs
+++ b/examples/gtk_opengl.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 use tao::{
   event::{Event, WindowEvent},
   event_loop::{ControlFlow, EventLoop},

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -252,7 +252,10 @@ fn handle_request(
 
 #[allow(non_snake_case)]
 pub unsafe fn wryCreate(env: JNIEnv, _: JClass) {
-  let mut main_pipe = MainPipe { env };
+  let mut main_pipe = MainPipe {
+    env,
+    package: super::PACKAGE.get().unwrap(),
+  };
 
   let looper = ThreadLooper::for_thread().unwrap();
 

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -261,9 +261,10 @@ pub unsafe fn wryCreate(env: JNIEnv, _: JClass) {
 
   looper
     .add_fd_with_callback(MAIN_PIPE[0].as_fd(), FdEvent::INPUT, move |fd, _event| {
-      let size = std::mem::size_of::<bool>();
-      let mut wake = false;
-      if libc::read(fd.as_raw_fd(), &mut wake as *mut _ as *mut _, size) == size as libc::ssize_t {
+      let mut buf = [0u8];
+      if libc::read(fd.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len())
+        == buf.len() as libc::ssize_t
+      {
         // unregister itself on errors
         main_pipe.recv().is_ok()
       } else {

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -17,7 +17,7 @@ use std::{
   sync::{Arc, Mutex},
 };
 
-use super::{find_class, EvalCallback, WebviewId, EVAL_CALLBACKS, EVAL_ID_GENERATOR, PACKAGE};
+use super::{find_class, EvalCallback, WebviewId, EVAL_CALLBACKS, EVAL_ID_GENERATOR};
 
 pub type ActivityId = i32;
 
@@ -126,6 +126,7 @@ pub fn get_webview(activity_id: ActivityId) -> Option<GlobalRef> {
 
 pub struct MainPipe<'a> {
   pub env: JNIEnv<'a>,
+  pub package: &'static str,
 }
 
 impl<'a> MainPipe<'a> {
@@ -188,7 +189,7 @@ impl<'a> MainPipe<'a> {
           let rust_webview_class = find_class(
             &mut self.env,
             &activity,
-            format!("{}/RustWebView", PACKAGE.get().unwrap()),
+            format!("{}/RustWebView", self.package),
           )?;
           let webview = self.env.new_object(
             &rust_webview_class,
@@ -237,7 +238,7 @@ impl<'a> MainPipe<'a> {
             )?;
           }
 
-          let webview_class_name = format!("{}/RustWebView", PACKAGE.get().unwrap());
+          let webview_class_name = format!("{}/RustWebView", self.package);
           self.env.call_method(
             &activity,
             "setWebView",
@@ -268,7 +269,7 @@ impl<'a> MainPipe<'a> {
             set_background_color(&mut self.env, &webview, color)?;
           }
           // Create and set webview client
-          let client_class_name = format!("{}/RustWebViewClient", PACKAGE.get().unwrap());
+          let client_class_name = format!("{}/RustWebViewClient", self.package);
           let rust_webview_client_class =
             find_class(&mut self.env, &activity, client_class_name.clone())?;
           let webview_client = self.env.new_object(
@@ -291,11 +292,7 @@ impl<'a> MainPipe<'a> {
           )?;
 
           // Add javascript interface (IPC)
-          let ipc_class = find_class(
-            &mut self.env,
-            &activity,
-            format!("{}/Ipc", PACKAGE.get().unwrap()),
-          )?;
+          let ipc_class = find_class(&mut self.env, &activity, format!("{}/Ipc", self.package))?;
           let ipc = self.env.new_object(
             ipc_class,
             format!("(L{webview_class_name};L{client_class_name};)V"),

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -131,13 +131,13 @@ pub struct MainPipe<'a> {
 
 impl<'a> MainPipe<'a> {
   pub(crate) fn send(activity_id: ActivityId, message: WebViewMessage) {
-    let size = std::mem::size_of::<bool>();
+    const BYTE: [u8; 1] = [0];
     if CHANNEL.0.send((activity_id, message)).is_ok() {
       unsafe {
         libc::write(
           MAIN_PIPE[1].as_raw_fd(),
-          &true as *const _ as *const _,
-          size,
+          BYTE.as_ptr() as *const _,
+          BYTE.len(),
         )
       };
     }

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -109,7 +109,7 @@ pub unsafe fn android_setup(
   _looper: &ThreadLooper,
   activity: GlobalRef,
 ) {
-  PACKAGE.get_or_init(move || package.to_string());
+  let package = PACKAGE.get_or_init(|| package.to_string());
 
   let vm = env.get_java_vm().unwrap();
 
@@ -136,13 +136,13 @@ pub unsafe fn android_setup(
   let rust_webchrome_client_class = find_class(
     &mut env,
     activity.as_obj(),
-    format!("{}/RustWebChromeClient", PACKAGE.get().unwrap()),
+    format!("{package}/RustWebChromeClient"),
   )
   .unwrap();
   let webchrome_client = env
     .new_object(
       &rust_webchrome_client_class,
-      format!("(L{}/WryActivity;)V", PACKAGE.get().unwrap()),
+      format!("(L{package}/WryActivity;)V"),
       &[activity.as_obj().into()],
     )
     .unwrap();

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -53,11 +53,11 @@ macro_rules! define_static_handlers {
   ($($var:ident = $type_name:ident { $($fields:ident:$types:ty),+ $(,)? });+ $(;)?) => {
     $(
     static $var: Lazy<Mutex<HashMap<WebviewId, $type_name>>> = Lazy::new(||Mutex::new(HashMap::new()));
-    pub struct $type_name {
+    struct $type_name {
       $($fields: $types,)*
     }
     impl $type_name {
-      pub fn new($($fields: $types,)*) -> Self {
+      fn new($($fields: $types,)*) -> Self {
         Self {
           $($fields,)*
         }
@@ -81,12 +81,12 @@ define_static_handlers! {
   ActivityId, WEBVIEW_ATTRIBUTES = CreateWebViewAttributes;
 }
 
-pub(crate) static PACKAGE: OnceCell<String> = OnceCell::new();
+static PACKAGE: OnceCell<String> = OnceCell::new();
 
 type EvalCallback = Box<dyn Fn(String) + Send + 'static>;
 
-pub static EVAL_ID_GENERATOR: Counter = Counter::new();
-pub static EVAL_CALLBACKS: OnceCell<Mutex<HashMap<i32, EvalCallback>>> = OnceCell::new();
+static EVAL_ID_GENERATOR: Counter = Counter::new();
+static EVAL_CALLBACKS: OnceCell<Mutex<HashMap<i32, EvalCallback>>> = OnceCell::new();
 
 pub fn destroy_webview(activity_id: ActivityId, webview_id: &WebviewId) {
   WEBVIEW_ATTRIBUTES.lock().unwrap().remove(&activity_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,9 +520,6 @@ pub struct NewWindowOpener {
   pub target_configuration: Retained<objc2_web_kit::WKWebViewConfiguration>,
 }
 
-unsafe impl Send for NewWindowOpener {}
-unsafe impl Sync for NewWindowOpener {}
-
 /// Window features of a window requested to open.
 #[non_exhaustive]
 #[derive(Debug)]


### PR DESCRIPTION
Partially superseding #1571, I'll take another look at that PR shortly, hadn't seen it no longer applies cleanly.

When we backtracked on the handler needing to be Send/Sync, `NewWindowOpener` can now also lose its unsafe override.