### PR TITLE
feat(windows): add `with_profile_name` for WebView2 multi-profile support

### DIFF
--- a/.changes/windows-with-profile-name.md
+++ b/.changes/windows-with-profile-name.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+On Windows, add `WebViewBuilderExtWindows::with_profile_name` to opt the webview into a named WebView2 profile. Webviews with different profile names within the same environment have isolated cookies, storage, IndexedDB, and cache while sharing the runtime — matching WebView2's documented multi-profile pattern.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1677,6 +1677,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   extension_path: Option<PathBuf>,
   default_context_menus: bool,
   environment: Option<ICoreWebView2Environment>,
+  profile_name: Option<String>,
 }
 
 #[cfg(windows)]
@@ -1692,6 +1693,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       browser_extensions_enabled: false,
       extension_path: None,
       environment: None,
+      profile_name: None,
     }
   }
 }
@@ -1776,6 +1778,19 @@ pub trait WebViewBuilderExtWindows {
   /// Set the environment for the webview.
   /// Useful if you need to share the same environment, for instance when using the [`WebViewBuilder::with_new_window_req_handler`].
   fn with_environment(self, environment: ICoreWebView2Environment) -> Self;
+
+  /// Set the WebView2 profile name for this webview. Webviews with different
+  /// profile names within the same environment have isolated cookies, storage,
+  /// IndexedDB, cache, and other site data, while sharing the runtime.
+  ///
+  /// When `None` (the default), the webview uses the unnamed default profile.
+  ///
+  /// See <https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/multi-profile-support>
+  /// for the underlying WebView2 multi-profile feature.
+  ///
+  /// Profile names must follow the WebView2 naming rules (alphanumeric, `.`,
+  /// `_`, `-`, ` `, up to 64 chars, not starting/ending with `.` or ` `).
+  fn with_profile_name<S: Into<String>>(self, name: S) -> Self;
 }
 
 #[cfg(windows)]
@@ -1822,6 +1837,11 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 
   fn with_environment(mut self, environment: ICoreWebView2Environment) -> Self {
     self.platform_specific.environment.replace(environment);
+    self
+  }
+
+  fn with_profile_name<S: Into<String>>(mut self, name: S) -> Self {
+    self.platform_specific.profile_name = Some(name.into());
     self
   }
 }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -135,7 +135,13 @@ impl InnerWebView {
     } else {
       Self::create_environment(&attributes, pl_attrs.clone())?
     };
-    let controller = Self::create_controller(hwnd, &env, attributes.incognito, background_color)?;
+    let controller = Self::create_controller(
+      hwnd,
+      &env,
+      attributes.incognito,
+      background_color,
+      pl_attrs.profile_name.as_deref(),
+    )?;
     let webview = Self::init_webview(
       parent,
       hwnd,
@@ -369,6 +375,7 @@ impl InnerWebView {
     env: &ICoreWebView2Environment,
     incognito: bool,
     background_color: Option<(u8, u8, u8, u8)>,
+    profile_name: Option<&str>,
   ) -> Result<ICoreWebView2Controller> {
     let (tx, rx) = mpsc::channel();
 
@@ -405,6 +412,11 @@ impl InnerWebView {
         }
 
         controller_opts.SetIsInPrivateModeEnabled(incognito)?;
+
+        if let Some(name) = profile_name {
+          controller_opts.SetProfileName(&HSTRING::from(name))?;
+        }
+
         env10.CreateCoreWebView2ControllerWithOptions(hwnd, &controller_opts, &handler)?;
       } else {
         env.CreateCoreWebView2Controller(hwnd, &handler)?


### PR DESCRIPTION
Adds `WebViewBuilderExtWindows::with_profile_name` so embedded webviews can opt into a named WebView2 profile, isolating cookies, storage, IndexedDB, and cache from the host app's default profile while sharing the same WebView2 environment/runtime.

## Motivation

A common use case for `wry` (and Tauri downstream) is hosting an in-app browser tab alongside the main app webview. Without profile isolation, both share the unnamed default profile under the same `user_data_folder`, which means anything a user does in the embedded browser (signing into github.com, storing cookies, etc.) is mixed with the host app's own `localStorage` state. Profile-wide operations like clearing browsing data become unsafe because they touch the host app's storage as collateral damage.

`with_data_directory` (separate `user_data_folder`) is the existing workaround but it creates an entirely separate WebView2 environment with its own runtime/networking stack — which has historically caused OAuth/login-page regressions in apps that tried it (downstream report: Glint #2665).

Microsoft's recommended multi-profile pattern (https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/multi-profile-support) is named profiles within a shared environment, which `ICoreWebView2ControllerOptions::SetProfileName` enables. This PR exposes it through wry.

## Changes

- New `profile_name: Option<String>` field on the Windows `PlatformSpecificWebViewAttributes`.
- New trait method on `WebViewBuilderExtWindows`: `with_profile_name<S: Into<String>>(self, name: S) -> Self`.
- In `create_controller`, when a profile name is configured, call `ICoreWebView2ControllerOptions::SetProfileName` before `CreateCoreWebView2ControllerWithOptions`.

When `with_profile_name` is not called the behavior is unchanged — the webview uses the unnamed default profile, same as today.

## Platform notes

This PR only touches Windows. macOS / iOS already have `with_data_store_identifier` for the equivalent functionality. A follow-up could add the Linux equivalent (a dedicated `WebsiteDataManager` directory) under a unified API name if there's appetite for that.

## Naming-rule notes

WebView2 enforces profile-name rules (alphanumeric + `.`, `_`, `-`, space; up to 64 chars; cannot start or end with `.` or space). The doc-comment on `with_profile_name` mentions these constraints. The patch doesn't validate the string client-side — `SetProfileName` returns an error for malformed names, which is surfaced as a `wry::Error` at build time.

## Related

- Closes #1321 (Support for Browser Profiles) — at least the Windows half.
- Tauri tracking issue: tauri-apps/tauri#9285.