### PR TITLE
feat(webview2): add with_native_window_occlusion option

### DIFF
--- a/.changes/windows-native-window-occlusion.md
+++ b/.changes/windows-native-window-occlusion.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add `WebViewBuilderExtWindows::with_native_window_occlusion` to optionally disable WebView2's native window occlusion detection, so a webview keeps rendering while its window is hidden or occluded. Useful for apps that pre-create and show/hide multiple webviews.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1671,6 +1671,7 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   default_context_menus: bool,
   environment: Option<ICoreWebView2Environment>,
   profile_name: Option<String>,
+  native_window_occlusion: bool,
 }
 
 #[cfg(windows)]
@@ -1687,6 +1688,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       extension_path: None,
       environment: None,
       profile_name: None,
+      native_window_occlusion: true, // This is WebView2's default behavior
     }
   }
 }
@@ -1784,6 +1786,27 @@ pub trait WebViewBuilderExtWindows {
   /// Profile names must follow the WebView2 naming rules (alphanumeric, `.`,
   /// `_`, `-`, ` `, up to 64 chars, not starting/ending with `.` or ` `).
   fn with_profile_name<S: Into<String>>(self, name: S) -> Self;
+
+  /// Determines whether WebView2's native window occlusion detection is enabled.
+  ///
+  /// The default value is `true`, which matches WebView2's default behavior: when the
+  /// webview's window is fully covered by other windows, or hidden, WebView2 may stop
+  /// rendering it to save resources (the `CalculateNativeWinOcclusion` feature).
+  ///
+  /// Setting this to `false` disables that detection so a webview keeps rendering even
+  /// while its window is hidden or occluded. This is useful for apps that pre-create
+  /// several webviews and show/hide them on demand (e.g. a tabbed/multi-service shell):
+  /// with occlusion enabled, a webview created while hidden may never initialize its
+  /// render surface and paints blank when first shown.
+  ///
+  /// See <https://github.com/MicrosoftEdge/WebView2Feedback/issues/1077> and
+  /// <https://github.com/tauri-apps/tauri/issues/9798>.
+  ///
+  /// ## Warning
+  ///
+  /// This has no effect if [`with_additional_browser_args`](Self::with_additional_browser_args)
+  /// is also used, since that fully overrides the browser arguments wry passes by default.
+  fn with_native_window_occlusion(self, enabled: bool) -> Self;
 }
 
 #[cfg(windows)]
@@ -1835,6 +1858,11 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 
   fn with_profile_name<S: Into<String>>(mut self, name: S) -> Self {
     self.platform_specific.profile_name = Some(name.into());
+    self
+  }
+
+  fn with_native_window_occlusion(mut self, enabled: bool) -> Self {
+    self.platform_specific.native_window_occlusion = enabled;
     self
   }
 }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -297,11 +297,18 @@ impl InnerWebView {
       .map(HSTRING::from);
 
     // additional browser args
+    let native_window_occlusion = pl_attrs.native_window_occlusion;
     let additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
       // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
       // and "smart screen" - See https://github.com/tauri-apps/tauri/issues/1345
-      let default_args = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection";
-      let mut arguments = String::from(default_args);
+      let mut disabled_features =
+        String::from("--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection");
+      // optionally disable native window occlusion so webviews keep rendering while
+      // their window is hidden/occluded - See https://github.com/tauri-apps/tauri/issues/9798
+      if !native_window_occlusion {
+        disabled_features.push_str(",CalculateNativeWinOcclusion");
+      }
+      let mut arguments = disabled_features;
 
       if attributes.autoplay {
         arguments.push_str(" --autoplay-policy=no-user-gesture-required");


### PR DESCRIPTION
# feat(webview2): add `with_native_window_occlusion` option

## What

Adds a Windows-specific builder option `WebViewBuilderExtWindows::with_native_window_occlusion(bool)` that lets an app opt out of WebView2's native window occlusion detection.

When set to `false`, wry appends `CalculateNativeWinOcclusion` to the `--disable-features` list it already passes by default. It defaults to `true`, so **current behavior is unchanged** unless you explicitly opt out.

## Why

On Windows, WebView2 stops (or never starts) rendering a webview whose host window is hidden or fully occluded, to save resources. That's fine for a single foreground webview, but it breaks apps that pre-create several webviews and show/hide them on demand (tabbed browsers, multi-service messaging shells, etc.): a webview created while hidden may never bring up its render surface and paints **blank** the first time it's shown.

This is a long-standing pain point with no in-library workaround today:

- tauri-apps/tauri#9798 — added webview isn't rendered/on top (Windows)
- tauri-apps/tauri#13092 — additional `WebviewWindow` blank
- MicrosoftEdge/WebView2Feedback#1077 — WebView2 created in a background/not-shown window renders blank
- MicrosoftEdge/WebView2Feedback#1094 — gray after parent hidden → visible

Disabling `CalculateNativeWinOcclusion` is the documented lever for this, but the only way to reach it today is `with_additional_browser_args`, which **fully overrides** wry's default args (the mini-menu / SmartScreen / autoplay / proxy flags) — so you lose all of those unless you reproduce them by hand. This option exposes just the occlusion toggle while keeping wry's defaults intact.

## How

- New field `native_window_occlusion: bool` on the Windows `PlatformSpecificWebViewAttributes` (defaults to `true`).
- New trait method on `WebViewBuilderExtWindows`.
- In `webview2/mod.rs`, when the option is `false`, append `,CalculateNativeWinOcclusion` to the default `--disable-features` string. No effect when `with_additional_browser_args` is used (documented), since that path is a full override.

## Usage

```rust
let webview = WebViewBuilder::new()
    .with_url("https://example.com")
    .with_native_window_occlusion(false) // keep rendering while hidden/occluded
    .build(&window)?;
```

## Notes

- Windows-only; no-op on other platforms (the method only exists under `#[cfg(windows)]`, like the other `WebViewBuilderExtWindows` options).
- Type-checks for `x86_64-pc-windows-gnu`.
- Added a covector changelog entry (`minor`).

Real-world validation: this is what made reliable multi-webview show/hide work in a Tauri app that pre-creates one hidden webview per service and swaps them — without it, the second-and-later webviews paint blank on first show.
