### PR TITLE
fix(macos): handle nil URL/method/header values in url_scheme_handler

### DIFF
--- a/src/wkwebview/class/url_scheme_handler.rs
+++ b/src/wkwebview/class/url_scheme_handler.rs
@@ -88,15 +88,37 @@ extern "C" fn start_task(
     if let Some(function) = function {
       // Get url request
       let request = task.request();
-      let url = request.URL().unwrap();
+      // WebKit may dispatch custom-scheme tasks whose request has nil URL,
+      // absoluteString, or HTTPMethod. Unwrapping them aborts across the FFI
+      // boundary, so bail out (or fall back to GET) instead.
+      let Some(url) = request.URL() else {
+        #[cfg(feature = "tracing")]
+        tracing::warn!("custom scheme request has nil URL, ignoring");
+        return;
+      };
 
-      let uri = url.absoluteString().unwrap().to_string();
+      let Some(absolute_uri) = url.absoluteString() else {
+        #[cfg(feature = "tracing")]
+        tracing::warn!("custom scheme URL has nil absoluteString, ignoring");
+        return;
+      };
+      let uri = absolute_uri.to_string();
 
       #[cfg(feature = "tracing")]
       span.record("uri", uri.clone());
 
       // Get request method (GET, POST, PUT etc...)
-      let method = request.HTTPMethod().unwrap().to_string();
+      let method = match request.HTTPMethod() {
+        Some(m) => m.to_string(),
+        None => {
+          #[cfg(feature = "tracing")]
+          tracing::warn!(
+            "custom scheme request for {} has nil HTTPMethod, defaulting to GET",
+            uri
+          );
+          "GET".to_string()
+        }
+      };
 
       // Prepare our HttpRequest
       let mut http_request = Request::builder().uri(uri).method(method.as_str());
@@ -127,9 +149,12 @@ extern "C" fn start_task(
       // get all our headers values and inject them in our request
       if let Some(all_headers) = all_headers {
         for current_header in all_headers.allKeys().iter() {
-          let header_value = all_headers.valueForKey(&current_header).unwrap();
-          // inject the header into the request
-          http_request = http_request.header(current_header.to_string(), header_value.to_string());
+          // Skip headers whose value is nil rather than aborting the task.
+          if let Some(header_value) = all_headers.valueForKey(&current_header) {
+            // inject the header into the request
+            http_request =
+              http_request.header(current_header.to_string(), header_value.to_string());
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

`url_scheme_handler::start_task` unwraps four values that WebKit may legitimately return as nil:

- `request.URL()` (L91)
- `url.absoluteString()` (L93)
- `request.HTTPMethod()` (L99)
- `all_headers.valueForKey(&current_header)` (L130)

When any of these is nil, the unwrap aborts inside an Objective-C callback invoked across the FFI boundary, producing a `SIGABRT` with no recovery path. In our downstream Tauri app, opening a graph view reliably triggered this — WebKit was synthesizing a custom-scheme request without a URL on the navigation path, and the unwrap turned an Option into a process abort.

## Change

Each of the four `unwrap()`s becomes a defensive branch:

- **Nil `URL` / `absoluteString`**: emit a `tracing::warn!` (gated on the `tracing` feature) and `return` from the task handler, dropping the malformed request rather than crashing the process.
- **Nil `HTTPMethod`**: warn and fall back to `"GET"`, which matches `NSURLRequest`'s default.
- **Nil header value**: skip that header inside the loop instead of aborting the whole request.

A short comment near the URL handling explains the rationale.

## Behavior

For well-formed requests (the common case), behavior is unchanged. For malformed requests, the task either completes with a degraded method/header set or terminates early, instead of aborting the process.

## Test plan

- [x] `cargo check` clean on `dev` profile (macOS arm64) on this branch.
- [x] `cargo fmt` applied.
- [x] Verified downstream (Tauri 2.11 + Wry 0.55.1 patched with this change) that the SIGABRT on graph-view open no longer occurs; the same flow on unpatched Wry 0.55.1 reliably reproduces the crash.

I'm happy to add a unit test if there's an established pattern for mocking a `WKURLSchemeTask` with nil values, but I didn't find one in the existing `src/wkwebview/` tests.