### PR TITLE
fix(linux): position gtk::Fixed child webviews via move_ (honor set_bounds)

### DIFF
--- a/.changes/fix-linux-gtk-fixed-webview-position.md
+++ b/.changes/fix-linux-gtk-fixed-webview-position.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On Linux, fix positioned child webviews in a `gtk::Fixed` losing their position after a layout pass. `WebView::set_bounds` now positions the webview via `gtk::Fixed::move_` (plus `set_size_request`) rather than a bare `size_allocate`, which the `gtk::Fixed` resets to the child's stored put-coordinate on the next size-allocate. This makes positioned multi-webview layouts created with `WebViewBuilderExtUnix::new_gtk` / `build_gtk` over a `gtk::Fixed` hold their bounds across resizes.

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -866,6 +866,20 @@ impl InnerWebView {
     }
 
     if self.is_in_fixed_parent {
+      // Position the webview via its parent `gtk::Fixed`'s `move_` (which persists
+      // across layout passes) and `set_size_request`, in addition to the
+      // immediate `size_allocate`. A bare `size_allocate` only sets a transient
+      // allocation that the `gtk::Fixed` resets to the child's stored
+      // put-coordinate on the next size-allocate, so the requested position was
+      // dropped on the first relayout.
+      if let Some(fixed) = self
+        .webview
+        .parent()
+        .and_then(|p| p.downcast::<gtk::Fixed>().ok())
+      {
+        fixed.move_(&self.webview, x, y);
+      }
+      self.webview.set_size_request(width, height);
       self
         .webview
         .size_allocate(&gtk::Allocation::new(x, y, width, height));


### PR DESCRIPTION
## What

On Linux, `WebView::set_bounds` positions a `gtk::Fixed`-parented webview with a bare `size_allocate`. That allocation is transient — `GtkFixed` re-allocates each child to its stored put-coordinate on the next size-allocate, so the requested position is dropped on the first relayout (the webview snaps back to where it was first placed). The size is also not retained as a request.

This positions the child via its parent `gtk::Fixed`'s `move_` and `set_size_request` (which persist across layout passes), keeping the immediate `size_allocate`:

```rust
if self.is_in_fixed_parent {
  if let Some(fixed) = self.webview.parent().and_then(|p| p.downcast::<gtk::Fixed>().ok()) {
    fixed.move_(&self.webview, x, y);
  }
  self.webview.set_size_request(width, height);
  self.webview.size_allocate(&gtk::Allocation::new(x, y, width, height));
}
```

## Why

This is the documented X11 + Wayland multi-webview path — `WebViewBuilderExtUnix::new_gtk` / `build_gtk` over a `gtk::Fixed` (see the `gtk_multiwebview` example). Today, `set_bounds` calls after the initial layout don't hold: positioned webviews drift back to their original spot on resize/relayout.

Context: this is the wry-side half of [tauri-apps/tauri#10420](https://github.com/tauri-apps/tauri/issues/10420) (multi-webview child positioning broken on Linux/GTK). The other half is Tauri packing child webviews into a `gtk::Fixed` rather than the window's vertical `gtk::Box` (proposed in that thread). With a `gtk::Fixed` parent + this change, `set_bounds` from app code positions children correctly and the position survives relayouts.

## Testing

Applied on top of `wry 0.55.1` and run in a Tauri v2 app on WSLg (Ubuntu 22.04, WebKitGTK 2.50.4), with content webviews hosted in a `gtk::Fixed`: webviews now hold their bounds across tab-switch, multi-tab, drawer-resize, and window-resize. Without `move_`, the position was dropped after the first relayout (reproduced and verified).

## Notes

Related (not in this PR): on this path `WebView::bounds()` doesn't report the child's position (returns `(0, 0)`), so a read-modify-write of bounds (e.g. `set_size` after `set_position`) can clobber the position. Happy to follow up separately.

A `.changes` entry is included (`wry: patch`).
