### PR TITLE
feat: add back/forward navigation APIs (fix #1735)

### DIFF
--- a/.changes/change-pr-1748.md
+++ b/.changes/change-pr-1748.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+Add back/forward navigation APIs (`go_back`, `go_forward`, `can_go_back`, and `can_go_forward`) to `WebView`.

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -452,6 +452,26 @@ impl<'a> MainPipe<'a> {
           reload(&mut self.env, webview.as_obj())?;
         }
       }
+      WebViewMessage::GoForward => {
+        if let Some(webview) = get_webview(activity_id) {
+          go_forward(&mut self.env, webview.as_obj())?;
+        }
+      }
+      WebViewMessage::GoBack => {
+        if let Some(webview) = get_webview(activity_id) {
+          go_back(&mut self.env, webview.as_obj())?;
+        }
+      }
+      WebViewMessage::CanGoForward(tx) => {
+        if let Some(webview) = get_webview(activity_id) {
+          tx.send(can_go_forward(&mut self.env, webview.as_obj())?)?;
+        }
+      }
+      WebViewMessage::CanGoBack(tx) => {
+        if let Some(webview) = get_webview(activity_id) {
+          tx.send(can_go_back(&mut self.env, webview.as_obj())?)?;
+        }
+      }
       WebViewMessage::GetCookies(tx, url) => {
         if let Some(webview) = get_webview(activity_id) {
           let url = self.env.new_string(url)?;
@@ -549,6 +569,24 @@ fn reload<'a>(env: &mut JNIEnv<'a>, webview: &JObject<'a>) -> JniResult<()> {
   Ok(())
 }
 
+fn go_forward<'a>(env: &mut JNIEnv<'a>, webview: &JObject<'a>) -> JniResult<()> {
+  env.call_method(webview, "goForward", "()V", &[])?;
+  Ok(())
+}
+
+fn go_back<'a>(env: &mut JNIEnv<'a>, webview: &JObject<'a>) -> JniResult<()> {
+  env.call_method(webview, "goBack", "()V", &[])?;
+  Ok(())
+}
+
+fn can_go_forward<'a>(env: &mut JNIEnv<'a>, webview: &JObject<'a>) -> JniResult<bool> {
+  Ok(env.call_method(webview, "canGoForward", "()Z", &[])?.z()?)
+}
+
+fn can_go_back<'a>(env: &mut JNIEnv<'a>, webview: &JObject<'a>) -> JniResult<bool> {
+  Ok(env.call_method(webview, "canGoBack", "()Z", &[])?.z()?)
+}
+
 fn set_background_color<'a>(
   env: &mut JNIEnv<'a>,
   webview: &JObject<'a>,
@@ -570,6 +608,10 @@ pub(crate) enum WebViewMessage {
   LoadUrl(String, Option<http::HeaderMap>),
   LoadHtml(String),
   Reload,
+  GoForward,
+  GoBack,
+  CanGoForward(Sender<bool>),
+  CanGoBack(Sender<bool>),
   ClearAllBrowsingData,
   OnDestroy {
     activity_id: ActivityId,

--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -464,12 +464,14 @@ impl<'a> MainPipe<'a> {
       }
       WebViewMessage::CanGoForward(tx) => {
         if let Some(webview) = get_webview(activity_id) {
-          tx.send(can_go_forward(&mut self.env, webview.as_obj())?)?;
+          tx.send(can_go_forward(&mut self.env, webview.as_obj())?)
+            .unwrap();
         }
       }
       WebViewMessage::CanGoBack(tx) => {
         if let Some(webview) = get_webview(activity_id) {
-          tx.send(can_go_back(&mut self.env, webview.as_obj())?)?;
+          tx.send(can_go_back(&mut self.env, webview.as_obj())?)
+            .unwrap();
         }
       }
       WebViewMessage::GetCookies(tx, url) => {

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -416,6 +416,28 @@ impl InnerWebView {
     Ok(())
   }
 
+  pub fn go_forward(&self) -> Result<()> {
+    MainPipe::send(self.activity_id, WebViewMessage::GoForward);
+    Ok(())
+  }
+
+  pub fn go_back(&self) -> Result<()> {
+    MainPipe::send(self.activity_id, WebViewMessage::GoBack);
+    Ok(())
+  }
+
+  pub fn can_go_forward(&self) -> Result<bool> {
+    let (tx, rx) = bounded(1);
+    MainPipe::send(self.activity_id, WebViewMessage::CanGoForward(tx));
+    rx.recv_timeout(MAIN_PIPE_TIMEOUT).map_err(Into::into)
+  }
+
+  pub fn can_go_back(&self) -> Result<bool> {
+    let (tx, rx) = bounded(1);
+    MainPipe::send(self.activity_id, WebViewMessage::CanGoBack(tx));
+    rx.recv_timeout(MAIN_PIPE_TIMEOUT).map_err(Into::into)
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     MainPipe::send(self.activity_id, WebViewMessage::ClearAllBrowsingData);
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2136,6 +2136,24 @@ impl WebView {
     self.webview.reload()
   }
 
+  /// Go to the next page.
+  pub fn go_forward(&self) -> Result<()> {
+    self.webview.go_forward()
+  }
+
+  /// Go to the previous page.
+  pub fn go_back(&self) -> Result<()> {
+    self.webview.go_back()
+  }
+
+  pub fn can_go_forward(&self) -> Result<bool> {
+    self.webview.can_go_forward()
+  }
+
+  pub fn can_go_back(&self) -> Result<bool> {
+    self.webview.can_go_back()
+  }
+
   /// Navigate to the specified url using the specified headers
   pub fn load_url_with_headers(&self, url: &str, headers: http::HeaderMap) -> Result<()> {
     self.webview.load_url_with_headers(url, headers)

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -806,6 +806,24 @@ impl InnerWebView {
     Ok(())
   }
 
+  pub fn go_forward(&self) -> Result<()> {
+    self.webview.go_forward();
+    Ok(())
+  }
+
+  pub fn go_back(&self) -> Result<()> {
+    self.webview.go_back();
+    Ok(())
+  }
+
+  pub fn can_go_forward(&self) -> Result<bool> {
+    Ok(self.webview.can_go_forward())
+  }
+
+  pub fn can_go_back(&self) -> Result<bool> {
+    Ok(self.webview.can_go_back())
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     if let Some(context) = self.webview.context() {
       if let Some(data_manger) = context.website_data_manager() {

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -1428,6 +1428,26 @@ impl InnerWebView {
     unsafe { self.webview.Reload() }.map_err(Into::into)
   }
 
+  pub fn go_forward(&self) -> Result<()> {
+    unsafe { self.webview.GoForward() }.map_err(Into::into)
+  }
+
+  pub fn go_back(&self) -> Result<()> {
+    unsafe { self.webview.GoBack() }.map_err(Into::into)
+  }
+
+  pub fn can_go_forward(&self) -> Result<bool> {
+    let mut can_go_forward = FALSE;
+    unsafe { self.webview.CanGoForward(&mut can_go_forward) }.map_err(Into::<Error>::into)?;
+    Ok(can_go_forward.into())
+  }
+
+  pub fn can_go_back(&self) -> Result<bool> {
+    let mut can_go_back = FALSE;
+    unsafe { self.webview.CanGoBack(&mut can_go_back) }.map_err(Into::<Error>::into)?;
+    Ok(can_go_back.into())
+  }
+
   pub fn bounds(&self) -> Result<Rect> {
     let mut bounds = Rect::default();
     let mut rect = RECT::default();

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -808,6 +808,24 @@ r#"Object.defineProperty(window, 'ipc', {
     Ok(())
   }
 
+  pub fn go_forward(&self) -> Result<()> {
+    unsafe { self.webview.goForward() };
+    Ok(())
+  }
+
+  pub fn go_back(&self) -> Result<()> {
+    unsafe { self.webview.goBack() };
+    Ok(())
+  }
+
+  pub fn can_go_forward(&self) -> Result<bool> {
+    Ok(unsafe { self.webview.canGoForward() })
+  }
+
+  pub fn can_go_back(&self) -> Result<bool> {
+    Ok(unsafe { self.webview.canGoBack() })
+  }
+
   pub fn clear_all_browsing_data(&self) -> Result<()> {
     unsafe {
       let config = self.webview.configuration();


### PR DESCRIPTION
## Summary

This PR adds back/forward navigation APIs and navigation state queries, as requested in #1735.

The following APIs were added:

 - `go_back()`
 - `go_forward()`
 - `can_go_back() -> bool`
 - `can_go_forward() -> bool`
 
 ## Implementation
 
 - Windows (WebView2) `GoBack / GoForward / CanGoBack / CanGoForward`
 - macOS / iOS (WKWebView) `goBack / goForward / canGoBack / canGoForward`
 - Linux (WebKitGTK) `go_back / go_forward / can_go_back / can_go_forward`
 - Android `goBack / goForward / canGoBack / canGoForward` through JNI
 
 Fixes #1735 