### PR TITLE
fix(macos): avoid panics on missing URL (fix #1752)

### DIFF
--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1346,8 +1346,9 @@ r#"Object.defineProperty(window, 'ipc', {
 }
 
 pub fn url_from_webview(webview: &WKWebView) -> Result<String> {
-  let url_obj = unsafe { webview.URL().unwrap() };
-  let absolute_url = url_obj.absoluteString().unwrap();
+  let absolute_url = unsafe { webview.URL() }
+    .and_then(|u| u.absoluteString())
+    .unwrap_or_default();
 
   let bytes = {
     let bytes: *const c_char = absolute_url.UTF8String();

--- a/src/wkwebview/navigation.rs
+++ b/src/wkwebview/navigation.rs
@@ -63,7 +63,10 @@ pub(crate) fn navigation_policy(
       false
     };
     let request = action.request();
-    let url = request.URL().unwrap().absoluteString().unwrap();
+    let url = request
+      .URL()
+      .and_then(|u| u.absoluteString())
+      .map(|s| s.to_string());
 
     if should_download {
       let has_download_handler = this.ivars().has_download_handler;
@@ -74,7 +77,7 @@ pub(crate) fn navigation_policy(
       }
     } else {
       let function = &this.ivars().navigation_policy_function;
-      match function(url.to_string()) {
+      match url.is_some_and(function) {
         true => (*handler).call((WKNavigationActionPolicy::Allow,)),
         false => (*handler).call((WKNavigationActionPolicy::Cancel,)),
       };


### PR DESCRIPTION
## Summary
This PR removes `unwrap` calls in two code paths, as requested in #1752.

## Affected code paths
- `src/wkwebview/mod.rs`, `url_from_webview()`
- `src/wkwebview/navigation.rs`, `navigation_policy()`

## Changes
- `url_from_webview()` now returns `Ok("")` when URL is unavailable, which is consistent with other platforms
- Navigation will be canceled instead of panicking, when URL is unavailable in `navigation_policy()`

Fixes #1752