### PR TITLE
feat(windows): add DirectComposition (visual) hosting for WebView2

### DIFF
--- a/.changes/webview2-composition-hosting.md
+++ b/.changes/webview2-composition-hosting.md
@@ -1,0 +1,5 @@
+---
+"wry": minor
+---
+
+On Windows, add DirectComposition (visual) hosting for WebView2: `WebViewBuilderExtWindows::with_composition_visual_target` creates the webview through `CreateCoreWebView2CompositionController` targeting a caller-supplied `IDCompositionVisual`, with host-window input forwarding (mouse, touch/pen, cursor, focus, bounds). `register_composition_visual_target` provides the same for embedders that construct the builder internally.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,8 @@ features = [
   "Win32_UI_HiDpi",
   "Win32_UI_Input",
   "Win32_UI_Input_KeyboardAndMouse",
+  # touch/pen forwarding for composition hosting (src/webview2/composition.rs)
+  "Win32_UI_Input_Pointer",
 ]
 
 [target.'cfg(target_vendor = "apple")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,8 @@ pub use wkwebview::{PrintMargin, PrintOptions, WryWebView};
 #[cfg(target_os = "windows")]
 pub(crate) mod webview2;
 #[cfg(target_os = "windows")]
+pub use self::webview2::register_composition_visual_target;
+#[cfg(target_os = "windows")]
 pub use self::webview2::ScrollBarStyle;
 #[cfg(target_os = "windows")]
 use self::webview2::*;
@@ -1749,6 +1751,11 @@ pub(crate) struct PlatformSpecificWebViewAttributes {
   default_context_menus: bool,
   environment: Option<ICoreWebView2Environment>,
   profile_name: Option<String>,
+  /// When set, the webview is created through
+  /// `CreateCoreWebView2CompositionController` targeting this
+  /// `IDCompositionVisual` (passed as `IUnknown`) instead of the windowed
+  /// controller path.
+  composition_visual_target: Option<windows::core::IUnknown>,
 }
 
 #[cfg(windows)]
@@ -1765,6 +1772,7 @@ impl Default for PlatformSpecificWebViewAttributes {
       extension_path: None,
       environment: None,
       profile_name: None,
+      composition_visual_target: None,
     }
   }
 }
@@ -1862,6 +1870,32 @@ pub trait WebViewBuilderExtWindows {
   /// Profile names must follow the WebView2 naming rules (alphanumeric, `.`,
   /// `_`, `-`, ` `, up to 64 chars, not starting/ending with `.` or ` `).
   fn with_profile_name<S: Into<String>>(self, name: S) -> Self;
+
+  /// Host the webview on a caller-supplied DirectComposition visual instead of
+  /// a child HWND.
+  ///
+  /// `visual` must be an `IDCompositionVisual` (any version), passed as
+  /// `IUnknown`. The webview is created through
+  /// `CreateCoreWebView2CompositionController` with the window passed to
+  /// [`WebViewBuilder::build`] as the input/parent HWND; that window receives
+  /// a subclass that forwards mouse and touch/pen input to the webview
+  /// (`SendMouseInput`/`SendPointerInput`), applies the webview cursor on
+  /// `WM_SETCURSOR`, and keeps controller bounds in sync on `WM_SIZE`.
+  /// Keyboard and IME input reach the webview natively once it takes focus
+  /// (on click, or via `MoveFocus`).
+  ///
+  /// In this mode the webview has no HWND of its own: [`WebView::set_bounds`]
+  /// only updates the controller bounds, [`WebView::set_visible`] only toggles
+  /// controller visibility, and [`WebView::reparent`] returns an error. The
+  /// visual's position and size in the host window are controlled entirely by
+  /// the caller's DirectComposition tree.
+  ///
+  /// Combine with [`WebViewBuilder::with_transparent`] for a webview that
+  /// composites over content drawn on sibling visuals below it.
+  ///
+  /// For embedders that construct the `WebViewBuilder` internally (so this
+  /// method cannot be called), see [`register_composition_visual_target`].
+  fn with_composition_visual_target(self, visual: windows::core::IUnknown) -> Self;
 }
 
 #[cfg(windows)]
@@ -1913,6 +1947,14 @@ impl WebViewBuilderExtWindows for WebViewBuilder<'_> {
 
   fn with_profile_name<S: Into<String>>(mut self, name: S) -> Self {
     self.platform_specific.profile_name = Some(name.into());
+    self
+  }
+
+  fn with_composition_visual_target(mut self, visual: windows::core::IUnknown) -> Self {
+    self
+      .platform_specific
+      .composition_visual_target
+      .replace(visual);
     self
   }
 }

--- a/src/webview2/composition.rs
+++ b/src/webview2/composition.rs
@@ -1,0 +1,603 @@
+// Copyright 2020-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! DirectComposition (visual) hosting for WebView2.
+//!
+//! Creates the webview through `CreateCoreWebView2CompositionController`
+//! targeting a caller-supplied `IDCompositionVisual` and forwards host-window
+//! input to it. In this mode WebView2 draws nothing to any HWND: its output
+//! goes to the visual, and the host window (which owns the Win32 input queue)
+//! must hand-deliver mouse/pointer events and cursor updates. Keyboard input
+//! needs no forwarding — once `MoveFocus` is called, WebView2's hidden input
+//! window takes Win32 focus and receives keys and IME natively.
+
+use std::{
+  cell::{Cell, RefCell},
+  collections::HashMap,
+  sync::mpsc,
+};
+
+use webview2_com::{
+  CreateCoreWebView2CompositionControllerCompletedHandler, CursorChangedEventHandler,
+  Microsoft::Web::WebView2::Win32::*,
+};
+use windows::{
+  core::{IUnknown, Interface, HSTRING, PCWSTR},
+  Win32::{
+    Foundation::{E_POINTER, E_UNEXPECTED, HWND, LPARAM, LRESULT, RECT, WPARAM},
+    Graphics::Gdi::ScreenToClient,
+    UI::{
+      Input::{
+        KeyboardAndMouse::{
+          ReleaseCapture, SetCapture, TrackMouseEvent, TME_LEAVE, TRACKMOUSEEVENT,
+        },
+        Pointer::{GetPointerPenInfo, GetPointerTouchInfo, GetPointerType, POINTER_INFO},
+      },
+      Shell::{DefSubclassProc, RemoveWindowSubclass, SetWindowSubclass},
+      WindowsAndMessaging::{
+        GetClientRect, LoadCursorW, SendMessageW, SetCursor, HCURSOR, HTCLIENT, IDC_ARROW,
+        POINTER_INPUT_TYPE, PT_PEN, PT_TOUCH, SIZE_MINIMIZED, WM_DESTROY, WM_ENTERSIZEMOVE,
+        WM_LBUTTONDBLCLK, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN,
+        WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_MOVE, WM_MOVING,
+        WM_POINTERDOWN, WM_POINTERUP, WM_POINTERUPDATE, WM_RBUTTONDBLCLK, WM_RBUTTONDOWN,
+        WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS, WM_SIZE, WM_USER, WM_XBUTTONDBLCLK,
+        WM_XBUTTONDOWN, WM_XBUTTONUP,
+      },
+    },
+  },
+};
+
+use crate::{Error, Result};
+
+// Distinct from wry's PARENT_SUBCLASS_ID (WM_USER + 0x64), PARENT_DESTROY_MESSAGE
+// (+ 0x65) and MAIN_THREAD_DISPATCHER_SUBCLASS_ID (+ 0x66) so both subclass
+// families can coexist on one HWND without colliding.
+const COMPOSITION_SUBCLASS_ID: u32 = WM_USER + 0x67;
+const COMPOSITION_DESTROY_MESSAGE: u32 = WM_USER + 0x68;
+
+// windows-rs files WM_MOUSELEAVE under `Win32_UI_Controls`; defined locally to
+// avoid pulling a whole feature for one message constant.
+const WM_MOUSELEAVE: u32 = 0x02A3;
+
+thread_local! {
+  /// Composition-visual targets registered per host HWND, for webviews built
+  /// by an embedding layer (e.g. tauri-runtime-wry) that constructs the
+  /// `WebViewBuilder` internally and offers no way to call
+  /// [`with_composition_visual_target`](crate::WebViewBuilderExtWindows::with_composition_visual_target)
+  /// on it. The host registers the visual for its HWND *before* asking the
+  /// embedder to create the webview; webview creation consumes it (once) when
+  /// no builder-supplied target is set. Main-thread only by construction —
+  /// registration and webview creation both happen on the UI thread, which is
+  /// also the COM STA the visual lives in.
+  static PENDING_VISUAL_TARGETS: RefCell<HashMap<isize, IUnknown>> =
+    RefCell::new(HashMap::new());
+}
+
+/// Registers `visual` (an `IDCompositionVisual`, passed as `IUnknown`) as the
+/// composition target for the next webview created on the host window `hwnd`.
+///
+/// This is the out-of-band counterpart of
+/// [`WebViewBuilderExtWindows::with_composition_visual_target`](crate::WebViewBuilderExtWindows::with_composition_visual_target),
+/// for callers that do not construct the `WebViewBuilder` themselves (for
+/// example applications embedding through `tauri-runtime-wry`, which builds
+/// the webview internally). The entry is keyed by HWND so concurrent window
+/// creations cannot cross-wire, and is consumed (removed) by the first webview
+/// created on that window; registering again replaces any pending entry for
+/// the same HWND. A builder-supplied target always takes precedence.
+///
+/// Must be called from the UI thread, before the webview is built. An entry
+/// that is never consumed holds one COM reference to the visual until the
+/// thread exits.
+pub fn register_composition_visual_target(hwnd: isize, visual: IUnknown) {
+  PENDING_VISUAL_TARGETS.with(|targets| {
+    targets.borrow_mut().insert(hwnd, visual);
+  });
+}
+
+/// Takes (and removes) the visual registered for `hwnd`, if any.
+pub(crate) fn take_registered_visual_target(hwnd: isize) -> Option<IUnknown> {
+  PENDING_VISUAL_TARGETS.with(|targets| targets.borrow_mut().remove(&hwnd))
+}
+
+/// Per-host state carried through the subclass `dwrefdata`. Boxed at attach,
+/// freed on `WM_DESTROY`/[`COMPOSITION_DESTROY_MESSAGE`] with the same
+/// null-out-refdata double-free guard the parent subclass uses.
+struct CompositionHost {
+  controller: ICoreWebView2Controller,
+  comp_controller: ICoreWebView2CompositionController,
+  /// `ICoreWebView2Environment3` when available — required to build
+  /// `ICoreWebView2PointerInfo` for touch/pen forwarding. `None` disables
+  /// pointer forwarding only; mouse forwarding never depends on it.
+  env3: Option<ICoreWebView2Environment3>,
+  /// Cursor last requested by the webview (`CursorChanged`), applied on
+  /// `WM_SETCURSOR` while the hit test is `HTCLIENT`.
+  cursor: Cell<HCURSOR>,
+  /// Whether a `TrackMouseEvent(TME_LEAVE)` request is outstanding, so
+  /// `WM_MOUSELEAVE` is delivered exactly once per hover session.
+  mouse_tracking: Cell<bool>,
+  cursor_changed_token: i64,
+}
+
+/// Creates a WebView2 composition controller parented (for input/ownership
+/// purposes) to `hwnd`, sets `visual` as its root visual target, and returns
+/// the object's `ICoreWebView2Controller` interface for the shared init path.
+///
+/// Mirrors `InnerWebView::create_controller`: the environment-10 options path
+/// carries incognito + profile name + default background color; otherwise the
+/// plain environment-3 creation is used (composition hosting does not exist
+/// below environment 3) and the background color is applied post-creation.
+pub fn create_composition_controller(
+  hwnd: HWND,
+  env: &ICoreWebView2Environment,
+  incognito: bool,
+  background_color: Option<(u8, u8, u8, u8)>,
+  profile_name: Option<&str>,
+  visual: &IUnknown,
+) -> Result<ICoreWebView2Controller> {
+  let (tx, rx) = mpsc::channel::<std::result::Result<ICoreWebView2CompositionController, Error>>();
+
+  let handler = CreateCoreWebView2CompositionControllerCompletedHandler::create(Box::new(
+    move |error_code, controller| {
+      let result = (|| {
+        error_code?;
+        controller.ok_or_else(|| windows::core::Error::from(E_POINTER).into())
+      })();
+      tx.send(result)
+        .map_err(|_| windows::core::Error::from(E_UNEXPECTED))
+    },
+  ));
+
+  unsafe {
+    if let Ok(env10) = env.cast::<ICoreWebView2Environment10>() {
+      let controller_opts = env10.CreateCoreWebView2ControllerOptions()?;
+
+      if let Some((r, g, b, mut a)) = background_color {
+        if let Ok(opts3) = controller_opts.cast::<ICoreWebView2ControllerOptions3>() {
+          if a != 0 {
+            a = 255;
+          }
+          opts3.SetDefaultBackgroundColor(COREWEBVIEW2_COLOR {
+            R: r,
+            G: g,
+            B: b,
+            A: a,
+          })?;
+        }
+      }
+
+      controller_opts.SetIsInPrivateModeEnabled(incognito)?;
+
+      if let Some(name) = profile_name {
+        controller_opts.SetProfileName(&HSTRING::from(name))?;
+      }
+
+      env10.CreateCoreWebView2CompositionControllerWithOptions(hwnd, &controller_opts, &handler)?;
+    } else {
+      let env3 = env
+        .cast::<ICoreWebView2Environment3>()
+        .map_err(windows::core::Error::from)?;
+      env3.CreateCoreWebView2CompositionController(hwnd, &handler)?;
+    }
+  }
+
+  let comp_controller: ICoreWebView2CompositionController = webview2_com::wait_with_pump(rx)??;
+
+  let controller: ICoreWebView2Controller =
+    comp_controller.cast().map_err(windows::core::Error::from)?;
+
+  unsafe {
+    comp_controller.SetRootVisualTarget(visual)?;
+
+    // The env-3 fallback path had no options object to carry the background
+    // color; apply it through the controller like the windowed late path does.
+    if let Some(color) = background_color {
+      if env.cast::<ICoreWebView2Environment10>().is_err() {
+        super::set_background_color(&controller, color)?;
+      }
+    }
+  }
+
+  Ok(controller)
+}
+
+/// Subclasses the host window to (a) keep controller bounds synced to the
+/// client area, (b) forward mouse and touch/pen input to the composition
+/// controller, and (c) apply the webview's cursor. The counterpart of
+/// `InnerWebView::attach_parent_subclass` for composition mode.
+pub unsafe fn attach_host_subclass(
+  parent: HWND,
+  controller: &ICoreWebView2Controller,
+) -> Result<()> {
+  let comp_controller: ICoreWebView2CompositionController =
+    controller.cast().map_err(windows::core::Error::from)?;
+
+  // Environment 3 is available by construction (the composition controller
+  // could not have been created without it); fetch it back through the
+  // webview's environment for pointer-info creation. A failure here only
+  // disables touch/pen forwarding.
+  let env3: Option<ICoreWebView2Environment3> = controller
+    .CoreWebView2()
+    .ok()
+    .and_then(|webview| webview.cast::<ICoreWebView2_2>().ok())
+    .and_then(|webview2| webview2.Environment().ok())
+    .and_then(|env| env.cast::<ICoreWebView2Environment3>().ok());
+
+  let default_cursor = LoadCursorW(None, IDC_ARROW).unwrap_or_default();
+
+  let host = Box::new(CompositionHost {
+    controller: controller.clone(),
+    comp_controller: comp_controller.clone(),
+    env3,
+    cursor: Cell::new(default_cursor),
+    mouse_tracking: Cell::new(false),
+    cursor_changed_token: 0,
+  });
+  let host_ptr = Box::into_raw(host);
+
+  // The webview pushes cursor changes (I-beam over text, pointer over links…);
+  // remember the cursor for WM_SETCURSOR and apply it immediately, since the
+  // mouse is over the webview when the change fires.
+  let mut token = 0i64;
+  let register = comp_controller.add_CursorChanged(
+    &CursorChangedEventHandler::create(Box::new(move |sender, _args| {
+      if let Some(sender) = sender {
+        if let Some(cursor) = resolve_cursor(&sender) {
+          // SAFETY: the host box outlives the registration — the destroy path
+          // removes this handler before freeing the box, on the same thread.
+          unsafe { (*host_ptr).cursor.set(cursor) };
+          let _ = unsafe { SetCursor(Some(cursor)) };
+        }
+      }
+      Ok(())
+    })),
+    &mut token,
+  );
+  if let Err(e) = register {
+    drop(Box::from_raw(host_ptr));
+    return Err(windows::core::Error::from(e).into());
+  }
+  (*host_ptr).cursor_changed_token = token;
+
+  let result = SetWindowSubclass(
+    parent,
+    Some(host_subclass_proc),
+    COMPOSITION_SUBCLASS_ID as usize,
+    host_ptr as usize,
+  );
+  if !result.as_bool() {
+    let _ = comp_controller.remove_CursorChanged(token);
+    drop(Box::from_raw(host_ptr));
+    return Err(Error::WebView2Error(webview2_com::Error::WindowsError(
+      windows::core::Error::from(E_UNEXPECTED),
+    )));
+  }
+
+  Ok(())
+}
+
+/// The cursor to apply for the webview's current state.
+///
+/// The `Cursor` property hands back an `HCURSOR` the WebView2 runtime
+/// rasterised at the system's base DPI; on a display-scaled monitor Windows
+/// stretches that bitmap and every cursor sourced from it reads fuzzy.
+/// `SystemCursorId` names the same cursor as its `IDC_*` resource id instead,
+/// so `LoadCursorW` yields the OS **shared** cursor, which the system renders
+/// crisply at the monitor's DPI. Only a custom CSS cursor — which has no
+/// system id (the property reports 0) — falls back to the runtime's bitmap
+/// handle.
+fn resolve_cursor(sender: &ICoreWebView2CompositionController) -> Option<HCURSOR> {
+  let mut id = 0u32;
+  if unsafe { sender.SystemCursorId(&mut id) }.is_ok() && id != 0 {
+    if let Ok(cursor) = unsafe { LoadCursorW(None, PCWSTR(id as usize as *const u16)) } {
+      return Some(cursor);
+    }
+  }
+  let mut cursor = HCURSOR::default();
+  unsafe { sender.Cursor(&mut cursor) }.ok().map(|_| cursor)
+}
+
+/// The counterpart of `InnerWebView::dettach_parent_subclass`.
+pub unsafe fn detach_host_subclass(parent: HWND) {
+  SendMessageW(parent, COMPOSITION_DESTROY_MESSAGE, None, None);
+  let _ = RemoveWindowSubclass(
+    parent,
+    Some(host_subclass_proc),
+    COMPOSITION_SUBCLASS_ID as usize,
+  );
+}
+
+unsafe extern "system" fn host_subclass_proc(
+  hwnd: HWND,
+  msg: u32,
+  wparam: WPARAM,
+  lparam: LPARAM,
+  _uidsubclass: usize,
+  dwrefdata: usize,
+) -> LRESULT {
+  let host_ptr = dwrefdata as *mut CompositionHost;
+  if host_ptr.is_null() {
+    return DefSubclassProc(hwnd, msg, wparam, lparam);
+  }
+  let host = &*host_ptr;
+
+  match msg {
+    WM_SIZE => {
+      if wparam.0 != SIZE_MINIMIZED as usize {
+        let mut client_rect = RECT::default();
+        if GetClientRect(hwnd, &mut client_rect).is_ok() {
+          let _ = host.controller.SetBounds(RECT {
+            left: 0,
+            top: 0,
+            right: client_rect.right - client_rect.left,
+            bottom: client_rect.bottom - client_rect.top,
+          });
+        }
+      }
+    }
+
+    WM_SETFOCUS | WM_ENTERSIZEMOVE => {
+      let _ = host
+        .controller
+        .MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
+    }
+
+    msg if msg == WM_MOVE || msg == WM_MOVING => {
+      let _ = host.controller.NotifyParentWindowPositionChanged();
+    }
+
+    WM_SETCURSOR => {
+      // Only own the cursor inside the client area (which the webview covers
+      // in composition mode); non-client hits keep the host's resize arrows.
+      if (lparam.0 & 0xFFFF) as u32 == HTCLIENT {
+        let _ = SetCursor(Some(host.cursor.get()));
+        return LRESULT(1);
+      }
+    }
+
+    WM_MOUSEMOVE | WM_MOUSELEAVE | WM_MOUSEWHEEL | WM_MOUSEHWHEEL | WM_LBUTTONDOWN
+    | WM_LBUTTONUP | WM_LBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP | WM_RBUTTONDBLCLK
+    | WM_MBUTTONDOWN | WM_MBUTTONUP | WM_MBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP
+    | WM_XBUTTONDBLCLK => {
+      forward_mouse_message(host, hwnd, msg, wparam, lparam);
+      // Deliberately fall through to DefSubclassProc: the host's own window
+      // proc still sees the message, so host-side window machinery (its event
+      // stream, drag/resize bookkeeping) keeps working. The webview and the
+      // host both observing input is by design in this hosting model — the
+      // host owns the input queue.
+    }
+
+    WM_POINTERDOWN | WM_POINTERUPDATE | WM_POINTERUP => {
+      forward_pointer_message(host, hwnd, msg, wparam);
+    }
+
+    msg if msg == WM_DESTROY || msg == COMPOSITION_DESTROY_MESSAGE => {
+      if !(dwrefdata as *mut ()).is_null() {
+        let host = Box::from_raw(host_ptr);
+        let _ = host
+          .comp_controller
+          .remove_CursorChanged(host.cursor_changed_token);
+        drop(host);
+
+        // Null out `dwrefdata` so a second destroy cannot double-free (same
+        // guard as the windowed parent subclass).
+        let _ = SetWindowSubclass(
+          hwnd,
+          Some(host_subclass_proc),
+          COMPOSITION_SUBCLASS_ID as usize,
+          std::ptr::null::<()>() as usize,
+        );
+      }
+    }
+
+    _ => (),
+  }
+
+  DefSubclassProc(hwnd, msg, wparam, lparam)
+}
+
+#[inline]
+fn get_x_lparam(lparam: LPARAM) -> i32 {
+  (lparam.0 & 0xFFFF) as u16 as i16 as i32
+}
+
+#[inline]
+fn get_y_lparam(lparam: LPARAM) -> i32 {
+  ((lparam.0 >> 16) & 0xFFFF) as u16 as i16 as i32
+}
+
+/// Translates one `WM_MOUSE*` message into `SendMouseInput`.
+///
+/// `COREWEBVIEW2_MOUSE_EVENT_KIND` values are defined to equal the `WM_*`
+/// message codes, so the message id passes through as the event kind. Wheel
+/// messages carry screen coordinates (translated to client); all others are
+/// already client-relative. Mouse capture is held across button drags so the
+/// webview keeps receiving moves outside the window, and `TME_LEAVE` tracking
+/// generates the `WM_MOUSELEAVE` the webview needs to clear hover state.
+fn forward_mouse_message(
+  host: &CompositionHost,
+  hwnd: HWND,
+  msg: u32,
+  wparam: WPARAM,
+  lparam: LPARAM,
+) {
+  let mut point = windows::Win32::Foundation::POINT {
+    x: get_x_lparam(lparam),
+    y: get_y_lparam(lparam),
+  };
+  let mut mouse_data = 0u32;
+  // LOWORD(wParam) carries the MK_* modifier state for every forwarded mouse
+  // message except WM_MOUSELEAVE (where wParam is unused and stays 0).
+  let mut virtual_keys = (wparam.0 & 0xFFFF) as u32;
+
+  match msg {
+    WM_MOUSEWHEEL | WM_MOUSEHWHEEL => {
+      // HIWORD(wParam): signed wheel delta. Wheel coordinates are screen-based.
+      mouse_data = ((wparam.0 >> 16) & 0xFFFF) as u16 as i16 as i32 as u32;
+      unsafe {
+        let _ = ScreenToClient(hwnd, &mut point);
+      }
+    }
+    WM_XBUTTONDOWN | WM_XBUTTONUP | WM_XBUTTONDBLCLK => {
+      // HIWORD(wParam): which X button (XBUTTON1/XBUTTON2).
+      mouse_data = ((wparam.0 >> 16) & 0xFFFF) as u32;
+    }
+    WM_MOUSELEAVE => {
+      host.mouse_tracking.set(false);
+      point = windows::Win32::Foundation::POINT { x: 0, y: 0 };
+      virtual_keys = 0;
+    }
+    WM_MOUSEMOVE => {
+      if !host.mouse_tracking.get() {
+        let mut tme = TRACKMOUSEEVENT {
+          cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
+          dwFlags: TME_LEAVE,
+          hwndTrack: hwnd,
+          dwHoverTime: 0,
+        };
+        if unsafe { TrackMouseEvent(&mut tme) }.is_ok() {
+          host.mouse_tracking.set(true);
+        }
+      }
+    }
+    _ => {}
+  }
+
+  match msg {
+    WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN | WM_XBUTTONDOWN => unsafe {
+      SetCapture(hwnd);
+      // The host HWND keeps Win32 focus when its client area is clicked, so
+      // hand keyboard/IME focus to the webview's hidden input window here —
+      // this is what makes typing and composition reach the page.
+      let _ = host
+        .controller
+        .MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
+    },
+    WM_LBUTTONUP | WM_RBUTTONUP | WM_MBUTTONUP | WM_XBUTTONUP => unsafe {
+      let _ = ReleaseCapture();
+    },
+    _ => {}
+  }
+
+  let _ = unsafe {
+    host.comp_controller.SendMouseInput(
+      COREWEBVIEW2_MOUSE_EVENT_KIND(msg as i32),
+      COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS(virtual_keys as i32),
+      mouse_data,
+      point,
+    )
+  };
+}
+
+/// Forwards touch/pen `WM_POINTER*` messages through `SendPointerInput`.
+///
+/// Mouse-sourced pointer messages are ignored (the `WM_MOUSE*` path above
+/// already covers the mouse; `EnableMouseInPointer` is never called). The
+/// himetric location/contact fields are left zeroed — WebView2 consumes the
+/// pixel fields for hit-testing.
+fn forward_pointer_message(host: &CompositionHost, hwnd: HWND, msg: u32, wparam: WPARAM) {
+  let Some(env3) = &host.env3 else {
+    return;
+  };
+
+  let pointer_id = (wparam.0 & 0xFFFF) as u32;
+  let mut pointer_type = POINTER_INPUT_TYPE::default();
+  if unsafe { GetPointerType(pointer_id, &mut pointer_type) }.is_err() {
+    return;
+  }
+  if pointer_type != PT_TOUCH && pointer_type != PT_PEN {
+    return;
+  }
+
+  let filled: Result<ICoreWebView2PointerInfo> = (|| {
+    let info =
+      unsafe { env3.CreateCoreWebView2PointerInfo() }.map_err(windows::core::Error::from)?;
+
+    if pointer_type == PT_TOUCH {
+      let mut touch = windows::Win32::UI::Input::Pointer::POINTER_TOUCH_INFO::default();
+      unsafe { GetPointerTouchInfo(pointer_id, &mut touch)? };
+      unsafe {
+        fill_common_pointer_info(&info, hwnd, &touch.pointerInfo)?;
+        info.SetTouchFlags(touch.touchFlags)?;
+        info.SetTouchMask(touch.touchMask)?;
+        info.SetTouchOrientation(touch.orientation)?;
+        info.SetTouchPressure(touch.pressure)?;
+        let mut contact = touch.rcContact;
+        client_rect_from_screen(hwnd, &mut contact);
+        info.SetTouchContact(contact)?;
+      }
+    } else {
+      let mut pen = windows::Win32::UI::Input::Pointer::POINTER_PEN_INFO::default();
+      unsafe { GetPointerPenInfo(pointer_id, &mut pen)? };
+      unsafe {
+        fill_common_pointer_info(&info, hwnd, &pen.pointerInfo)?;
+        info.SetPenFlags(pen.penFlags)?;
+        info.SetPenMask(pen.penMask)?;
+        info.SetPenPressure(pen.pressure)?;
+        info.SetPenRotation(pen.rotation)?;
+        info.SetPenTiltX(pen.tiltX)?;
+        info.SetPenTiltY(pen.tiltY)?;
+      }
+    }
+
+    Ok(info)
+  })();
+
+  if let Ok(info) = filled {
+    let _ = unsafe {
+      host
+        .comp_controller
+        .SendPointerInput(COREWEBVIEW2_POINTER_EVENT_KIND(msg as i32), &info)
+    };
+  }
+}
+
+/// Copies the shared `POINTER_INFO` fields into a `ICoreWebView2PointerInfo`,
+/// translating the screen-based pixel locations into host client coordinates.
+unsafe fn fill_common_pointer_info(
+  info: &ICoreWebView2PointerInfo,
+  hwnd: HWND,
+  src: &POINTER_INFO,
+) -> Result<()> {
+  info.SetPointerKind(src.pointerType.0 as u32)?;
+  info.SetPointerId(src.pointerId)?;
+  info.SetFrameId(src.frameId)?;
+  info.SetPointerFlags(src.pointerFlags.0 as u32)?;
+  info.SetTime(src.dwTime)?;
+  info.SetHistoryCount(src.historyCount)?;
+  info.SetInputData(src.InputData)?;
+  info.SetKeyStates(src.dwKeyStates)?;
+  info.SetPerformanceCount(src.PerformanceCount)?;
+  info.SetButtonChangeKind(src.ButtonChangeType.0)?;
+
+  let mut pixel = src.ptPixelLocation;
+  let _ = ScreenToClient(hwnd, &mut pixel);
+  info.SetPixelLocation(pixel)?;
+  let mut pixel_raw = src.ptPixelLocationRaw;
+  let _ = ScreenToClient(hwnd, &mut pixel_raw);
+  info.SetPixelLocationRaw(pixel_raw)?;
+
+  Ok(())
+}
+
+/// Translates a screen-space RECT into client space in place.
+fn client_rect_from_screen(hwnd: HWND, rect: &mut RECT) {
+  let mut top_left = windows::Win32::Foundation::POINT {
+    x: rect.left,
+    y: rect.top,
+  };
+  let mut bottom_right = windows::Win32::Foundation::POINT {
+    x: rect.right,
+    y: rect.bottom,
+  };
+  unsafe {
+    let _ = ScreenToClient(hwnd, &mut top_left);
+    let _ = ScreenToClient(hwnd, &mut bottom_right);
+  }
+  *rect = RECT {
+    left: top_left.x,
+    top: top_left.y,
+    right: bottom_right.x,
+    bottom: bottom_right.y,
+  };
+}

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+mod composition;
 mod drag_drop;
 mod util;
+
+pub use composition::register_composition_visual_target;
 
 use std::{
   borrow::Cow, cell::RefCell, collections::HashSet, fmt::Write, fs, path::PathBuf, rc::Rc,
@@ -58,6 +61,11 @@ pub(crate) struct InnerWebView {
   parent: RefCell<HWND>,
   hwnd: HWND,
   is_child: bool,
+  /// True when hosted on a DirectComposition visual. `hwnd` is then the *host*
+  /// window (no container child window exists), and input/size plumbing goes
+  /// through `composition::attach_host_subclass` instead of the windowed
+  /// parent subclass.
+  is_composition: bool,
   pub controller: ICoreWebView2Controller,
   pub webview: ICoreWebView2,
   pub env: ICoreWebView2Environment,
@@ -73,7 +81,11 @@ impl Drop for InnerWebView {
     if self.is_child {
       let _ = unsafe { DestroyWindow(self.hwnd) };
     }
-    unsafe { Self::dettach_parent_subclass(*self.parent.borrow()) }
+    if self.is_composition {
+      unsafe { composition::detach_host_subclass(*self.parent.borrow()) }
+    } else {
+      unsafe { Self::dettach_parent_subclass(*self.parent.borrow()) }
+    }
   }
 }
 
@@ -114,7 +126,24 @@ impl InnerWebView {
   ) -> Result<Self> {
     let _ = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
 
-    let hwnd = Self::create_container_hwnd(parent, &attributes, is_child)?;
+    // Composition hosting creates no container child window — the webview
+    // renders on the caller's DirectComposition visual and the *host* window
+    // is used for environment/input purposes. The visual comes from the
+    // builder (`with_composition_visual_target`) or, for webviews built by an
+    // embedding layer that never exposes the wry builder (e.g.
+    // tauri-runtime-wry), from the per-HWND registry
+    // (`register_composition_visual_target`).
+    let composition_visual = pl_attrs
+      .composition_visual_target
+      .clone()
+      .or_else(|| composition::take_registered_visual_target(parent.0 as isize));
+    let is_composition = composition_visual.is_some();
+
+    let hwnd = if is_composition {
+      parent
+    } else {
+      Self::create_container_hwnd(parent, &attributes, is_child)?
+    };
 
     let drop_handler = attributes.drag_drop_handler.take();
     let bounds = attributes.bounds;
@@ -135,13 +164,24 @@ impl InnerWebView {
     } else {
       Self::create_environment(&attributes, pl_attrs.clone())?
     };
-    let controller = Self::create_controller(
-      hwnd,
-      &env,
-      attributes.incognito,
-      background_color,
-      pl_attrs.profile_name.as_deref(),
-    )?;
+    let controller = if let Some(visual) = &composition_visual {
+      composition::create_composition_controller(
+        hwnd,
+        &env,
+        attributes.incognito,
+        background_color,
+        pl_attrs.profile_name.as_deref(),
+        visual,
+      )?
+    } else {
+      Self::create_controller(
+        hwnd,
+        &env,
+        attributes.incognito,
+        background_color,
+        pl_attrs.profile_name.as_deref(),
+      )?
+    };
     let webview = Self::init_webview(
       parent,
       hwnd,
@@ -151,6 +191,7 @@ impl InnerWebView {
       &controller,
       pl_attrs,
       is_child,
+      is_composition,
     )?;
 
     let drag_drop_controller = drop_handler.map(|handler| {
@@ -169,6 +210,7 @@ impl InnerWebView {
       hwnd,
       controller,
       is_child,
+      is_composition,
       webview,
       env,
       drag_drop_controller,
@@ -437,6 +479,7 @@ impl InnerWebView {
     controller: &ICoreWebView2Controller,
     pl_attrs: super::PlatformSpecificWebViewAttributes,
     is_child: bool,
+    is_composition: bool,
   ) -> Result<ICoreWebView2> {
     let webview = unsafe { controller.CoreWebView2()? };
 
@@ -600,7 +643,11 @@ impl InnerWebView {
     }
 
     // Subclass parent for resizing and focus
-    if !is_child {
+    if is_composition {
+      // The composition host subclass owns resize/focus AND forwards
+      // mouse/pointer input + cursor to the visual-hosted webview.
+      unsafe { composition::attach_host_subclass(parent, controller)? };
+    } else if !is_child {
       unsafe { Self::attach_parent_subclass(parent, controller) };
     }
 
@@ -1535,15 +1582,20 @@ impl InnerWebView {
         bottom: size.height,
       })?;
 
-      SetWindowPos(
-        self.hwnd,
-        None,
-        position.x,
-        position.y,
-        size.width,
-        size.height,
-        SWP_ASYNCWINDOWPOS | SWP_NOACTIVATE | SWP_NOZORDER,
-      )?;
+      // In composition mode `self.hwnd` IS the host window — never move or
+      // size it from here; the controller bounds above are the whole job (the
+      // visual is positioned by the caller's DirectComposition tree).
+      if !self.is_composition {
+        SetWindowPos(
+          self.hwnd,
+          None,
+          position.x,
+          position.y,
+          size.width,
+          size.height,
+          SWP_ASYNCWINDOWPOS | SWP_NOACTIVATE | SWP_NOZORDER,
+        )?;
+      }
     }
 
     Ok(())
@@ -1565,13 +1617,17 @@ impl InnerWebView {
 
   pub fn set_visible(&self, visible: bool) -> Result<()> {
     unsafe {
-      let _ = ShowWindow(
-        self.hwnd,
-        match visible {
-          true => SW_SHOW,
-          false => SW_HIDE,
-        },
-      );
+      // Don't show/hide the host window in composition mode; webview
+      // visibility is controller-only there.
+      if !self.is_composition {
+        let _ = ShowWindow(
+          self.hwnd,
+          match visible {
+            true => SW_SHOW,
+            false => SW_HIDE,
+          },
+        );
+      }
 
       self.controller.SetIsVisible(visible)?;
     }
@@ -1778,6 +1834,12 @@ impl InnerWebView {
   }
 
   pub fn reparent(&self, parent: isize) -> Result<()> {
+    // A composition-hosted webview has no child window to reparent; its host
+    // subclass and visual tree are bound to the original window.
+    if self.is_composition {
+      return Err(Error::UnsupportedWindowHandle);
+    }
+
     let parent = HWND(parent as _);
 
     unsafe {


### PR DESCRIPTION
## Motivation

WebView2 supports two hosting models: the windowed controller wry uses today, and a composition controller (`CreateCoreWebView2CompositionController`) that renders into a caller-supplied DirectComposition visual instead of an HWND. Composition hosting is what makes layered DirectComposition apps possible: native content (e.g. a wgpu/D3D swapchain on a sibling visual) drawn *beneath* a transparent webview in the same window, with the webview used as the UI chrome layer. The windowed model cannot express this — a child HWND always occludes everything under it.

This PR adds composition hosting as an opt-in mode. It is used in production by a Windows PDF application (Colophon) that renders documents on a native wgpu surface beneath a transparent Tauri/wry webview UI.

Related: #391 (offscreen rendering) asks for a different but adjacent capability; the composition controller introduced here is also the natural substrate for future texture-stream/offscreen work.

## API

Two entry points, both `#[cfg(windows)]`:

- **`WebViewBuilderExtWindows::with_composition_visual_target(visual: IUnknown)`** — supplies an `IDCompositionVisual` (any version, passed as `IUnknown` so no new `windows`-crate interface features leak into wry's public API). When set, the webview is created through `CreateCoreWebView2CompositionController` with that visual as the root visual target, instead of creating a `WRY_WEBVIEW` child window.

- **`register_composition_visual_target(hwnd: isize, visual: IUnknown)`** (crate-root re-export) — the out-of-band counterpart for embedding layers that construct the `WebViewBuilder` internally and never expose it to the application, most importantly `tauri-runtime-wry`. The host registers the visual for its window *before* asking the embedder to create the webview; webview creation on that HWND consumes the entry (once) when the builder carries no target of its own. The registry is per-HWND (concurrent window creations cannot cross-wire), consume-once, and UI-thread-only by construction (thread-local; registration and creation both happen on the UI thread, which is also the COM STA the visual lives in). A builder-supplied target always takes precedence. This is the piece that lets a Tauri app opt a window into composition hosting today with no tauri-runtime-wry changes; if upstreaming a first-class knob to tauri-runtime-wry later, the builder method is the primitive it would call.

## Behavior in composition mode

- **No container HWND.** `InnerWebView.hwnd` is the host window itself and `is_composition` is set. Guarded on that flag: `set_bounds` only updates controller bounds (never `SetWindowPos` — that would move the host window), `set_visible` only toggles `controller.SetIsVisible` (never `ShowWindow` on the host), `reparent` returns `Error::UnsupportedWindowHandle` (there is no child window to move; the host subclass and visual tree are bound to the original window), and `Drop` detaches the composition subclass instead of the windowed parent subclass.
- **Controller creation** mirrors `create_controller`: the `ICoreWebView2Environment10` options path carries incognito + profile name + default background color; otherwise plain `ICoreWebView2Environment3` creation (composition hosting does not exist below env3) with the background color applied post-creation. `with_transparent(true)` flows through unchanged as `DefaultBackgroundColor` alpha = 0.
- **All existing glue is shared**: initialization scripts, the IPC bridge, custom protocols (including the `{scheme}.localhost` workaround), settings, theme, navigation/download/new-window/permission handlers — `init_webview` is common to both modes; the only branch is which subclass gets attached.

## Host input forwarding

A composition-hosted webview receives no input from Windows — the host window owns the input queue. The new host subclass (subclass id `WM_USER+0x67`, distinct from the existing `+0x64/+0x65/+0x66` so both families can coexist on one HWND) provides:

- **Mouse**: every `WM_MOUSE*` message (move/leave/wheel/hwheel/all buttons including double-clicks and X buttons) is translated to `SendMouseInput` (`COREWEBVIEW2_MOUSE_EVENT_KIND` equals the `WM_*` code by definition). Wheel coordinates are screen-based and translated with `ScreenToClient`. Mouse capture is held across button drags; `TrackMouseEvent(TME_LEAVE)` generates the leave events hover cleanup needs.
- **Keyboard/IME**: deliberately *not* forwarded message-by-message. On mouse button-down (and `WM_SETFOCUS`) the subclass calls `MoveFocus(PROGRAMMATIC)`; WebView2's hidden input HWND then takes real Win32 focus and receives keys and IME natively.
- **Touch/pen**: `WM_POINTERDOWN/UPDATE/UP` for `PT_TOUCH`/`PT_PEN` forwarded via `SendPointerInput` with an `ICoreWebView2PointerInfo` filled from `GetPointerTouchInfo`/`GetPointerPenInfo` (pixel locations and contact rect translated to client coordinates).
- **Cursor**: `CursorChanged` events cache an `HCURSOR`, applied on `WM_SETCURSOR` for `HTCLIENT` hits (non-client hits fall through so frameless-resize arrows keep working). The handle prefers `SystemCursorId` → `LoadCursorW` (the OS shared cursor, crisp at any monitor DPI) over the `Cursor` bitmap property, which the runtime rasterises at base DPI and Windows then stretches blurry on scaled displays; custom CSS cursors (no system id) still use the bitmap handle.
- **Size/move/focus**: `WM_SIZE` → `SetBounds(client rect)`; `WM_MOVE`/`WM_MOVING` → `NotifyParentWindowPositionChanged`; `WM_SETFOCUS`/`WM_ENTERSIZEMOVE` → `MoveFocus` (the same behavior the windowed parent subclass provides).
- **Pass-through**: forwarded messages still reach the host's own window proc (`DefSubclassProc`), so tao's event stream and window machinery observe them unchanged. Both sides seeing input is inherent to this hosting model.

Dependency change: `Win32_UI_Input_Pointer` added to the `windows` crate features (for the `WM_POINTER` APIs). Nothing else.

## What is NOT covered / known limitations

- **Touch/pen is best-effort.** The himetric location/contact fields of `ICoreWebView2PointerInfo` are left zeroed (WebView2 hit-tests on the pixel fields). The mouse path is the one exercised in production.
- **OLE drag-drop (`with_drag_drop_handler`) is untested in composition mode.** It would register on the *host* HWND; a correct composition-mode implementation would likely use `ICoreWebView2CompositionController3::DragEnter` instead. The producing app disables it.
- **JS `window.close()` destroys the host window** in composition mode: the existing `WindowCloseRequested` handler destroys `hwnd`, which is the container in windowed mode but the host here. Arguably the right default (the webview *is* the window's content), but flagged for review.
- Non-Windows code paths and the default (non-composition) Windows path are untouched; a webview built without a composition target takes exactly the existing code.

## Verification

- `cargo check --target x86_64-pc-windows-msvc` and `cargo fmt --check` pass; native-host `cargo check` unaffected.
- Runtime verification comes from production use in the Colophon PDF app (this code, as a wry 0.55.1 fork with the same diff): a transparent composition-hosted webview over a wgpu-rendered document visual, exercised through a manual UAT gate covering mouse move/click/double-click/drag/capture, wheel and horizontal wheel scroll, hover states and mouse-leave cleanup, text selection, keyboard and IME composition input, cursor shapes on mixed-DPI monitors, window resize/move/minimize/restore, focus handoff, and multi-window creation via the per-HWND registry (through unmodified tauri-runtime-wry). Not run on Windows by CI in this PR; happy to add an example if maintainers want one (a minimal `composition.rs` example needs a DComp device + visual setup, ~100 lines).

<!-- change file added in .changes/webview2-composition-hosting.md -->
