### PR TITLE
fix: bump memmap2 to 0.9.11 (RUSTSEC-2026-0186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,9 +1599,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Fixes #1770

`memmap2` was locked at 0.9.5, pulled in via `winit` (a dev-dependency of wry) → `smithay-client-toolkit` / `sctk-adwaita` (Linux Wayland window-decoration theming).

**RUSTSEC-2026-0186**: affected versions under-validated the `offset`/`len` parameters on `Mmap::[unchecked_]advise_range()`, `MmapMut::[unchecked_]advise_range()`, and `MmapMut::flush[_async]_range()`, allowing an out-of-bounds value to reach `pointer::offset()`/`pointer::add()` before being passed to the `madvise`/`msync` syscalls (or Windows equivalents). The invalid pointer is never dereferenced, but passing it to those syscalls is undefined behavior. Fixed upstream in `memmap2` 0.9.11.

Note this dependency chain is dev-dependency-only (Linux/Wayland decoration theming for wry's own examples), not part of the published library's runtime graph on other platforms — lower real-world exposure than a direct runtime dependency, but worth clearing for `cargo audit` cleanliness and Linux dev builds.

A plain `cargo update -p memmap2` resolves cleanly to 0.9.11 with no other version bumps required. `Cargo.lock` only, no source changes. Verified `cargo check --workspace` passes.