### PR TITLE
fix: avoid panic on invalid IPC request URI

### DIFF
--- a/.changes/fix-ipc-invalid-uri-panic.md
+++ b/.changes/fix-ipc-invalid-uri-panic.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Don't panic in the IPC handler when the webview's current document URL is not a valid `http::Uri` (for example a `file://` URL, or one containing a raw space or non-ASCII characters). Such invalid IPC requests are now logged (under the `tracing` feature) and dropped instead of aborting the process, matching the existing behavior of the WKWebView backend.

--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -418,7 +418,13 @@ pub unsafe fn ipc(mut env: JNIEnv, _: JClass, webview_id: JString, url: JString,
       let body = body.to_string_lossy().to_string();
       let webview_id = webview_id.to_string_lossy().to_string();
       if let Some(ipc) = IPC.lock().unwrap().get(&webview_id) {
-        (ipc.handler)(Request::builder().uri(url).body(body).unwrap())
+        match Request::builder().uri(url).body(body) {
+          Ok(request) => (ipc.handler)(request),
+          Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("WebView received invalid IPC request: {_error}")
+          }
+        }
       }
     }
     (Err(_e), _, _) | (_, Err(_e), _) | (_, _, Err(_e)) => {

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -732,12 +732,14 @@ impl InnerWebView {
 
       if let Some(js) = msg.js_value() {
         if let Some(ipc_handler) = &ipc_handler {
-          ipc_handler(
-            Request::builder()
-              .uri(webview.uri().unwrap().to_string())
-              .body(js.to_string())
-              .unwrap(),
-          );
+          let uri = webview.uri().map(|u| u.to_string()).unwrap_or_default();
+          match Request::builder().uri(uri).body(js.to_string()) {
+            Ok(request) => ipc_handler(request),
+            Err(_error) => {
+              #[cfg(feature = "tracing")]
+              tracing::warn!("WebView received invalid IPC request: {_error}")
+            }
+          }
         }
       }
     });

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -971,7 +971,14 @@ impl InnerWebView {
 
         #[cfg(feature = "tracing")]
         let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
-        ipc_handler(Request::builder().uri(url).body(js).unwrap());
+
+        match Request::builder().uri(url).body(js) {
+          Ok(request) => ipc_handler(request),
+          Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("WebView received invalid IPC request: {_error}")
+          }
+        }
 
         Ok(())
       })),


### PR DESCRIPTION
## What

The IPC handlers in the `webview2`, `webkitgtk`, and `android` backends build an `http::Request` from the webview's current document URL and `.unwrap()` the result, e.g.:

```rust
ipc_handler(Request::builder().uri(url).body(js).unwrap());
```

`Request::builder().uri(...).body(...)` validates the URI against the strict `http` crate rules. If the document URL is something a browser accepts but `http::Uri` rejects — for example a `file://` URL (whose empty authority yields `InvalidUri(InvalidFormat)`), or a URL containing a raw space or a non-ASCII/emoji character (`InvalidUri(InvalidUriChar)`) — the builder returns an `Err` and the `.unwrap()` aborts the whole process:

```
called `Result::unwrap()` on an `Err` value: http::Error(InvalidUri(InvalidFormat))
```

Because the URL comes from whatever the webview happens to have loaded, an application has no reliable way to prevent this from user-side, so it manifests as an intermittent hard crash.

The WKWebView backend already avoids this — its script-message handler builds the request and returns early when the builder fails instead of unwrapping (see `src/wkwebview/class/wry_web_view_delegate.rs`). This PR makes the other three backends behave the same way.

## How

In each IPC handler, build the request, log the error under the `tracing` feature, and only forward it to the IPC handler when it built successfully:

```rust
let request = Request::builder().uri(url).body(js);
#[cfg(feature = "tracing")]
if let Err(error) = &request {
  tracing::warn!("WebView received invalid IPC request: {error}");
}
if let Ok(request) = request {
  ipc_handler(request);
}
```

For `webkitgtk`, `webview.uri()` was also unwrapped; it is now `webview.uri().map(|u| u.to_string()).unwrap_or_default()`, so a missing URI yields an empty string (which fails URI validation and drops the message) instead of panicking.

## Scope / behavior

This targets the crash only. An IPC message whose document URL is valid in the browser but not a valid `http::Uri` is now dropped (and logged under `tracing`) instead of aborting the process — the same trade-off the WKWebView backend already makes. Behavior for valid URLs is unchanged.

I don't have a Rust toolchain on hand to run `cargo build`/`clippy` locally, so I've leaned on matching the existing WKWebView pattern and keeping the change minimal; happy to adjust to whatever CI/clippy prefers.

Closes #1255
