### PR TITLE
refactor(android): process all MainPipe messages on wake up

### DIFF
--- a/src/android/main_pipe.rs
+++ b/src/android/main_pipe.rs
@@ -135,8 +135,18 @@ impl<'a> MainPipe<'a> {
 
   pub fn recv(&mut self) -> JniResult<()> {
     let package = super::PACKAGE.get().unwrap();
-    // SAFETY: The `CHANNEL` is `static` that the sender never drops
-    let (activity_id, message) = CHANNEL.1.recv().unwrap();
+    while let Ok((activity_id, message)) = CHANNEL.1.try_recv() {
+      self.handle_message(package, activity_id, message)?;
+    }
+    Ok(())
+  }
+
+  fn handle_message(
+    &mut self,
+    package: &str,
+    activity_id: ActivityId,
+    message: WebViewMessage,
+  ) -> JniResult<()> {
     match message {
       WebViewMessage::CreateWebView(attrs) => {
         let Some(ActivityProxy { activity, .. }) = activity_proxy(activity_id) else {


### PR DESCRIPTION
Paired with https://github.com/tauri-apps/tao/pull/1271

Although I have not observed the current one being faulty, I think it's still worth while processing all the messages in the channel once we wake up like we did in tao.