### PR TITLE
fix(macos): keep window.opener alive for window.open popups

### DIFF
--- a/.changes/macos-window-opener.md
+++ b/.changes/macos-window-opener.md
@@ -1,0 +1,8 @@
+---
+"wry": patch
+---
+
+On macOS, keep `window.opener` alive for `window.open` popups (fixes OAuth/SSO
+postMessage logins) by reusing the opener's `WKWebViewConfiguration` with its
+user scripts and script message handlers stripped first, avoiding a
+duplicate-handler crash on recent macOS.

--- a/src/wkwebview/class/wry_web_view_ui_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_ui_delegate.rs
@@ -251,6 +251,13 @@ define_class!(
             // controller.
             window.setReleasedWhenClosed(false);
 
+            // Strip the opener's script handlers before reusing its
+            // configuration, or they get double-registered and abort on recent
+            // macOS. Reusing the configuration keeps `window.opener` wired.
+            let controller = configuration.userContentController();
+            controller.removeAllUserScripts();
+            controller.removeAllScriptMessageHandlers();
+
             let webview = objc2_web_kit::WKWebView::initWithFrame_configuration(
               mtm.alloc::<objc2_web_kit::WKWebView>(),
               window.frame(),


### PR DESCRIPTION
On macOS, `window.open` popups created through the
`createWebViewWithConfiguration:forNavigationAction:windowFeatures:` path lose
`window.opener` (it is `null` in the popup), which breaks OAuth/SSO flows that
`postMessage` their result back to the opener.

WebKit only wires `window.opener` when the popup webview is created with the
configuration it hands the delegate, which `initWithFrame_configuration`
already does. The problem is what that configuration still carries.

## The abort

Returning `NewWindowResponse::Allow` with a custom protocol registered on the
parent aborts the process on macOS 26:

```
thread 'main' panicked at wry-0.54.4/src/wkwebview/class/wry_web_view.rs:129:8:
tried to access uninitialized instance variable
  16: objc2::__macro_helpers::defined_ivars::get_initialized_ivar_ptr
  17: objc2::top_level_traits::DefinedClass::ivars
  18: wry::wkwebview::class::wry_web_view::WryWebView::add_custom_task_key
  19: wry::wkwebview::class::url_scheme_handler::start_task
        at wry-0.54.4/src/wkwebview/class/url_scheme_handler.rs:69:29

thread 'main' panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
```

The `Allow` arm builds the popup as a plain `objc2_web_kit::WKWebView`, but the
inherited configuration still carries the parent's URL scheme handler. When it
fires, `start_task` reads `WryWebView` ivars that were never initialized on that
object. `start_task` is `extern "C"`, so the panic cannot unwind and becomes
`abort()`.

## Repro

Standalone, no Tauri, no app framework — `wry` + `tao` + `http` only:

https://github.com/gxiang314/wry-popup-repro

```sh
git clone https://github.com/gxiang314/wry-popup-repro
cd wry-popup-repro && cargo run
```

Click the button. The process aborts. Full backtraces and macOS `.ips` crash
reports are in `evidence/`.

Verified on macOS 26.5.2 (25F84), arm64, rustc 1.97.1, wry 0.54.4.

## This patch

Clearing the configuration's `userContentController` before the popup webview
is created avoids the abort and keeps `window.opener` wired:

| wry | result |
| --- | --- |
| 0.54.4 stock | aborts |
| 0.54.4 + this patch | survives, `window.opener` live |

Same machine, same app, same click, only wry differs.

I want to be upfront that this is a workaround, not a root-cause fix. It works
because the popup no longer triggers the inherited custom protocol path. The
underlying mismatch is that the `Allow` arm creates a plain `WKWebView` while
the inherited handlers assume a `WryWebView`. If you'd rather fix that directly
I'm happy to redo the patch — this one is what unblocked OAuth for me and it
does not regress anything I could find.

Relates to tauri-apps/tauri#14263.
