### PR TITLE
build: conditionally compile media capture permission for macOS deplo…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -109,6 +109,35 @@ fn main() {
       || target.contains("openbsd"));
   alias("linux", linux);
   alias("gtk", cfg!(feature = "os-webview") && linux);
+
+  // Detect the macOS deployment target from the environment (set by Tauri or the user).
+  // This allows conditional compilation based on the minimum supported macOS version.
+  // We define two custom cfg flags:
+  // - macos_12_or_later: true if deployment target is macOS 12.0+
+  // - macos_11_or_earlier: true if deployment target is macOS 11.x or older
+  //
+  // These flags are used in the WebView implementation to conditionally compile APIs
+  // that were introduced in macOS 12 (e.g., requestMediaCapturePermissionForOrigin).
+  // On older deployment targets, the unsupported code is simply excluded,
+  // preventing compilation errors and removing the need for downstream patches.
+
+  println!("cargo::rustc-check-cfg=cfg(macos_12_or_later)");
+  println!("cargo::rustc-check-cfg=cfg(macos_11_or_earlier)");
+
+  let deployment_target =
+    std::env::var("MACOSX_DEPLOYMENT_TARGET").unwrap_or_else(|_| "10.15".to_string());
+  let major: u32 = deployment_target
+    .split('.')
+    .next()
+    .unwrap_or("10")
+    .parse()
+    .unwrap_or(10);
+
+  if major >= 12 {
+    println!("cargo:rustc-cfg=macos_12_or_later");
+  } else {
+    println!("cargo:rustc-cfg=macos_11_or_earlier");
+  }
 }
 
 fn alias(alias: &str, condition: bool) {

--- a/src/wkwebview/class/wry_web_view_ui_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_ui_delegate.rs
@@ -124,6 +124,7 @@ define_class!(
       }
     }
 
+    #[cfg(macos_12_or_later)]
     #[unsafe(method(webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:))]
     fn request_media_capture_permission(
       &self,


### PR DESCRIPTION
## Motivation

When building `wry` with a macOS deployment target lower than 12.0 (e.g. 10.15 or 11.0), compilation fails because the delegate method `requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:` is only available on macOS 12.0+. This forces downstream users to maintain forks or manually patch `wry`.

## Solution

- In `build.rs`, read the `MACOSX_DEPLOYMENT_TARGET` environment variable and set custom `cfg` flags `macos_12_or_later` / `macos_11_or_earlier`.
- Guard the entire `requestMediaCapturePermissionForOrigin` method with `#[cfg(macos_12_or_later)]`.
- On older deployment targets the method is excluded, so the system default permission flow takes over (no functional loss).

The recently added custom `permission_handler` logic is fully preserved when compiling for macOS ≥ 12.

## Testing

- Built a Tauri 2 project using this branch with `MACOSX_DEPLOYMENT_TARGET=11.0`: **compilation succeeds** (previously failed).
- Built with `MACOSX_DEPLOYMENT_TARGET=12.0`: **compilation succeeds** and the permission handler works as expected.

## Impact

- No behavioral change for macOS 12+ builds.
- Removes the need for downstream patches when targeting older macOS versions.