### PR TITLE
fix(webview2): don't panic on IPC from non-http(s) documents

### DIFF
--- a/.changes/webview2-ipc-invalid-uri.md
+++ b/.changes/webview2-ipc-invalid-uri.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On Windows, fixed a panic in the WebView2 IPC handler when the posting document's `Source` URL is not a valid `http::Uri` (e.g. `file:`, `data:` or `blob:` documents). The failed `Request` build was unwrapped inside a callback that cannot unwind, aborting the process; the message is now dropped instead.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -971,7 +971,18 @@ impl InnerWebView {
 
         #[cfg(feature = "tracing")]
         let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
-        ipc_handler(Request::builder().uri(url).body(js).unwrap());
+        // The document that posted this message may have a `Source` URL that is not a
+        // valid `http::Uri` (e.g. `file:`, `data:` or `blob:` documents). Building the
+        // request then fails, and unwrapping here would panic inside a WebView2 callback
+        // that cannot unwind, aborting the whole process. Skip the message instead so a
+        // stray IPC post can't take down the app.
+        match Request::builder().uri(url.as_str()).body(js) {
+          Ok(request) => ipc_handler(request),
+          Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(url = %url, error = %_error, "ignoring IPC message with invalid source URL");
+          }
+        }
 
         Ok(())
       })),


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Bug fix

## Summary

On Windows, the WebView2 `WebMessageReceived` handler builds an `http::Request` from the posting document's `Source` URL and unwraps the result:

```rust
ipc_handler(Request::builder().uri(url).body(js).unwrap());
```

When a message is posted from a document whose URL is not a valid `http::Uri` — for example a `file:`, `data:` or `blob:` document — `Request::builder().uri(url)` fails with `http::Error(InvalidUri(InvalidFormat))`. Because this runs inside a WebView2 callback that cannot unwind, the `.unwrap()` panic turns into a "panic in a function that cannot unwind" abort and takes the whole process down.

This is easy to hit for any app that hosts arbitrary or local content in a webview that also injects the wry IPC bootstrap: navigate to a `file://` page (or let an `http(s)` page open a `data:`/`blob:` document) and have it call `window.ipc.postMessage(...)`.

## Fix

Match on the `Request::builder(...).body(...)` result instead of unwrapping. On success the handler runs as before; on failure the message is dropped (and logged under the `tracing` feature) rather than aborting the process.

Reproduced: `Request::builder().uri("file:///C:/Users/me/index.html").body(())` returns `Err(InvalidUri(InvalidFormat))`, matching the observed crash.
