### PR TITLE
feat(macos/ios): enable fullscreen without private api

### DIFF
--- a/.changes/macos-fullscreen.md
+++ b/.changes/macos-fullscreen.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Enable WebView element fullscreen support on macOS 12.3+ and iOS 15.4+ without using private APIs. Support for older OS versions is still behind the `fullscreen` feature flag.

--- a/README.md
+++ b/README.md
@@ -282,12 +282,11 @@ Wry uses a set of feature flags to toggle several advanced features.
 - `drag-drop` (default): Enables [`WebViewBuilder::with_drag_drop_handler`] to control the behavior when there are files
   interacting with the window.
 - `devtools`: Enables devtools on release builds. Devtools are always enabled in debug builds.
-  On **macOS**, enabling devtools, requires calling private APIs so you should not enable this flag in release
-  build if your app needs to publish to App Store.
+  On **macOS**, enabling devtools, requires calling private functions, so avoid this in release builds if you publish your app on the App Store.
 - `transparent`: Transparent background on **macOS** requires calling private functions.
-  Avoid this in release build if your app needs to publish to App Store.
-- `fullscreen`: Fullscreen video and other media on **macOS** requires calling private functions.
-  Avoid this in release build if your app needs to publish to App Store.
+  Avoid this in release builds if you publish your app on the App Store.
+- `fullscreen`: Fullscreen video and other media elements on **macOS** < 12.3 and **iOS** < 15.4 requires calling private functions.
+  Avoid this in release builds if you publish your app on the App Store.
 - `linux-body`: Enables body support of custom protocol request on Linux. Requires
   WebKit2GTK v2.40 or above.
 - `tracing`: enables [`tracing`] for `evaluate_script`, `ipc_handler`, and `custom_protocols`.

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -13,10 +13,10 @@ use gdkx11::{
 };
 #[cfg(feature = "x11")]
 use gtk::glib::{self, translate::FromGlibPtrFull};
-use gtk::glib::{Cast, IsA};
 use gtk::{
   gdk::{self},
   gio::Cancellable,
+  glib::{Cast, IsA},
   prelude::*,
 };
 use http::Request;

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -380,7 +380,8 @@ impl InnerWebView {
       }
 
       if (cfg!(target_os = "macos") && (version.0 > 12 || (version.0 == 12 && version.1 >= 3)))
-        || (cfg!(target_os = "ios") && (version.0 > 15 || (version.0 == 15 && version.1 >= 4))) {
+        || (cfg!(target_os = "ios") && (version.0 > 15 || (version.0 == 15 && version.1 >= 4)))
+      {
         // NOTE: Public API alternative for private config fullScreenEnabled (see below)
         // Only available on macOS 12.3+ and iOS 15.4+
         _preference.setElementFullscreenEnabled(true);

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -370,25 +370,19 @@ impl InnerWebView {
       #[cfg(feature = "transparent")]
       if attributes.transparent || attributes.background_color.is_some() {
         let no = NSNumber::numberWithBool(false);
-        #[cfg(target_os = "macos")]
         {
-          if version.0 > 10 || (version.0 == 10 && version.1 >= 14) {
+          if cfg!(target_os = "ios") || version.0 > 10 || (version.0 == 10 && version.1 >= 14) {
             // NOTE: Private API — `drawsBackground`.
             // Available: macOS 10.14+ (no public doc).
             config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
           }
         }
-        #[cfg(target_os = "ios")]
-        {
-          // NOTE: Private API — `drawsBackground`.
-          config.setValue_forKey(Some(&no), ns_string!("drawsBackground"));
-        }
       }
 
       if (cfg!(target_os = "macos") && (version.0 > 12 || (version.0 == 12 && version.1 >= 3)))
         || (cfg!(target_os = "ios") && (version.0 > 15 || (version.0 == 15 && version.1 >= 4))) {
-        // NOTE: Private API — `drawsBackground`.
-        // Available: macOS 10.14+ (no public doc).
+        // NOTE: Public API alternative for private config fullScreenEnabled (see below)
+        // Only available on macOS 12.3+ and iOS 15.4+
         _preference.setElementFullscreenEnabled(true);
       }
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -365,12 +365,13 @@ impl InnerWebView {
         config.setMediaTypesRequiringUserActionForPlayback(WKAudiovisualMediaTypes::None);
       }
 
+      let version = util::operating_system_version();
+
       #[cfg(feature = "transparent")]
       if attributes.transparent || attributes.background_color.is_some() {
         let no = NSNumber::numberWithBool(false);
         #[cfg(target_os = "macos")]
         {
-          let version = util::operating_system_version();
           if version.0 > 10 || (version.0 == 10 && version.1 >= 14) {
             // NOTE: Private API — `drawsBackground`.
             // Available: macOS 10.14+ (no public doc).
@@ -384,8 +385,16 @@ impl InnerWebView {
         }
       }
 
+      if (cfg!(target_os = "macos") && (version.0 > 12 || (version.0 == 12 && version.1 >= 3)))
+        || (cfg!(target_os = "ios") && (version.0 > 15 || (version.0 == 15 && version.1 >= 4))) {
+        // NOTE: Private API — `drawsBackground`.
+        // Available: macOS 10.14+ (no public doc).
+        _preference.setElementFullscreenEnabled(true);
+      }
+
       #[cfg(feature = "fullscreen")]
       // NOTE: Private API — `fullScreenEnabled` is a private KVC key on WKPreferences.
+      // This is the private API alternative to setElementFullscreenEnabled above that also works on older macOS/iOS versions.
       _preference.setValue_forKey(Some(&_yes), ns_string!("fullScreenEnabled"));
 
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/pull/15640

tested on macos 26