### PR TITLE
fix(webview2): honor WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS via the API on Windows (survives Runtime 150 elevated-host hardening)

### DIFF
--- a/.changes/webview2-elevated-browser-args.md
+++ b/.changes/webview2-elevated-browser-args.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+On Windows, fold the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable into the args passed through the WebView2 API so it survives WebView2 Runtime 150's elevated-host hardening. This restores WebDriver automation (e.g. msedgedriver's `--remote-debugging-port`) for apps launched by an elevated host such as CI runners.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -297,7 +297,7 @@ impl InnerWebView {
       .map(HSTRING::from);
 
     // additional browser args
-    let additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
+    let mut additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
       // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
       // and "smart screen" - See https://github.com/tauri-apps/tauri/issues/1345
       let default_args = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection";
@@ -326,6 +326,24 @@ impl InnerWebView {
 
       arguments
     });
+
+    // WebView2 Runtime 150 hardened elevated (high-integrity) host processes to
+    // ignore the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable. That
+    // silently breaks WebDriver automation, where msedgedriver injects
+    // `--remote-debugging-port` through that env var: with the port dropped the
+    // DevTools/CDP endpoint never opens and session creation times out. Fold the env
+    // var into the args passed via the API (`AdditionalBrowserArguments`), which is
+    // still honored when elevated, so automation keeps working.
+    // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/5645.
+    if let Ok(env_args) = std::env::var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS") {
+      let env_args = env_args.trim();
+      if !env_args.is_empty() {
+        if !additional_browser_args.is_empty() {
+          additional_browser_args.push(' ');
+        }
+        additional_browser_args.push_str(env_args);
+      }
+    }
 
     let (tx, rx) = mpsc::channel();
     let options = CoreWebView2EnvironmentOptions::default();


### PR DESCRIPTION
Closes #1782.

## Problem

WebView2 Runtime 150 hardened elevated (high-integrity) host processes to ignore `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`, HKCU policy, and command-line switch overrides — only HKLM policy and args passed via the WebView2 **API** (`ICoreWebView2EnvironmentOptions::AdditionalBrowserArguments`) survive. This is by-design, see [MicrosoftEdge/WebView2Feedback#5645](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5645).

WebDriver automation of wry/Tauri apps relies on msedgedriver injecting `--remote-debugging-port` through that env var. On an elevated host — e.g. GitHub-hosted Windows runners, which run as admin — with Runtime ≥150, the env var is dropped, the CDP/DevTools endpoint never opens, and session creation times out. `wry` never read the env var itself, and `set_allows_automation` is a no-op on Windows (only the WebKitGTK backend consumes it), so nothing on the wry side currently survives the hardening.

## Fix

`create_environment` already passes `AdditionalBrowserArguments` through the API. Fold `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` into that call so the args survive elevation.

## Design note — unconditional vs. gated

This is the **unconditional** variant: it folds the env var in whenever it's set (effectively gated by the env var's *presence*, which is rare outside automation). It's minimal and self-contained — no new plumbing — and it fixes the regression for *any* elevated use of the env var, not only automation.

Trade-off: when the host is **not** elevated the runtime also reads the env var, so the args may be applied twice — harmless for idempotent flags like `--remote-debugging-port`, and moot if the runtime treats the env var as overriding the API property.

Happy to switch to a variant **gated on `allows_automation`** if you'd prefer to avoid any behavior change for non-automation apps. That needs the automation flag plumbed from `WebContext` into `create_environment`, which is why I defaulted to the smaller change.

## Testing

`src/webview2/mod.rs` is `#[cfg(windows)]`, so this needs Windows CI to compile-check. Behaviorally it's exercised end-to-end by tauri-driver-based WebDriver E2E on an elevated Windows host (where the regression surfaced). Included a covector `patch` changefile.
