### PR TITLE
fix(windows): ignore `MoveFocus` error on creation

### DIFF
--- a/.changes/ignore-move-focus-error.md
+++ b/.changes/ignore-move-focus-error.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On Windows, ignore set webview focus error on create as it fails if the hosting window is minimized.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -608,7 +608,8 @@ impl InnerWebView {
       controller.SetIsVisible(attributes.visible)?;
 
       if attributes.focused {
-        controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC)?;
+        // Ignore this error since it fails when the window is minimized
+        let _ = controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
       }
     }
 


### PR DESCRIPTION
Fix #1798

Since the move focus fail is not fatal, we can ignore it here.