### PR TITLE
docs(android): why `WEBVIEW_ATTRIBUTES` exists

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -139,6 +139,8 @@ pub unsafe fn android_setup(
 
   register_activity_proxy(vm, activity_id, activity, window_manager);
 
+  // We don't always destroy the rust window when `onDestroy` if it's caused by a configuration change.
+  // This is used to re-create the webview to match in that case.
   if let Some(webview_attributes) = WEBVIEW_ATTRIBUTES.lock().unwrap().get(&activity_id) {
     MainPipe::send(
       activity_id,

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -141,6 +141,7 @@ pub unsafe fn android_setup(
 
   // We don't always destroy the rust window when `onDestroy` if it's caused by a configuration change.
   // This is used to re-create the webview to match in that case.
+  // See https://developer.android.com/guide/topics/resources/runtime-changes
   if let Some(webview_attributes) = WEBVIEW_ATTRIBUTES.lock().unwrap().get(&activity_id) {
     MainPipe::send(
       activity_id,


### PR DESCRIPTION
Closes #1792

To be honest, I don't even think we should support this use case, modern Android apps should declare `android:configChanges` so the activity is never re-created.