### PR TITLE
fix(android): log and clear webview creation errors

### DIFF
--- a/src/android/binding.rs
+++ b/src/android/binding.rs
@@ -285,8 +285,15 @@ pub unsafe fn onFirstActivityCreateWry(env: JNIEnv, _: JClass) {
       if libc::read(fd.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len())
         == buf.len() as libc::ssize_t
       {
-        // unregister itself on errors
-        main_pipe.recv().is_ok()
+        match main_pipe.recv() {
+          Ok(()) => true,
+          Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!("Failed to process Android main pipe message: {_error}");
+            let _ = main_pipe.env.exception_clear();
+            false
+          }
+        }
       } else {
         // unregister itself
         false


### PR DESCRIPTION
## Summary

- keep Android main-pipe failures from leaving a pending Java exception at the JNI boundary
- log the WebView creation error when tracing is enabled, clear the Java exception, and unregister the failing looper callback

Closes #1785

This is intentionally the minimal defensive part of the issue. It does not add an embedder callback for asynchronous creation failures, which would need a wider API design.

## Validation

- `cargo test --lib` passed: 9 tests
- `git diff --check` passed
- `rustfmt --check src/android/binding.rs` reached the file but reports the repository's existing newline-style mismatch on this Windows checkout

The Android-specific path was not compiled locally because an Android target/toolchain is not installed here.