### PR TITLE
fix(android): override getDefaultVideoPoster to suppress placeholder

### DIFF
--- a/.changes/video-poster-placeholder.md
+++ b/.changes/video-poster-placeholder.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Override `getDefaultVideoPoster()` on Android to return a transparent bitmap instead of null, preventing Chromium from painting its default gray play-button placeholder on `<video>` elements.

--- a/src/android/kotlin/RustWebChromeClient.kt
+++ b/src/android/kotlin/RustWebChromeClient.kt
@@ -14,6 +14,7 @@ import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.DialogInterface
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -117,6 +118,13 @@ class RustWebChromeClient(private val activity: WryActivity, private val webView
    * @return one of the PERMISSION_REQUEST_* constants.
    */
   private external fun onPermissionRequestNative(webviewId: String, resource: String): Int
+
+  override fun getDefaultVideoPoster(): Bitmap {
+    // Return a transparent bitmap so Chromium doesn't paint its default gray play-button placeholder on <video> elements.
+    // Matches react-native-webview's approach — see https://github.com/react-native-webview/react-native-webview/blob/58daac9e2e532ca1dcb49003b86568218b9b2b1d/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.kt
+    return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
+  }
+
   /**
    * @return true when Rust denies geolocation; false continues the normal Android permission flow.
    */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix — overrides `getDefaultVideoPoster()` on Android to return a transparent bitmap instead of null, preventing Chromium from painting its default gray play-button placeholder on `<video>` elements.

Closes #1802

## Why is this change needed?

Android's `WebChromeClient.getDefaultVideoPoster()` returns `null` by default. When a `<video>` element has no poster attribute, Chromium paints a stretched gray play-button placeholder bitmap in its place. This is visually undesirable in apps that use video elements without poster images.

## What does this PR implement?

Overrides `getDefaultVideoPoster()` in `RustWebChromeClient` to return a transparent `ARGB_8888` bitmap (`Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)`), matching the approach used by [react-native-webview](https://github.com/react-native-webview/react-native-webview/blob/58daac9e2e532ca1dcb49003b86568218b9b2b1d/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.kt).

## Verification

- `cargo test` passes
- Verified on Android device — gray placeholder no longer appears on `<video>` elements