### PR TITLE
fix: avoid ipc global lexical collisions

### DIFF
--- a/.changes/configurable-ipc-global.md
+++ b/.changes/configurable-ipc-global.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Make the injected `window.ipc` property configurable so websites can declare their own global `ipc` binding without a syntax error while preserving the existing Wry IPC API.

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -345,7 +345,8 @@ impl InnerWebView {
     };
 
     // Initialize message handler
-    w.init("Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: function(x) { window.webkit.messageHandlers['ipc'].postMessage(x) } }) })", true)?;
+    // Keep the bridge configurable so it does not block a page's global lexical `ipc` binding.
+    w.init("Object.defineProperty(window, 'ipc', { configurable: true, value: Object.freeze({ postMessage: function(x) { window.webkit.messageHandlers['ipc'].postMessage(x) } }) })", true)?;
 
     // Initialize scripts
     for init_script in attributes.initialization_scripts {

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -944,10 +944,11 @@ impl InnerWebView {
     attributes: &mut WebViewAttributes,
     token: &mut EventRegistrationToken,
   ) -> Result<()> {
+    // Keep the bridge configurable so it does not block a page's global lexical `ipc` binding.
     Self::add_script_to_execute_on_document_created(
       webview,
       String::from(
-        r#"Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: s=> window.chrome.webview.postMessage(s) }) });"#,
+        r#"Object.defineProperty(window, 'ipc', { configurable: true, value: Object.freeze({ postMessage: s=> window.chrome.webview.postMessage(s) }) });"#,
       ),
     )?;
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -637,8 +637,10 @@ impl InnerWebView {
       };
 
       // Initialize scripts
+      // Keep the bridge configurable so it does not block a page's global lexical `ipc` binding.
       w.init(
 r#"Object.defineProperty(window, 'ipc', {
+  configurable: true,
   value: Object.freeze({postMessage: function(s) {window.webkit.messageHandlers.ipc.postMessage(s);}})
 });"#,
       true


### PR DESCRIPTION
## Summary

- make Wry's injected `window.ipc` property configurable on WKWebView, WebView2, and WebKitGTK
- preserve the existing frozen `window.ipc.postMessage` bridge for API and version-skew compatibility
- add the required patch release note

## Root cause

Wry currently installs `window.ipc` as a non-configurable own property. ECMAScript global declaration instantiation then rejects a page script that declares a global lexical binding with the same name, such as `const ipc`, before that script can execute. Google Workspace bundles hit this collision and fail with an `ipc` redeclaration syntax error.

Making the property configurable removes that declaration conflict without renaming or removing `window.ipc`. Existing Wry callers and Tauri's v2 postMessage fallback continue to use the same frozen bridge, including when `tauri` and `tauri-runtime-wry` are updated independently.

Closes tauri-apps/tauri#11612.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --verbose` (8 unit tests and 9 doc tests passed; 2 doc tests ignored)
- `cargo clippy --all-targets`
- `git diff --check`
- JavaScriptCore regression check: the current descriptor fails with `Can't create duplicate variable that shadows a global property: 'ipc'`; the configurable descriptor accepts `const ipc` and leaves `globalThis.ipc.postMessage` callable
- Node/V8 regression check for the same declaration and bridge behavior
