### PR TITLE
fix(ohos): wire go_back/go_forward to the real ArkWeb controller

### DIFF
--- a/.changes/ignore-move-focus-error.md
+++ b/.changes/ignore-move-focus-error.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On Windows, ignore set webview focus error on create as it fails if the hosting window is minimized.

--- a/.changes/unknown-delegate-method.md
+++ b/.changes/unknown-delegate-method.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On macOS in debug mode, don't register `requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:` delegate method on macOS 11 or older to prevent a debug_assertion startup panic.

--- a/.changes/video-poster-placeholder.md
+++ b/.changes/video-poster-placeholder.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Override `getDefaultVideoPoster()` on Android to return a transparent bitmap instead of null, preventing Chromium from painting its default gray play-button placeholder on `<video>` elements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,7 +2418,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 [[package]]
 name = "openharmony-ability"
 version = "0.3.0"
-source = "git+https://github.com/harmony-contrib/openharmony-ability.git#295a276a699ba2352addc69b8cacb6acd3be6ab1"
+source = "git+https://github.com/harmony-contrib/openharmony-ability.git?rev=16719fc0ee0b1399d364cc85a5125cbb21d2749e#16719fc0ee0b1399d364cc85a5125cbb21d2749e"
 dependencies = [
  "futures-channel",
  "http",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "openharmony-ability-derive"
 version = "0.3.0"
-source = "git+https://github.com/harmony-contrib/openharmony-ability.git#295a276a699ba2352addc69b8cacb6acd3be6ab1"
+source = "git+https://github.com/harmony-contrib/openharmony-ability.git?rev=16719fc0ee0b1399d364cc85a5125cbb21d2749e#16719fc0ee0b1399d364cc85a5125cbb21d2749e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,12 @@ tao-macros = "0.1.4"
 libc = "0.2"
 dom_query = { version = "0.28.0", default-features = false }
 
+[target.'cfg(target_vendor = "apple")'.build-dependencies]
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "NSProcessInfo",
+] }
+
 [dev-dependencies]
 pollster = "1.0.0"
 tao = "0.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,8 +203,8 @@ dom_query = { version = "0.28.0", default-features = false }
 [target.'cfg(target_env = "ohos")'.dependencies]
 # openharmony-ability = { version = "0.3.0", features = ["webview"] }
 # openharmony-ability-derive = { version = "0.3.0" }
-openharmony-ability = { git = "https://github.com/harmony-contrib/openharmony-ability.git", features = ["webview"] }
-openharmony-ability-derive = { git = "https://github.com/harmony-contrib/openharmony-ability.git" }
+openharmony-ability = { git = "https://github.com/harmony-contrib/openharmony-ability.git", rev = "16719fc0ee0b1399d364cc85a5125cbb21d2749e", features = ["webview"] }
+openharmony-ability-derive = { git = "https://github.com/harmony-contrib/openharmony-ability.git", rev = "16719fc0ee0b1399d364cc85a5125cbb21d2749e" }
 
 [target.'cfg(target_vendor = "apple")'.build-dependencies]
 objc2-foundation = { version = "0.3.2", default-features = false, features = [

--- a/bench/src/run_benchmark.rs
+++ b/bench/src/run_benchmark.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::{
   collections::{HashMap, HashSet},
   env,
@@ -101,39 +101,60 @@ fn run_max_mem_benchmark() -> Result<HashMap<String, u64>> {
   Ok(results)
 }
 
-fn rlib_size(target_dir: &std::path::Path, prefix: &str) -> u64 {
-  let mut size = 0;
-  let mut seen = std::collections::HashSet::new();
-  println!("{:?}", target_dir);
+fn rlib_size(target_dir: &std::path::Path, library: &str) -> Result<u64> {
+  let prefix = format!("lib{library}");
 
-  for entry in std::fs::read_dir(target_dir.join("deps")).unwrap() {
-    let entry = entry.unwrap();
-    let os_str = entry.file_name();
-    let name = os_str.to_str().unwrap();
-    if name.starts_with(prefix) && name.ends_with(".rlib") {
-      let start = name.split('-').next().unwrap().to_string();
-      if seen.contains(&start) {
-        println!("skip {}", name);
-      } else {
-        seen.insert(start);
-        size += entry.metadata().unwrap().len();
-        println!("check size {} {}", name, size);
+  let mut size = 0;
+  let mut seen = HashSet::new();
+
+  let build_dir = target_dir.join("build").join(library);
+  for entry in std::fs::read_dir(&build_dir).with_context(|| {
+    format!(
+      "failed to read target build directory: {}",
+      build_dir.display()
+    )
+  })? {
+    let entry = entry.context("failed to read directory entry")?;
+    let out_path = entry.path().join("out");
+
+    for file in std::fs::read_dir(&out_path).with_context(|| {
+      format!(
+        "failed to read target build output directory: {}",
+        out_path.display()
+      )
+    })? {
+      let file = file.context("failed to read build output directory entry")?;
+      let name = file.file_name().to_string_lossy().to_string();
+      if name.starts_with(&prefix) && name.ends_with(".rlib") {
+        let start = name.split('-').next().unwrap();
+        if seen.insert(start.to_string()) {
+          size += file
+            .metadata()
+            .context("failed to read file metadata")?
+            .len();
+        }
       }
     }
   }
-  assert!(size > 0);
-  size
+
+  if size == 0 {
+    anyhow::bail!(
+      "no rlib files found for prefix {prefix} in {}",
+      build_dir.display()
+    );
+  }
+
+  Ok(size)
 }
 
 fn get_binary_sizes(target_dir: &Path) -> Result<HashMap<String, u64>> {
   let mut sizes = HashMap::<String, u64>::new();
 
-  let wry_size = rlib_size(target_dir, "libwry");
+  let wry_size = rlib_size(target_dir, "wry")?;
   println!("wry {} bytes", wry_size);
   sizes.insert("wry_rlib".to_string(), wry_size);
 
-  // add up size for everything in target/release/deps/libtao*
-  let tao_size = rlib_size(target_dir, "libtao");
+  let tao_size = rlib_size(target_dir, "tao")?;
   println!("tao {} bytes", tao_size);
   sizes.insert("tao_rlib".to_string(), tao_size);
 

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+#[cfg(target_os = "macos")]
+#[path = "src/wkwebview/util.rs"]
+mod util;
+
 fn main() {
   let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
   if target_os == "macos" || target_os == "ios" {
     println!("cargo:rustc-link-lib=framework=WebKit");
+  }
+
+  // TODO: Remove in objc2 0.7.0, ref <https://github.com/madsmtm/objc2/issues/645>
+  #[cfg(target_os = "macos")]
+  {
+    if std::env::var("CARGO_CFG_DEBUG_ASSERTIONS").is_ok() {
+      let os = util::operating_system_version();
+      if os.0 < 12 {
+        println!("cargo:rustc-cfg=macos_12_unavailable")
+      }
+    }
   }
 
   if target_os == "android" {

--- a/src/android/kotlin/RustWebChromeClient.kt
+++ b/src/android/kotlin/RustWebChromeClient.kt
@@ -14,6 +14,7 @@ import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.DialogInterface
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -117,6 +118,13 @@ class RustWebChromeClient(private val activity: WryActivity, private val webView
    * @return one of the PERMISSION_REQUEST_* constants.
    */
   private external fun onPermissionRequestNative(webviewId: String, resource: String): Int
+
+  override fun getDefaultVideoPoster(): Bitmap {
+    // Return a transparent bitmap so Chromium doesn't paint its default gray play-button placeholder on <video> elements.
+    // Matches react-native-webview's approach — see https://github.com/react-native-webview/react-native-webview/blob/58daac9e2e532ca1dcb49003b86568218b9b2b1d/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.kt
+    return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
+  }
+
   /**
    * @return true when Rust denies geolocation; false continues the normal Android permission flow.
    */

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -139,6 +139,9 @@ pub unsafe fn android_setup(
 
   register_activity_proxy(vm, activity_id, activity, window_manager);
 
+  // We don't always destroy the rust window when `onDestroy` if it's caused by a configuration change.
+  // This is used to re-create the webview to match in that case.
+  // See https://developer.android.com/guide/topics/resources/runtime-changes
   if let Some(webview_attributes) = WEBVIEW_ATTRIBUTES.lock().unwrap().get(&activity_id) {
     MainPipe::send(
       activity_id,

--- a/src/ohos/mod.rs
+++ b/src/ohos/mod.rs
@@ -274,19 +274,31 @@ impl InnerWebView {
   }
 
   pub fn go_forward(&self) -> Result<()> {
-    Ok(())
+    self
+      .webview
+      .forward()
+      .map_err(|e| Error::OpenHarmonyWebviewError(format!("Failed to go forward: {}", e)))
   }
 
   pub fn go_back(&self) -> Result<()> {
-    Ok(())
+    self
+      .webview
+      .back()
+      .map_err(|e| Error::OpenHarmonyWebviewError(format!("Failed to go back: {}", e)))
   }
 
   pub fn can_go_forward(&self) -> Result<bool> {
-    Ok(true)
+    self
+      .webview
+      .can_go_forward()
+      .map_err(|e| Error::OpenHarmonyWebviewError(format!("Failed to check forward: {}", e)))
   }
 
   pub fn can_go_back(&self) -> Result<bool> {
-    Ok(true)
+    self
+      .webview
+      .can_go_back()
+      .map_err(|e| Error::OpenHarmonyWebviewError(format!("Failed to check back: {}", e)))
   }
 }
 

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -608,7 +608,8 @@ impl InnerWebView {
       controller.SetIsVisible(attributes.visible)?;
 
       if attributes.focused {
-        controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC)?;
+        // Ignore this error since it fails when the window is minimized
+        let _ = controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
       }
     }
 

--- a/src/wkwebview/class/wry_web_view_ui_delegate.rs
+++ b/src/wkwebview/class/wry_web_view_ui_delegate.rs
@@ -124,6 +124,9 @@ define_class!(
       }
     }
 
+    // TODO: Remove in objc2 0.7.0, ref <https://github.com/madsmtm/objc2/issues/645>
+    // Using not(unavailable) instead of available to prevent false positives if the build script failed to set the cfg
+    #[cfg(not(macos_12_unavailable))]
     #[unsafe(method(webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:))]
     fn request_media_capture_permission(
       &self,


### PR DESCRIPTION
## Summary

Wire `go_back` / `go_forward` / `can_go_back` / `can_go_forward` on the OpenHarmony backend to the real ArkWeb controller.

Previously these were no-ops (`go_back`/`go_forward` returned `Ok(())`) and `can_go_*` were hardcoded to `true`, so navigation calls and back-key handling from the host app silently did nothing.

## Dependencies

Requires openharmony-ability to expose `back` / `forward` / `can_go_back` / `can_go_forward` on its Webview helper (companion PR in that repo).

## Test plan

- `cargo check --target x86_64-unknown-linux-ohos` passes.
- ArkWeb APIs (`backward()` / `forward()` / `accessBackward()` / `accessForward()`) verified against the DevEco SDK type declarations.