### PR TITLE
perf: only register `window.ipc` if IPC handler is set

### DIFF
--- a/.changes/no-window-ipc.if-no-handler.md
+++ b/.changes/no-window-ipc.if-no-handler.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+Only inject `window.ipc` if the webview is built with `WebViewBuilder::with_ipc_handler`

--- a/src/webkitgtk/mod.rs
+++ b/src/webkitgtk/mod.rs
@@ -311,7 +311,9 @@ impl InnerWebView {
     Self::attach_handlers(&webview, web_context, &mut attributes);
 
     // IPC handler
-    Self::attach_ipc_handler(webview.clone(), &mut attributes);
+    if let Some(ipc_handler) = attributes.ipc_handler.take() {
+      Self::attach_ipc_handler(webview.clone(), ipc_handler);
+    }
 
     // Drag drop handler
     if let Some(drag_drop_handler) = attributes.drag_drop_handler.take() {
@@ -718,9 +720,8 @@ impl InnerWebView {
     is_in_fixed_parent
   }
 
-  fn attach_ipc_handler(webview: WebView, attributes: &mut WebViewAttributes) {
+  fn attach_ipc_handler(webview: WebView, ipc_handler: Box<dyn Fn(Request<String>)>) {
     // Message handler
-    let ipc_handler = attributes.ipc_handler.take();
     let manager = webview
       .user_content_manager()
       .expect("WebView does not have UserContentManager");
@@ -731,14 +732,12 @@ impl InnerWebView {
       let _span = tracing::info_span!(parent: None, "wry::ipc::handle").entered();
 
       if let Some(js) = msg.js_value() {
-        if let Some(ipc_handler) = &ipc_handler {
-          let uri = webview.uri().map(|u| u.to_string()).unwrap_or_default();
-          match Request::builder().uri(uri).body(js.to_string()) {
-            Ok(request) => ipc_handler(request),
-            Err(_error) => {
-              #[cfg(feature = "tracing")]
-              tracing::warn!("WebView received invalid IPC request: {_error}")
-            }
+        let uri = webview.uri().map(|u| u.to_string()).unwrap_or_default();
+        match Request::builder().uri(uri).body(js.to_string()) {
+          Ok(request) => ipc_handler(request),
+          Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("WebView received invalid IPC request: {_error}")
           }
         }
       }

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -949,7 +949,7 @@ impl InnerWebView {
     Self::add_script_to_execute_on_document_created(
       webview,
       String::from(
-        r#"Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: s=> window.chrome.webview.postMessage(s) }) });"#,
+        r#"Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: s => window.chrome.webview.postMessage(s) }) });"#,
       ),
     )?;
 

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -478,7 +478,9 @@ impl InnerWebView {
     unsafe { Self::attach_handlers(hwnd, &webview, &mut attributes, &mut token, env)? };
 
     // IPC handler
-    unsafe { Self::attach_ipc_handler(&webview, &mut attributes, &mut token)? };
+    if let Some(ipc_handler) = attributes.ipc_handler.take() {
+      unsafe { Self::attach_ipc_handler(&webview, ipc_handler, &mut token)? };
+    };
 
     // Custom protocols handler
     let http_or_https = if pl_attrs.use_https { "https" } else { "http" };
@@ -941,7 +943,7 @@ impl InnerWebView {
   #[inline]
   unsafe fn attach_ipc_handler(
     webview: &ICoreWebView2,
-    attributes: &mut WebViewAttributes,
+    ipc_handler: Box<dyn Fn(Request<String>)>,
     token: &mut EventRegistrationToken,
   ) -> Result<()> {
     Self::add_script_to_execute_on_document_created(
@@ -951,10 +953,9 @@ impl InnerWebView {
       ),
     )?;
 
-    let ipc_handler = attributes.ipc_handler.take();
     webview.add_WebMessageReceived(
       &WebMessageReceivedEventHandler::create(Box::new(move |_, args| {
-        let (Some(args), Some(ipc_handler)) = (args, &ipc_handler) else {
+        let Some(args) = args else {
           return Ok(());
         };
 

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -636,13 +636,13 @@ impl InnerWebView {
         parent_view: None,
       };
 
-      // Initialize scripts
-      w.init(
-r#"Object.defineProperty(window, 'ipc', {
-  value: Object.freeze({postMessage: function(s) {window.webkit.messageHandlers.ipc.postMessage(s);}})
-});"#,
-      true
-      );
+      if self.ipc_handler_delegate.is_some() {
+        // Initialize scripts
+        w.init(
+          r#"Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: function(s) { window.webkit.messageHandlers.ipc.postMessage(s) } }) });"#,
+          true,
+        );
+      }
       for init_script in attributes.initialization_scripts {
         w.init(&init_script.script, init_script.for_main_frame_only);
       }

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -636,7 +636,7 @@ impl InnerWebView {
         parent_view: None,
       };
 
-      if self.ipc_handler_delegate.is_some() {
+      if w.ipc_handler_delegate.is_some() {
         // Initialize scripts
         w.init(
           r#"Object.defineProperty(window, 'ipc', { value: Object.freeze({ postMessage: function(s) { window.webkit.messageHandlers.ipc.postMessage(s) } }) });"#,


### PR DESCRIPTION
Closes #1813

I'm not sure if this can be done for Android or simply not worth the time if it doesn't take much time anyways.