### PR TITLE
feat(android): launch new task on `startActivity`

### DIFF
--- a/src/android/kotlin/WryActivity.kt
+++ b/src/android/kotlin/WryActivity.kt
@@ -186,9 +186,11 @@ abstract class WryActivity : AppCompatActivity() {
 
     // Called by tao through JNI
     fun startActivity(cls: Class<*>): Int {
-        val intent = Intent(this, cls)
         val id = kotlin.random.Random.nextInt()
-        intent.putExtra(ACTIVITY_ID_KEY, id)
+        val intent = Intent(this, cls).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+            putExtra(ACTIVITY_ID_KEY, id)
+        }
         startActivity(intent)
         return id
     }


### PR DESCRIPTION
Reference https://github.com/tauri-apps/tauri/issues/15857

<img width="654" height="1379" alt="image" src="https://github.com/user-attachments/assets/b43645b4-2fa0-479e-9bdc-d9cafbd3d456" />

This will also require us to remove the `android:launchMode="singleTask"` from our cli template, but I still don't fully understand why it was added in the first place (oh, maybe it's so sharing to the app don't create new activities? I wonder how this should/can be done now...)
