### PR TITLE
fix(macos): domain-match parent cookies in cookies_for_url

### DIFF
--- a/.changes/macos-cookies-domain-match.md
+++ b/.changes/macos-cookies-domain-match.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Fix macOS `cookies_for_url` to include parent Domain cookies for subdomain URLs via RFC 6265 domain-match.

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -1201,8 +1201,8 @@ impl InnerWebView {
     self.cookies().map(|cookies| {
       cookies.into_iter().filter(|cookie: &cookie::Cookie| {
         let secure = cookie.secure().unwrap_or_default();
-        // domain is the same
-        cookie.domain() == url.domain()
+        // domain-match (includes parent Domain cookies for subdomain URLs)
+        cookie_domain_matches(cookie.domain(), url.domain())
           // and one of
           && (
             // cookie is secure and url is https
@@ -1437,6 +1437,35 @@ impl Drop for InnerWebView {
   }
 }
 
+/// Whether `request_host` domain-matches `cookie_domain` per RFC 6265 §5.1.3.
+///
+/// Exact host matches always succeed. Parent-domain cookies also match subdomain
+/// request hosts (e.g. `example.com` for `www.example.com`). A leading `.` on the
+/// cookie domain is stripped before comparison when present.
+fn cookie_domain_matches(cookie_domain: Option<&str>, request_host: Option<&str>) -> bool {
+  let (Some(cookie_domain), Some(request_host)) = (cookie_domain, request_host) else {
+    return false;
+  };
+
+  let cookie_domain = cookie_domain.strip_prefix('.').unwrap_or(cookie_domain);
+
+  if cookie_domain.eq_ignore_ascii_case(request_host) {
+    return true;
+  }
+
+  // Domain cookie: request-host is a subdomain of cookie-domain.
+  if request_host.len() > cookie_domain.len() {
+    let start = request_host.len() - cookie_domain.len();
+    if request_host.as_bytes().get(start - 1) == Some(&b'.')
+      && request_host[start..].eq_ignore_ascii_case(cookie_domain)
+    {
+      return true;
+    }
+  }
+
+  false
+}
+
 /// Converts from wry screen-coordinates to macOS screen-coordinates.
 /// wry: top-left is (0, 0) and y increasing downwards
 /// macOS:
@@ -1489,5 +1518,34 @@ unsafe fn wait_for_blocking_operation<T>(rx: std::sync::mpsc::Receiver<T>) -> Re
     let mode = ns_string!("NSDefaultRunLoopMode");
 
     rl.acceptInputForMode_beforeDate(mode, &limit_date);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::cookie_domain_matches;
+
+  #[test]
+  fn cookie_domain_matches_exact_and_subdomain() {
+    assert!(cookie_domain_matches(
+      Some("www.example.com"),
+      Some("www.example.com")
+    ));
+    assert!(cookie_domain_matches(
+      Some("example.com"),
+      Some("www.example.com")
+    ));
+    assert!(cookie_domain_matches(
+      Some(".example.com"),
+      Some("www.example.com")
+    ));
+    assert!(!cookie_domain_matches(
+      Some("example.com"),
+      Some("notexample.com")
+    ));
+    assert!(!cookie_domain_matches(
+      Some("www.example.com"),
+      Some("example.com")
+    ));
   }
 }


### PR DESCRIPTION
Use RFC 6265 domain-match in macOS cookies_for_url so parent Domain cookies (e.g. example.com) are returned for subdomain URLs like www.example.com.

Fixes #1749