### PR TITLE
fix(windows): preserve parent subclass when child webviews drop

### DIFF
--- a/.changes/windows-child-drop-parent-subclass.md
+++ b/.changes/windows-child-drop-parent-subclass.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On Windows, preserve the parent window's resize and focus subclass when dropping a child webview.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -72,8 +72,13 @@ impl Drop for InnerWebView {
     let _ = unsafe { self.controller.Close() };
     if self.is_child {
       let _ = unsafe { DestroyWindow(self.hwnd) };
+    } else {
+      // Only top-level webviews install the parent resize/focus subclass in
+      // `init_webview`. A child webview shares that parent HWND but does not
+      // own its subclass; removing it here would detach the host webview's
+      // WM_SIZE handler and freeze the host at its current bounds.
+      unsafe { Self::dettach_parent_subclass(*self.parent.borrow()) }
     }
-    unsafe { Self::dettach_parent_subclass(*self.parent.borrow()) }
   }
 }
 


### PR DESCRIPTION
## Problem

On Windows, dropping a webview created by `build_as_child` removes the parent HWND's Wry resize/focus subclass. Child webviews never install that subclass; a sibling top-level webview owns it. After a child is dropped, subsequent `WM_SIZE` messages no longer resize the host webview.

A minimal lifecycle is:

1. Create a top-level Wry webview in a resizable parent window.
2. Create a second webview with `build_as_child` using the same parent window.
3. Drop the child webview.
4. Resize the parent window.

The top-level webview remains at its pre-drop bounds instead of following the parent.

## Cause

`InnerWebView::init_webview` calls `attach_parent_subclass` only when `!is_child`, but `InnerWebView::drop` called `dettach_parent_subclass` unconditionally. Because the subclass procedure and ID are shared on the parent HWND, a child drop removed the top-level webview's subclass.

The detach path also sends `PARENT_DESTROY_MESSAGE`; its handler drops the controller reference stored in the parent subclass data and clears that data. A child therefore released a reference associated with the top-level webview even though it never installed or owned the registration. The top-level `InnerWebView` retains its own controller reference, but the ownership is still incorrect.

The removed subclass handles more than sizing: it also routes `WM_SETFOCUS` / `WM_ENTERSIZEMOVE` through `MoveFocus` and processes `WM_MOVE` / `WM_MOVING`. Losing it can therefore affect focus and movement after a child has been closed, in addition to leaving the top-level webview at stale bounds.

## Fix

Detach the parent subclass only in the non-child destructor path. Child teardown still closes its WebView2 controller and destroys its own container HWND. This matches the existing `!self.is_child` ownership guard in `reparent()`.

## Verification

- `cargo check --lib` on Windows