### PR TITLE
fix(ios): follow the system background when no color is set

### DIFF
--- a/.changes/ios-system-background-no-color.md
+++ b/.changes/ios-system-background-no-color.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On iOS, follow the system background color when no `background_color` is set, so the webview no longer flashes its opaque white default before the page paints.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ objc2-ui-kit = { version = "0.3.2", default-features = false, features = [
   "UIApplication",
   "UIEvent",
   "UIColor",
+  "UIInterface",
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -466,6 +466,15 @@ impl InnerWebView {
           // This has to be monitored as it may clash with isOpaque = true.
           // The webview background color may also applied too late so actually not that useful.
           webview.setBackgroundColor(Some(&color));
+        } else {
+          // Without a color the webview stays opaque and white, flashing before the page paints.
+          // Fall back to the system background so it follows the current appearance instead.
+          webview.setOpaque(false);
+          let color = objc2_ui_kit::UIColor::systemBackgroundColor();
+          if !is_child {
+            ns_view.setBackgroundColor(Some(&color));
+          }
+          webview.setBackgroundColor(Some(&color));
         }
         webview
       };

--- a/src/wkwebview/mod.rs
+++ b/src/wkwebview/mod.rs
@@ -449,33 +449,24 @@ impl InnerWebView {
         let frame = ns_view.frame();
         let webview: Retained<WryWebView> =
           objc2::msg_send![super(webview), initWithFrame: frame, configuration: &**config];
-        if let Some((red, green, blue, alpha)) = attributes.background_color {
-          // This is required first since the webview color is applied too late.
-          webview.setOpaque(false);
-
-          let color = objc2_ui_kit::UIColor::colorWithRed_green_blue_alpha(
+        // Without a background color the webview stays opaque and white, flashing before the
+        // page paints, so fall back to the system background to follow the current appearance.
+        let color = if let Some((red, green, blue, alpha)) = attributes.background_color {
+          objc2_ui_kit::UIColor::colorWithRed_green_blue_alpha(
             red as f64 / 255.0,
             green as f64 / 255.0,
             blue as f64 / 255.0,
             alpha as f64 / 255.0,
-          );
-
-          if !is_child {
-            ns_view.setBackgroundColor(Some(&color));
-          }
-          // This has to be monitored as it may clash with isOpaque = true.
-          // The webview background color may also applied too late so actually not that useful.
-          webview.setBackgroundColor(Some(&color));
+          )
         } else {
-          // Without a color the webview stays opaque and white, flashing before the page paints.
-          // Fall back to the system background so it follows the current appearance instead.
-          webview.setOpaque(false);
-          let color = objc2_ui_kit::UIColor::systemBackgroundColor();
-          if !is_child {
-            ns_view.setBackgroundColor(Some(&color));
-          }
-          webview.setBackgroundColor(Some(&color));
+          objc2_ui_kit::UIColor::systemBackgroundColor()
+        };
+        // setOpaque must come first since the color is applied too late on its own.
+        webview.setOpaque(false);
+        if !is_child {
+          ns_view.setBackgroundColor(Some(&color));
         }
+        webview.setBackgroundColor(Some(&color));
         webview
       };
 


### PR DESCRIPTION
On iOS a `WebView` created without a `background_color` keeps UIKit's default: opaque and white. During the gap between the launch screen dismissing and the page painting its first frame, that white shows through as a flash — noticeable in dark mode, where the app is dark on both sides of it.

The existing `background_color` path already sets `setOpaque(false)` and paints the given colour to avoid exactly this (see the `Some` branch). The `None` case was left untouched, so it still flashes.

This adds an `else` branch: when no colour is given, set the webview non-opaque and fall back to `UIColor.systemBackgroundColor`, which follows the current light/dark appearance. Apps that pass a `background_color` are unaffected.

Requires the `UIInterface` feature of `objc2-ui-kit` for `systemBackgroundColor`, added to `Cargo.toml`.

Tested on a device (iOS, dark and light): the launch flash is gone in both.
