### PR TITLE
fix(webview2): honor WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS via the API on Windows

### DIFF
--- a/.changes/webview2-elevated-browser-args.md
+++ b/.changes/webview2-elevated-browser-args.md
@@ -1,0 +1,5 @@
+---
+wry: patch
+---
+
+On Windows, fold the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable into the args passed through the WebView2 API so it survives WebView2 Runtime 150's elevated-host hardening. This restores WebDriver automation (e.g. msedgedriver's `--remote-debugging-port`) for apps launched by an elevated host such as CI runners.

--- a/src/webview2/mod.rs
+++ b/src/webview2/mod.rs
@@ -297,7 +297,7 @@ impl InnerWebView {
       .map(HSTRING::from);
 
     // additional browser args
-    let additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
+    let mut additional_browser_args = pl_attrs.additional_browser_args.unwrap_or_else(|| {
       // remove "mini menu" - See https://github.com/tauri-apps/wry/issues/535
       // and "smart screen" - See https://github.com/tauri-apps/tauri/issues/1345
       let default_args = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection";
@@ -326,6 +326,24 @@ impl InnerWebView {
 
       arguments
     });
+
+    // WebView2 Runtime 150 hardened elevated (high-integrity) host processes to
+    // ignore the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable. That
+    // silently breaks WebDriver automation, where msedgedriver injects
+    // `--remote-debugging-port` through that env var: with the port dropped the
+    // DevTools/CDP endpoint never opens and session creation times out. Fold the env
+    // var into the args passed via the API (`AdditionalBrowserArguments`), which is
+    // still honored when elevated, so automation keeps working.
+    // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/5645.
+    if let Ok(env_args) = std::env::var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS") {
+      let env_args = env_args.trim();
+      if !env_args.is_empty() {
+        if !additional_browser_args.is_empty() {
+          additional_browser_args.push(' ');
+        }
+        additional_browser_args.push_str(env_args);
+      }
+    }
 
     let (tx, rx) = mpsc::channel();
     let options = CoreWebView2EnvironmentOptions::default();


### PR DESCRIPTION
## Problem

WebView2 Runtime 150 hardened **elevated** (high-integrity) host processes to ignore the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable — for such hosts only the WebView2 **API** args (and HKLM policy) survive. This is by design; see [MicrosoftEdge/WebView2Feedback#5645](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5645).

It silently breaks WebDriver automation. `msedgedriver` passes `--remote-debugging-port` through that env var; with the port dropped, the DevTools/CDP endpoint never opens and session creation times out:

```
WebDriverError: The operation was aborted due to timeout when running ".../session" with method "POST"
```

This reproduces on GitHub-hosted Windows runners (they run as admin = elevated) after the runner image auto-updated Edge/WebView2 from 149 → 150.

Closes #1782.

## Fix

Read `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` in-process via `std::env::var` (in-process reads are unaffected by the hardening) and fold it into the arguments wry already passes through the WebView2 API (`AdditionalBrowserArguments`, via `set_additional_browser_arguments`). API args are still honored for elevated hosts, so automation keeps working.

The env var is appended after any existing `additional_browser_args` (app-provided or wry's defaults). This is safe with respect to double-application: WebView2 gives the env var precedence over the API property when the env var is honored, so on non-elevated hosts the env applies directly (API copy ignored), and on elevated hosts the env is dropped and the API copy takes effect.

## Testing

- The change is Windows-only (`src/webview2/mod.rs`) and uses only `std` string ops on the existing arguments value — no new APIs.
- I develop on macOS and couldn't get a reliable `--target x86_64-pc-windows-msvc` cross-check locally (the failure was in the target sysroot / unrelated deps, not this change), so I'm leaning on CI here for the Windows build. Happy to add a test if you have a preferred harness for the WebView2 env path.

Reported downstream against WebdriverIO's Tauri testing service, where it breaks the msedgedriver-based Windows E2E lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
