### PR TITLE
fix(android): don't crash when a URL has no cookies

### DIFF
--- a/.changes/android-getcookies-npe.md
+++ b/.changes/android-getcookies-npe.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+**Android:** fix a crash when reading cookies for a URL that has none. `CookieManager.getCookie` returns `null` in that case — a documented, ordinary result — but `RustWebView.getCookies` declared a non-null `String` return type, so Kotlin's intrinsic null check threw an uncaught `NullPointerException` on the main thread and killed the app. It now returns an empty string, which the Rust side already parses into an empty cookie list.

--- a/src/android/kotlin/RustWebView.kt
+++ b/src/android/kotlin/RustWebView.kt
@@ -89,7 +89,11 @@ class RustWebView(context: Context, val initScripts: Array<String>, val id: Stri
 
     fun getCookies(url: String): String {
         val cookieManager = CookieManager.getInstance()
-        return cookieManager.getCookie(url)
+        // `getCookie` returns null when the URL has no cookies, which is a
+        // documented, ordinary result — not an error. Returning it from a
+        // non-null `String` throws an uncaught NullPointerException on the
+        // main thread and takes the whole app down.
+        return cookieManager.getCookie(url) ?: ""
     }
 
     {{class-extension}}


### PR DESCRIPTION
Fixes #1837.

## The bug

`CookieManager.getCookie(url)` returns `null` when the given URL has no cookies. That is documented, ordinary behaviour — not an error. `RustWebView.getCookies` declares a non-null `String` return type and returns that value directly, so Kotlin's intrinsic null check throws, and because it runs on the main thread with nothing catching it, the app dies:

```
FATAL EXCEPTION: main
java.lang.NullPointerException: getCookie(...) must not be null
	at <app>.RustWebView.getCookies(RustWebView.kt:94)
	at android.os.MessageQueue.nativePollOnce(Native Method)
	at android.os.Looper.loop(Looper.java:392)
	at android.app.ActivityThread.main(ActivityThread.java:10346)
```

Any `WebviewWindow::cookies_for_url` call for a URL with no cookies set reaches it, and a caller has no way to know that in advance — which is exactly when you would ask.

## The fix

Return `""` instead. `main_pipe.rs` already does:

```rust
tx.send(
  cookies
    .split("; ")
    .flat_map(|c| cookie::Cookie::parse(c.to_string()))
    .collect(),
)
```

so an empty string yields an empty cookie list — the correct answer for "this URL has no cookies" — with no Rust-side change needed.

## Verification

Measured on a physical device (Samsung Galaxy S23 FE, Android 16 / One UI), against wry 0.55.1 via tauri 2.11.5.

**Before** — one webview loaded `https://www.icloud.com`, then two `cookies_for_url` calls, each bracketed by a log line before and after:

```
BEFORE cookies_for_url(https://www.icloud.com)
AFTER  cookies_for_url(https://www.icloud.com) -> 1 cookie(s): ["x-apple-group"]
BEFORE cookies_for_url(https://idmsa.apple.com)
AFTER  cookies_for_url(https://idmsa.apple.com) -> 0 cookie(s): []
FATAL EXCEPTION: main
java.lang.NullPointerException: getCookie(...) must not be null
```

**After** — same app, same sequence, with this patch applied via `[patch.crates-io]`:

```
BEFORE cookies_for_url(https://www.icloud.com)
AFTER  https://www.icloud.com -> 1 cookie(s)
BEFORE cookies_for_url(https://idmsa.apple.com)
AFTER  https://idmsa.apple.com -> 0 cookie(s)
BEFORE cookies_for_url(https://p130-ckdatabasews.icloud.com)
AFTER  https://p130-ckdatabasews.icloud.com -> 1 cookie(s)
BEFORE cookies_for_url(https://example.com)
AFTER  https://example.com -> 0 cookie(s)
BEFORE cookies_for_url(https://never-visited-by-this-app.invalid)
AFTER  https://never-visited-by-this-app.invalid -> 0 cookie(s)
alive 1/3 after all five reads
alive 2/3 after all five reads
alive 3/3 after all five reads
DONE — patched wry survived every URL
```

## One thing worth a separate look

`main_pipe.rs`'s `GetCookies` arm ends the JNI call chain with `.unwrap_or_default()`:

```rust
let cookies = self.env
  .call_method(webview, "getCookies", "(Ljava/lang/String;)Ljava/lang/String;", &[(&url).into()])
  ...
  .unwrap_or_default();
```

When the Kotlin side throws, that swallows the JNI error into an empty `String` and the caller receives `Ok(vec![])` — so from Rust the call looks like it succeeded and reported "no cookies" — while the pending Java exception still kills the process a moment later. That is why the `-> 0 cookie(s)` line above appears immediately before the crash, and why this took a few attempts to attribute correctly.

This PR does not touch that, since fixing the Kotlin side removes the throw that triggers it. But the same pattern would turn any future Java-side exception in these handlers into a silently wrong result plus a crash, so it may be worth clearing or propagating the exception there. Happy to open a separate issue if you'd like.